### PR TITLE
Cascade delete

### DIFF
--- a/snorkel/db_helpers.py
+++ b/snorkel/db_helpers.py
@@ -1,4 +1,4 @@
-from .models import Corpus, Document, Sentence
+from .models import Corpus, CandidateSet, AnnotationKeySet, ParameterSet
 from sqlalchemy.orm import object_session
 
 
@@ -17,7 +17,16 @@ def cascade_delete_set(s):
         for candidate in s:
             session.delete(candidate)
 
-    # TODO: AnnotationKeySet
+    # If an AnnotationKeySet, delete all AnnotationKeys, cascades down to Annotations, Parameters
+    elif isinstance(s, AnnotationKeySet):
+        for ak in s.keys:
+            session.delete(ak)
+
+    # ParameterSets already cascade to deleting all Parameters
+    elif isinstance(s, ParameterSet):
+        pass
+    else:
+        raise ValueError("Unhandled set type: " + s.__name__)
 
     # Finally, delete the set and commit
     session.delete(s)

--- a/snorkel/db_helpers.py
+++ b/snorkel/db_helpers.py
@@ -1,24 +1,48 @@
-from .models import Corpus, CandidateSet, AnnotationKeySet, ParameterSet, AnnotatorLabel, Label
+from .models import Corpus, CandidateSet, AnnotationKeySet, ParameterSet, AnnotatorLabel, Label, Context
 from .queries import get_or_create_single_key_set
 from sqlalchemy.orm import object_session
 
 
-# TODO
-def reload_annotator_labels(session, candidate_class, context_classes, annotator_name):
-    """Reloads stable annotator labels into the Label table"""
-    aks, ak = get_or_create_single_key_set(annotator_name)
-
+def reload_annotator_labels(session, candidate_class, annotator_name):
+    """
+    Reloads stable annotator labels into the Label table
+    Note that this function currently *does not* handle creating necessary Contexts / Candidates.
+    """
+    aks, ak = get_or_create_single_key_set(session, annotator_name)
+    
+    labels = []
+    missed = []
     for al in session.query(AnnotatorLabel).filter(AnnotatorLabel.annotator_name == annotator_name).all():
 
         # Check for labeled Contexts
         contexts = []
         for stable_id in al.context_stable_ids:
             context = session.query(Context).filter(Context.stable_id == stable_id).first()
+            if context:
+                contexts.append(context)
+        if len(contexts) < len(al.context_stable_ids):
+            missed.append(al)
+            continue
 
-            # If context does not exist, create it
-            # TODO: This is a little bit involved...
-            if context is None:
-                pass  # TODO
+        # Check for Candidate
+        candidate_query = session.query(candidate_class)
+        for i, arg in enumerate(candidate_class.__argnames__):
+            candidate_query = candidate_query.filter(getattr(candidate_class, arg) == contexts[i])
+        candidate = candidate_query.first()
+        if candidate is None:
+            missed.append(al)
+            continue
+
+        # Check for Label, otherwise create
+        label = session.query(Label).filter(Label.key == ak).filter(Label.candidate == candidate).first()
+        if label is None:
+            label = Label(candidate=candidate, key=ak, value=al.value)
+            session.add(label)
+            labels.append(label)
+
+    session.commit()
+    print "Labels created: %s\nLabels skipped: %s" % (len(labels), len(missed))
+    return labels, missed
 
 
 def cascade_delete_set(s):

--- a/snorkel/db_helpers.py
+++ b/snorkel/db_helpers.py
@@ -1,0 +1,24 @@
+from .models import Corpus, Document, Sentence
+from sqlalchemy.orm import object_session
+
+
+def cascade_delete_set(s):
+    """Given a many-to-many set, delete all contained / dependent elements"""
+    session = object_session(s)
+
+    # If a Corpus, delete all the documents and everything else cascades
+    # Corpus -> Document -> Sentence -> Span -> Candidate -> Annotation
+    if isinstance(s, Corpus):
+        for document in s:
+            session.delete(document)
+
+    # If a CandidateSet, delete all the candidates and similarly everything will cascade
+    elif isinstance(s, CandidateSet):
+        for candidate in s:
+            session.delete(candidate)
+
+    # TODO: AnnotationKeySet
+
+    # Finally, delete the set and commit
+    session.delete(s)
+    session.commit()

