### PR TITLE
Make ProgressBar for CorpusParser active only for max_docs option

### DIFF
--- a/snorkel/parser.py
+++ b/snorkel/parser.py
@@ -30,20 +30,19 @@ class CorpusParser:
         corpus = Corpus(name=name)
         if session is not None:
             session.add(corpus)
-        texts = []
+        if self.max_docs is not None:
+            pb = ProgressBar(self.max_docs)
         for i, (doc, text) in enumerate(self.doc_parser.parse()):
-            if self.max_docs and i == self.max_docs:
-                break
+            if self.max_docs is not None:
+                pb.bar(i)
+                if i == self.max_docs:
+                    break
             corpus.append(doc)
-            texts.append(text)
-
-        pb = ProgressBar(len(corpus) if self.max_docs is None 
-            else min(len(corpus), self.max_docs))
-        for i in range(len(corpus)):
-            pb.bar(i)
-            for _ in self.sent_parser.parse(corpus.documents[i], texts[i]):
+            for _ in self.sent_parser.parse(doc, text):
                 pass
-        pb.close()
+        if self.max_docs is not None:
+            pb.bar(self.max_docs)
+            pb.close()
         if session is not None:
             session.commit()
         corpus.stats()


### PR DESCRIPTION
I pushed a ProgressBar for the CorpusParser a little prematurely--we won't always be able to fit all the texts in memory. But with these changes, we can not keep any in memory and still have a ProgressBar whenever they give us a max_docs value. If they run out of docs before they hit max_docs (which I don't think will happen very often, since usually you'd use that to intentionally subsample your corpus, I think), then it'll just jump to 100% when it finishes.

Also, pardon the funky capitalization of the branch name. Typed that one a little fast. :)