### PR TITLE
Split tokens to expand Ngrams candidate space

### DIFF
--- a/snorkel/candidates.py
+++ b/snorkel/candidates.py
@@ -254,8 +254,6 @@ class Ngrams(CandidateSpace):
                 # NOTE: For simplicity, we only split single tokens right now!
                 if l == 1 and self.split_rgx is not None:
                     m = re.search(self.split_rgx, text[char_start:char_end+1])
-
-                    # NOTE: For simplicity, we only consider *a single split* here
                     if m is not None and l < self.n_max:
                         yield Ngram(char_start=char_start, char_end=char_start + m.start(1) - 1, sent=s)
                         yield Ngram(char_start=char_start + m.end(1), char_end=char_end, sent=s)

--- a/snorkel/candidates.py
+++ b/snorkel/candidates.py
@@ -1,4 +1,5 @@
 import sys
+import re
 from collections import defaultdict
 from itertools import chain
 from time import time
@@ -227,21 +228,34 @@ class Ngrams(CandidateSpace):
     Defines the space of candidates as all n-grams (n <= n_max) in a sentence _x_,
     indexing by **character offset**.
     """
-    def __init__(self, n_max=5):
-        self.n_max = n_max
+    def __init__(self, n_max=5, split_tokens=['-', '/']):
+        self.n_max        = n_max
+        self.split_rgx    = r'('+r'|'.join(split_tokens)+r')' if split_tokens and len(split_tokens) > 0 else None
     
     def apply(self, x):
         s = x if isinstance(x, dict) else x._asdict()
         try:
             cos   = s[CHAR_OFFSETS]
             words = s[WORDS]
+            text  = s[TEXT]
         except:
-            raise ValueError("Input object must have %s, %s attributes" % (CHAR_OFFSET, WORDS))
+            raise ValueError("Input object must have attributes: " + ' '.join([CHAR_OFFSET, WORDS, TEXT]))
 
         # Loop over all n-grams in **reverse** order (to facilitate longest-match semantics)
         L = len(cos)
         for l in range(1, self.n_max+1)[::-1]:
             for i in range(L-l+1):
-                ws = words[i:i+l] 
-                cl = cos[i+l-1] - cos[i] + len(words[i+l-1])  # NOTE that we derive char_len without using sep
-                yield Ngram(char_start=cos[i], char_end=cos[i]+cl-1, sent=s)
+                cl         = cos[i+l-1] - cos[i] + len(words[i+l-1])
+                char_start = cos[i]
+                char_end   = cos[i] + cl - 1
+                yield Ngram(char_start=char_start, char_end=char_end, sent=s)
+                
+                # Check for split
+                # NOTE: For simplicity, we only split single tokens right now!
+                if l == 1 and self.split_rgx is not None:
+                    m = re.search(self.split_rgx, text[char_start:char_end+1])
+
+                    # NOTE: For simplicity, we only consider *a single split* here
+                    if m is not None and l < self.n_max:
+                        yield Ngram(char_start=char_start, char_end=char_start + m.start(1) - 1, sent=s)
+                        yield Ngram(char_start=char_start + m.end(1), char_end=char_end, sent=s)

--- a/test/CandidateSpaceTests.py
+++ b/test/CandidateSpaceTests.py
@@ -1,24 +1,37 @@
 import os, sys, unittest, cPickle
+from time import sleep
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 from snorkel.candidates import *
+from snorkel.parser import SentenceParser
 
 DATA_PATH = os.environ['SNORKELHOME'] + '/test/data/'
 
 class TestCandidateSpace(unittest.TestCase):
     
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         with open(DATA_PATH + 'CDR_TestSet_sents.pkl', 'rb') as f:
-            self.sents = cPickle.load(f)
-
+            cls.sents = cPickle.load(f)
         with open(DATA_PATH + 'CDR_TestSet_sent_0_ngrams.pkl', 'rb') as f:
-            self.gold_ngrams_0 = cPickle.load(f)
+            cls.gold_ngrams_0 = cPickle.load(f)
+        cls.sp     = SentenceParser()
 
-    def tearDown(self):
-        pass
-
+    @classmethod
+    def tearDownClass(cls):
+        sleep(1)  # TODO: Fix sentence parser so that this hack not necessary!
+        cls.sp._kill_pserver()
+    
     def test_ngrams(self):
-        ngrams = Ngrams(n_max=3)
+        ngrams = Ngrams(n_max=3, split_tokens=None)
         self.assertEqual(self.gold_ngrams_0, list(ngrams.apply(self.sents[0])))
+
+    def test_split_tokens(self):
+        ngrams = Ngrams(n_max=3)
+        test_sent = "We found disease A/B in cow Alpha-3."
+        sent      = list(self.sp.parse(test_sent))[0]
+        ngs       = list(ngrams.apply(sent))
+        self.assertEqual(len(ngs), 25)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/MatcherTests.py
+++ b/test/MatcherTests.py
@@ -38,14 +38,13 @@ class TestMatchers(unittest.TestCase):
         pass
 
     def test_slot_fill_match(self):
-        sent_parser = SentenceParser()
         
         # Test 1
         dm        = DictionaryMatch(d=['X','Y','Z'])
         rm        = RegexMatchSpan(rgx=r'\d{3}')
         sf        = SlotFillMatch(dm, rm, pattern="{0}-{1}")
         test_sent = "X-123 causes gas."
-        sent      = list(sent_parser.parse(test_sent))[0]
+        sent      = list(self.sp.parse(test_sent))[0]
         matches   = list(sf.apply(self.ngrams.apply(sent)))
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0].get_span(), "X-123")
@@ -54,7 +53,7 @@ class TestMatchers(unittest.TestCase):
         dm        = DictionaryMatch(d=['Burritos', 'Tacos'], ignore_case=True)
         sf        = SlotFillMatch(dm, pattern="{0} and/or {0}")
         test_sent = "Burritos and/or tacos causes gas."
-        sent      = list(sent_parser.parse(test_sent))[0]
+        sent      = list(self.sp.parse(test_sent))[0]
         matches   = list(sf.apply(self.ngrams.apply(sent)))
         self.assertEqual(len(matches), 1)
         self.assertEqual(matches[0].get_span(), "Burritos and/or tacos")


### PR DESCRIPTION
Note: this only splits **single tokens** for simplicity.  I can do more than this, it just gets a bit uglier... but let me know

Another question is whether by default `Ngrams` should have `split_tokens=['-', '/']` (as it does here), or `split_tokens=None`...