--- a/snorkel/db_helpers.py
+++ b/snorkel/db_helpers.py
@@ -1,5 +1,24 @@
-from .models import Corpus, CandidateSet, AnnotationKeySet, ParameterSet
+from .models import Corpus, CandidateSet, AnnotationKeySet, ParameterSet, AnnotatorLabel, Label
+from .queries import get_or_create_single_key_set
 from sqlalchemy.orm import object_session
+
+
+# TODO
+def reload_annotator_labels(session, candidate_class, context_classes, annotator_name):
+    """Reloads stable annotator labels into the Label table"""
+    aks, ak = get_or_create_single_key_set(annotator_name)
+
+    for al in session.query(AnnotatorLabel).filter(AnnotatorLabel.annotator_name == annotator_name).all():
+
+        # Check for labeled Contexts
+        contexts = []
+        for stable_id in al.context_stable_ids:
+            context = session.query(Context).filter(Context.stable_id == stable_id).first()
+
+            # If context does not exist, create it
+            # TODO: This is a little bit involved...
+            if context is None:
+                pass  # TODO
 
 
 def cascade_delete_set(s):

--- a/snorkel/db_helpers.py
+++ b/snorkel/db_helpers.py
@@ -1,4 +1,4 @@
-from .models import Corpus, CandidateSet, AnnotationKeySet, ParameterSet, AnnotatorLabel, Label, Context
+from .models import Corpus, CandidateSet, AnnotationKeySet, ParameterSet, StableLabel, Label, Context
 from .queries import get_or_create_single_key_set
 from sqlalchemy.orm import object_session
 
@@ -12,7 +12,7 @@ def reload_annotator_labels(session, candidate_class, annotator_name):
     
     labels = []
     missed = []
-    for al in session.query(AnnotatorLabel).filter(AnnotatorLabel.annotator_name == annotator_name).all():
+    for al in session.query(StableLabel).filter(StableLabel.annotator_name == annotator_name).all():
 
         # Check for labeled Contexts
         contexts = []

--- a/snorkel/models/__init__.py
+++ b/snorkel/models/__init__.py
@@ -39,7 +39,7 @@ from .meta import SnorkelBase, SnorkelSession, snorkel_engine, snorkel_postgres
 from .context import Context, Corpus, Document, Sentence, TemporarySpan, Span
 from .context import construct_stable_id, split_stable_id
 from .candidate import Candidate, CandidateSet, candidate_subclass
-from .annotation import Feature, Label, Prediction, AnnotationKey, AnnotationKeySet, AnnotatorLabel
+from .annotation import Feature, Label, Prediction, AnnotationKey, AnnotationKeySet, StableLabel
 from .parameter import Parameter, ParameterSet
 
 # This call must be performed after all classes that extend SnorkelBase are

--- a/snorkel/models/__init__.py
+++ b/snorkel/models/__init__.py
@@ -39,7 +39,7 @@ from .meta import SnorkelBase, SnorkelSession, snorkel_engine, snorkel_postgres
 from .context import Context, Corpus, Document, Sentence, TemporarySpan, Span
 from .context import construct_stable_id, split_stable_id
 from .candidate import Candidate, CandidateSet, candidate_subclass
-from .annotation import Feature, Label, Prediction, AnnotationKey, AnnotationKeySet
+from .annotation import Feature, Label, Prediction, AnnotationKey, AnnotationKeySet, AnnotatorLabel
 from .parameter import Parameter, ParameterSet
 
 # This call must be performed after all classes that extend SnorkelBase are

