### PR TITLE
Update corpus object to refer to 'contexts' instead of 'sentences'

### DIFF
--- a/examples/GeneTaggerExample_Extraction.ipynb
+++ b/examples/GeneTaggerExample_Extraction.ipynb
@@ -144,7 +144,7 @@
     }
    ],
    "source": [
-    "sents = list(corpus.get_sentences())\n",
+    "sents = list(corpus.get_contexts())\n",
     "print len(sents)\n",
     "sents[0]"
    ]

--- a/test/CDR_tests.ipynb
+++ b/test/CDR_tests.ipynb
@@ -43,7 +43,7 @@
     "%time corpus = Corpus(xml_parser, sent_parser, max_docs=20)\n",
     "\n",
     "print len(corpus.get_docs())\n",
-    "print len(corpus.get_sentences())"
+    "print len(corpus.get_contexts())"
    ]
   },
   {
@@ -68,7 +68,7 @@
    "outputs": [],
    "source": [
     "with open(ROOT + '/test/data/CDR_TestSet_sents.pkl', 'w+') as f:\n",
-    "    cPickle.dump(corpus.get_sentences(), f)"
+    "    cPickle.dump(corpus.get_contexts(), f)"
    ]
   },
   {
@@ -88,7 +88,7 @@
    "source": [
     "from snorkel.candidates import Ngrams\n",
     "ngrams = Ngrams(n_max=3)\n",
-    "ngs    = list(ngrams.apply(corpus.get_sentences()[0]))\n",
+    "ngs    = list(ngrams.apply(corpus.get_contexts()[0]))\n",
     "\n",
     "with open(ROOT + '/test/data/CDR_TestSet_sent_0_ngrams.pkl', 'w+') as f:\n",
     "    cPickle.dump(ngs, f)"
@@ -156,14 +156,14 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mImportError\u001b[0m                               Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-7-caf31880bd76>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mddlite_candidates\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mCandidates\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mget_ipython\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmagic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mu'time c = Candidates(ngrams, matcher, corpus.get_sentences())'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_candidates\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m5\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-7-caf31880bd76>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mddlite_candidates\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mCandidates\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      2\u001b[0m \u001b[0mget_ipython\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmagic\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mu'time c = Candidates(ngrams, matcher, corpus.get_contexts())'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0mc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_candidates\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m5\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;31mImportError\u001b[0m: No module named ddlite_candidates"
      ]
     }
    ],
    "source": [
     "from ddlite_candidates import Candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.get_candidates()[:5]"
    ]
   },
@@ -266,7 +266,7 @@
     "    gold_by_sid[g.sent_id].append(g)\n",
     "\n",
     "# Get sentences\n",
-    "view_sents = [s for s in corpus.get_sentences() if len(c.get_candidates_in(s.id)) < len(gold_by_sid[s.id])]\n",
+    "view_sents = [s for s in corpus.get_contexts() if len(c.get_candidates_in(s.id)) < len(gold_by_sid[s.id])]\n",
     "shuffle(view_sents)\n",
     "view_sents = view_sents[:50]"
    ]
@@ -333,7 +333,7 @@
     "matcher = DictionaryMatch(d=diseases, longest_match_only=False, stemmer='porter')\n",
     "\n",
     "# Extract a new set of candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.gold_stats(gold)"
    ]
   },
@@ -365,7 +365,7 @@
     "    DictionaryMatch(d=acronyms, ignore_case=False))\n",
     "\n",
     "# Extract a new set of candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.gold_stats(gold)"
    ]
   },
@@ -393,7 +393,7 @@
     "    DictionaryMatch(d=acronyms, ignore_case=False))\n",
     "\n",
     "# Extract a new set of candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.gold_stats(gold)"
    ]
   },

--- a/test/ParserTests.py
+++ b/test/ParserTests.py
@@ -6,7 +6,7 @@ from snorkel.parser import *
 ROOT = os.environ['SNORKELHOME']
 
 class TestParsers(unittest.TestCase):
-    
+
     @classmethod
     def setUpClass(cls):
         cls.sp = SentenceParser()
@@ -38,10 +38,10 @@ class TestParsers(unittest.TestCase):
         corpus = Corpus(xml_parser, sent_parser, max_docs=20)
 
         print len(corpus.get_docs())
-        print len(corpus.get_sentences())
+        print len(corpus.get_contexts())
 
         self.assertEqual(corpus.get_docs(), gold_docs)
-        self.assertEqual(corpus.get_sentences(), gold_sents)
+        self.assertEqual(corpus.get_contexts(), gold_sents)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tutorial/CDR_Tutorial.ipynb
+++ b/tutorial/CDR_Tutorial.ipynb
@@ -149,7 +149,7 @@
     }
    ],
    "source": [
-    "sent = corpus.get_sentences_in(doc.id)[0]\n",
+    "sent = corpus.get_contexts_in(doc.id)[0]\n",
     "print sent"
    ]
   },
@@ -237,7 +237,7 @@
    ],
    "source": [
     "from snorkel.candidates import Candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.get_candidates()[:5]"
    ]
   },
@@ -362,7 +362,7 @@
     "    gold_by_sid[g.sent_id].append(g)\n",
     "\n",
     "# Get sentences\n",
-    "view_sents = [s for s in corpus.get_sentences() if len(c.get_candidates_in(s.id)) < len(gold_by_sid[s.id])]\n",
+    "view_sents = [s for s in corpus.get_contexts() if len(c.get_candidates_in(s.id)) < len(gold_by_sid[s.id])]\n",
     "shuffle(view_sents)\n",
     "view_sents = view_sents[:50]"
    ]
@@ -683,7 +683,7 @@
     "matcher = DictionaryMatch(d=diseases, longest_match_only=False, stemmer='porter')\n",
     "\n",
     "# Extract a new set of candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.gold_stats(gold)"
    ]
   },
@@ -730,7 +730,7 @@
     "    DictionaryMatch(d=acronyms, ignore_case=False))\n",
     "\n",
     "# Extract a new set of candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.gold_stats(gold)"
    ]
   },
@@ -772,7 +772,7 @@
     "    DictionaryMatch(d=acronyms, ignore_case=False))\n",
     "\n",
     "# Extract a new set of candidates\n",
-    "%time c = Candidates(ngrams, matcher, corpus.get_sentences())\n",
+    "%time c = Candidates(ngrams, matcher, corpus.get_contexts())\n",
     "c.gold_stats(gold)"
    ]
   },


### PR DESCRIPTION
All of our materials have been updated to use the new method calls (e.g., "get_contexts" instead of "get_sentences"), and a new object SentencesCorpus is a subclass of Corpus and accepts the "sentence" versions of those methods as well, for backwards compatibility.