### PR TITLE
Concat matcher

### DIFF
--- a/ddlite_matcher.py
+++ b/ddlite_matcher.py
@@ -1,6 +1,5 @@
 import bisect, re
 from collections import defaultdict
-import sys
 
 class CandidateExtractor(object):
   """


### PR DESCRIPTION
As discussed this morning, PR for ConcatDictionaryMatch that merge consecutive candidates from a dictionary.
Moreover,  there is a 'dictionary_optional' option for which candidates will be merged with the candidates from the main dictionary. But candidates from just this dictionary won't be extracted.
For instance, if 'decrease' and 'of' are in the optional dictionary while 'germination' is in the main one, 'decrease of germination' will be extracted as candidate while just 'of' won't be extracted.

The class is made from the syntax from ddlite_matcher.py in master but can be remade to be adapted with the version in the candidate-extractor-2 branch that @ajratner is working on if needed.

Feel free to modify anything or to just add this as a "concat" option in the original DictionaryMatch class