--- a/snorkel/models/annotation.py
+++ b/snorkel/models/annotation.py
@@ -145,15 +145,15 @@ class AnnotatorLabel(SnorkelBase):
     A special secondary table for preserving labels created by *human annotators* (e.g. in the Viewer)
     in a stable format that does not cascade, and is independent of the Candidate ids.
     """
-    __tablename__ = 'annotator_label'
-    id                 = Column(Integer, primary_key=True)
-    stable_id          = Column(String, nullable=False)  # '~~'-concatenation of context_stable_ids + annotator
-    annotator          = Column(String, nullable=False)
-    value              = Column(Integer, nullable=False)
+    __tablename__  = 'annotator_label'
+    id             = Column(Integer, primary_key=True)
+    stable_id      = Column(String, nullable=False)  # '~~'-concatenation of context_stable_ids + annotator
+    annotator_name = Column(String, nullable=False)
+    value          = Column(Integer, nullable=False)
     if snorkel_postgres:
         context_stable_ids = Column(postgresql.ARRAY(String), nullable=False)
     else:
         context_stable_ids = Column(PickleType, nullable=False)
 
     def __repr__(self):
-        return "%s (%s : %s) [STABLE]" % (self.__class__.__name__, self.annotator, self.value)
+        return "%s (%s : %s) [STABLE]" % (self.__class__.__name__, self.annotator_name, self.value)

--- a/snorkel/models/annotation.py
+++ b/snorkel/models/annotation.py
@@ -1,11 +1,9 @@
 from .meta import SnorkelBase, snorkel_postgres
-import re
-from sqlalchemy import Column, String, Integer, Float, ForeignKey, UniqueConstraint, Table
+from sqlalchemy import Column, String, Integer, Float, ForeignKey, UniqueConstraint, Table, PickleType
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.dialects import postgresql
 from snorkel.utils import camel_to_under
-from sqlalchemy.orm.collections import attribute_mapped_collection
 
 
 annotation_key_set_annotation_key_association = \
@@ -140,7 +138,7 @@ class Prediction(AnnotationMixin, SnorkelBase):
     value = Column(Float, nullable=False)
 
 
-class AnnotatorLabel(SnorkelBase):
+class StableLabel(SnorkelBase):
     """
     A special secondary table for preserving labels created by *human annotators* (e.g. in the Viewer)
     in a stable format that does not cascade, and is independent of the Candidate ids.

--- a/snorkel/models/annotation.py
+++ b/snorkel/models/annotation.py
@@ -90,7 +90,7 @@ class AnnotationMixin(object):
 
     @declared_attr
     def key(cls):
-        return relationship('AnnotationKey', backref=backref(camel_to_under(cls.__name__) + 's', cascade='all'))
+        return relationship('AnnotationKey', backref=backref(camel_to_under(cls.__name__) + 's', cascade='all, delete-orphan'))
 
     # Every annotation is with respect to a candidate
     @declared_attr
@@ -99,7 +99,7 @@ class AnnotationMixin(object):
 
     @declared_attr
     def candidate(cls):
-        return relationship('Candidate', backref=backref(camel_to_under(cls.__name__) + 's', cascade_backrefs=False),
+        return relationship('Candidate', backref=backref(camel_to_under(cls.__name__) + 's', cascade='all, delete-orphan', cascade_backrefs=False),
                             cascade_backrefs=False)
 
     # NOTE: What remains to be defined in the subclass is the **value**

--- a/snorkel/models/candidate.py
+++ b/snorkel/models/candidate.py
@@ -131,9 +131,11 @@ def candidate_subclass(class_name, args, table_name=None):
         # Primary arguments are constituent Contexts, and their ids
         class_attribs[arg + '_id']  = Column(Integer, ForeignKey('context.id'))
         class_attribs[arg]          = relationship('Context',
-                                                  backref=backref(table_name + '_' + arg + 's', cascade_backrefs=False),
-                                                  cascade_backrefs=False,
-                                                  foreign_keys=class_attribs[arg + '_id'])
+                                                      backref=backref(table_name + '_' + arg + 's',
+                                                                      cascade_backrefs=False,
+                                                                      cascade='all, delete-orphan'),
+                                                      cascade_backrefs=False,
+                                                      foreign_keys=class_attribs[arg + '_id'])
         unique_con_args.append(class_attribs[arg + '_id'])
 
         # Canonical ids, to be set post-entity normalization stage

--- a/snorkel/models/parameter.py
+++ b/snorkel/models/parameter.py
@@ -22,7 +22,7 @@ class Parameter(SnorkelBase):
     __tablename__ = 'parameter'
 
     feature_key_id = Column(Integer, ForeignKey('annotation_key.id'), primary_key=True)
-    feature_key = relationship('AnnotationKey', backref=backref('parameters', cascade_backrefs=False), cascade_backrefs=False)
+    feature_key = relationship('AnnotationKey', backref=backref('parameters', cascade='all, delete-orphan', cascade_backrefs=False), cascade_backrefs=False)
     set_id = Column(Integer, ForeignKey('parameter_set.id'), primary_key=True)
     set = relationship('ParameterSet', backref=backref('parameters', cascade='all, delete-orphan'))
     value = Column(Float, nullable=False)

--- a/snorkel/viewer.py
+++ b/snorkel/viewer.py
@@ -211,7 +211,7 @@ class Viewer(widgets.DOMWidget):
 
                 # Create stable AnnotatorLabel
                 stable_id = '~~'.join([c.stable_id for c in candidate.get_contexts()] + [self.annotator.name])
-                self.annotations_stable[cid] = AnnotatorLabel(stable_id=stable_id, annotator=self.annotator.name, value=value, context_stable_ids=[c.stable_id for c in candidate.get_contexts()])
+                self.annotations_stable[cid] = AnnotatorLabel(stable_id=stable_id, annotator_name=self.annotator.name, value=value, context_stable_ids=[c.stable_id for c in candidate.get_contexts()])
                 self.session.add(self.annotations_stable[cid])
 
                 self.session.commit()

--- a/snorkel/viewer.py
+++ b/snorkel/viewer.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from .models import Label
+from .models import Label, AnnotatorLabel
 from .queries import get_or_create_single_key_set
 try:
     from IPython.core.display import display, Javascript
@@ -87,9 +87,12 @@ class Viewer(widgets.DOMWidget):
             pass
 
         # Loads existing annotations
-        self.annotations = [None] * len(self.candidates)
+        self.annotations        = [None] * len(self.candidates)
+        self.annotations_stable = [None] * len(self.candidates)
         init_labels_serialized = []
         for i, candidate in enumerate(self.candidates):
+
+            # First look for the annotation in the primary annotations table
             existing_annotation = self.session.query(Label) \
                 .filter(Label.key == self.annotator) \
                 .filter(Label.candidate == candidate) \
@@ -104,6 +107,13 @@ class Viewer(widgets.DOMWidget):
                     raise ValueError(str(existing_annotation) +
                                      ' has value not in {1, -1}, which Viewer does not support.')
                 init_labels_serialized.append(str(i) + '~~' + value_string)
+
+                # If the annotator label is in the main table, also get its stable version
+                stable_id = '~~'.join([c.stable_id for c in candidate.get_contexts()] + [self.annotator.name])
+                existing_annotation_stable = self.session.query(AnnotatorLabel) \
+                    .filter(AnnotatorLabel.stable_id == stable_id).one()
+                self.annotations_stable[i] = existing_annotation_stable
+
         self._labels_serialized = ','.join(init_labels_serialized)
 
         # Configures message handler
@@ -184,13 +194,26 @@ class Viewer(widgets.DOMWidget):
                 raise ValueError('Unexpected label returned from widget: ' + str(value) +
                                  '. Expected values are True and False.')
 
+            # If label already exists, just update value (in both Label and AnnotatorLabel)
             if self.annotations[cid] is not None:
                 if self.annotations[cid].value != value:
-                    self.annotations[cid].value = value
+                    self.annotations[cid].value        = value
+                    self.annotations_stable[cid].value = value
                     self.session.commit()
+
+            # Otherwise, create a Label *and an AnnotatorLabel*
             else:
-                self.annotations[cid] = Label(key=self.annotator, candidate=self.candidates[cid], value=value)
+                candidate = self.candidates[cid]
+
+                # Create Label
+                self.annotations[cid] = Label(key=self.annotator, candidate=candidate, value=value)
                 self.session.add(self.annotations[cid])
+
+                # Create stable AnnotatorLabel
+                stable_id = '~~'.join([c.stable_id for c in candidate.get_contexts()] + [self.annotator.name])
+                self.annotations_stable[cid] = AnnotatorLabel(stable_id=stable_id, annotator=self.annotator.name, value=value, context_stable_ids=[c.stable_id for c in candidate.get_contexts()])
+                self.session.add(self.annotations_stable[cid])
+
                 self.session.commit()
         elif content.get('event', '') == 'delete_label':
             cid = content.get('cid', None)

--- a/snorkel/viewer.py
+++ b/snorkel/viewer.py
@@ -1,5 +1,5 @@
 from __future__ import print_function
-from .models import Label, AnnotatorLabel
+from .models import Label, StableLabel
 from .queries import get_or_create_single_key_set
 try:
     from IPython.core.display import display, Javascript
@@ -110,8 +110,8 @@ class Viewer(widgets.DOMWidget):
 
                 # If the annotator label is in the main table, also get its stable version
                 stable_id = '~~'.join([c.stable_id for c in candidate.get_contexts()] + [self.annotator.name])
-                existing_annotation_stable = self.session.query(AnnotatorLabel) \
-                    .filter(AnnotatorLabel.stable_id == stable_id).one()
+                existing_annotation_stable = self.session.query(StableLabel) \
+                    .filter(StableLabel.stable_id == stable_id).one()
                 self.annotations_stable[i] = existing_annotation_stable
 
         self._labels_serialized = ','.join(init_labels_serialized)
@@ -194,14 +194,14 @@ class Viewer(widgets.DOMWidget):
                 raise ValueError('Unexpected label returned from widget: ' + str(value) +
                                  '. Expected values are True and False.')
 
-            # If label already exists, just update value (in both Label and AnnotatorLabel)
+            # If label already exists, just update value (in both Label and StableLabel)
             if self.annotations[cid] is not None:
                 if self.annotations[cid].value != value:
                     self.annotations[cid].value        = value
                     self.annotations_stable[cid].value = value
                     self.session.commit()
 
-            # Otherwise, create a Label *and an AnnotatorLabel*
+            # Otherwise, create a Label *and a StableLabel*
             else:
                 candidate = self.candidates[cid]
 
@@ -209,9 +209,9 @@ class Viewer(widgets.DOMWidget):
                 self.annotations[cid] = Label(key=self.annotator, candidate=candidate, value=value)
                 self.session.add(self.annotations[cid])
 
-                # Create stable AnnotatorLabel
+                # Create StableLabel
                 stable_id = '~~'.join([c.stable_id for c in candidate.get_contexts()] + [self.annotator.name])
-                self.annotations_stable[cid] = AnnotatorLabel(stable_id=stable_id, annotator_name=self.annotator.name, value=value, context_stable_ids=[c.stable_id for c in candidate.get_contexts()])
+                self.annotations_stable[cid] = StableLabel(stable_id=stable_id, annotator_name=self.annotator.name, value=value, context_stable_ids=[c.stable_id for c in candidate.get_contexts()])
                 self.session.add(self.annotations_stable[cid])
 
                 self.session.commit()


### PR DESCRIPTION
One of the major user annoyances / points of friction currently is difficulty in deleting tables.  Part of this can be solved by simplifying the schema a bit (e.g., getting rid of many-to-many sets!), but mainly just three important things, which this PR aims to address:

1. `cascade_delete_set`: Easy function for deleting many-to-many sets, and cascading the delete all the way through, e.g. `Corpus -> Documents -> Sentences -> Spans -> Candidates -> Labels`;
2. Set up cascades in data model properly to make deleting easier / cascade fully through
3. `AnnotatorLabel`: A new class to **preserve labels created by human annotators** in a stable format, a.k.a. the one thing we shouldn't delete, so they are not lost when deletes cascade.

These are all implemented, but I still need to finish an easy function to reload `Labels` given just the stable `AnnotatorLabel` table.  The only annoying point here is reconstructing missing `Candidates` and constituent `Contexts`, given just the `AnnotatorLabel` table... probably just need to redefine the stable_id to be recursively constructed.  Will aim to finish this later tonight