### PR TITLE
Minor context traversal additions + tutorial section

### DIFF
--- a/snorkel/candidates.py
+++ b/snorkel/candidates.py
@@ -147,7 +147,7 @@ class Ngrams(CandidateSpace):
                 w     = context.words[i+l-1]
                 start = offsets[i]
                 end   = offsets[i+l-1] + len(w) - 1
-                ts    = TemporarySpan(char_start=start, char_end=end, parent=context)
+                ts    = TemporarySpan(char_start=start, char_end=end, sentence=context)
                 if ts not in seen:
                     seen.add(ts)
                     yield ts
@@ -157,11 +157,11 @@ class Ngrams(CandidateSpace):
                 if l == 1 and self.split_rgx is not None:
                     m = re.search(self.split_rgx, context.text[start-offsets[0]:end-offsets[0]+1])
                     if m is not None and l < self.n_max + 1:
-                        ts1 = TemporarySpan(char_start=start, char_end=start + m.start(1) - 1, parent=context)
+                        ts1 = TemporarySpan(char_start=start, char_end=start + m.start(1) - 1, sentence=context)
                         if ts1 not in seen:
                             seen.add(ts1)
                             yield ts
-                        ts2 = TemporarySpan(char_start=start + m.end(1), char_end=end, parent=context)
+                        ts2 = TemporarySpan(char_start=start + m.end(1), char_end=end, sentence=context)
                         if ts2 not in seen:
                             seen.add(ts2)
                             yield ts2
@@ -215,7 +215,7 @@ class PretaggedCandidateExtractor(UDF):
                         char_end = context.char_offsets[i] + len(context.words[i]) - 1
 
                     # Insert / load temporary span, also store map to entity CID
-                    tc = TemporarySpan(char_start=char_start, char_end=char_end, parent=context)
+                    tc = TemporarySpan(char_start=char_start, char_end=char_end, sentence=context)
                     tc.load_id_or_insert(self.session)
                     entity_cids[tc.id] = cid
                     entity_spans[et].append(tc)

--- a/snorkel/features/context_features.py
+++ b/snorkel/features/context_features.py
@@ -29,13 +29,13 @@ def get_token_count_feats(candidate, context, attr, ngram, stopwords):
 
 def get_document_token_count_feats_base(candidate, attr, ngram, stopwords):
     """Apply @get_token_count_feats over the parent @Document of @candidate"""
-    doc = candidate.get_parent().parent
+    doc = candidate.get_parent().get_parent()
     return get_token_count_feats(candidate, doc, attr, ngram, stopwords)
 
 
 def get_sentence_token_count_feats_base(candidate, attr, ngram, stopwords):
     """Apply @get_token_count_feats over the parent @Sentence of @candidate"""
-    sentence = candidate.get_parent().parent
+    sentence = candidate.get_parent().get_parent()
     return get_token_count_feats(candidate, sentence, attr, ngram, stopwords)
 
 

--- a/snorkel/lf_helpers.py
+++ b/snorkel/lf_helpers.py
@@ -21,7 +21,7 @@ def get_text_splits(c):
     spans.sort()
 
     # NOTE: Assume all Spans in same parent Context
-    text = span.parent.text
+    text = span.get_parent().text
 
     # Get text chunks
     chunks = [text[:spans[0][0]], "{{%s}}" % spans[0][2]]
@@ -79,7 +79,7 @@ def get_left_tokens(c, window=3, attrib='words', n_max=1, case_sensitive=False):
     span = c if isinstance(c, Span) else c[0] 
     i    = span.get_word_start()
     f = (lambda w: w) if case_sensitive else (lambda w: w.lower())
-    return [ngram for ngram in tokens_to_ngrams(map(f, span.parent._asdict()[attrib][max(0, i-window):i]), n_max=n_max)]
+    return [ngram for ngram in tokens_to_ngrams(map(f, span.get_parent()._asdict()[attrib][max(0, i-window):i]), n_max=n_max)]
 
 
 def get_right_tokens(c, window=3, attrib='words', n_max=1, case_sensitive=False):
@@ -92,7 +92,7 @@ def get_right_tokens(c, window=3, attrib='words', n_max=1, case_sensitive=False)
     span = c if isinstance(c, Span) else c[-1]
     i    = span.get_word_end()
     f = (lambda w: w) if case_sensitive else (lambda w: w.lower())
-    return [ngram for ngram in tokens_to_ngrams(map(f, span.parent._asdict()[attrib][i+1:i+1+window]), n_max=n_max)]
+    return [ngram for ngram in tokens_to_ngrams(map(f, span.get_parent()._asdict()[attrib][i+1:i+1+window]), n_max=n_max)]
 
 
 def contains_token(c, tok, attrib='words', case_sensitive=False):
@@ -112,7 +112,7 @@ def get_doc_candidate_spans(c):
     arguments of Candidates.
     """
     # TODO: Fix this to be more efficient and properly general!!
-    spans = list(chain.from_iterable(s.spans for s in c[0].parent.document.sentences))
+    spans = list(chain.from_iterable(s.spans for s in c[0].get_parent().document.sentences))
     return [s for s in spans if s != c[0]]
 
 
@@ -122,7 +122,7 @@ def get_sent_candidate_spans(c):
     arguments of Candidates.
     """
     # TODO: Fix this to be more efficient and properly general!!
-    return [s for s in c[0].parent.spans if s != c[0]]
+    return [s for s in c[0].get_parent().spans if s != c[0]]
 
 
 def get_matches(lf, candidate_set, match_values=[1,-1]):

--- a/snorkel/models/candidate.py
+++ b/snorkel/models/candidate.py
@@ -29,7 +29,7 @@ class Candidate(SnorkelBase):
 
     def get_parent(self):
         # Fails if both contexts don't have same parent
-        p = [c.parent for c in self.get_contexts()]
+        p = [c.get_parent() for c in self.get_contexts()]
         if p.count(p[0]) == len(p):
             return p[0]
         else:

--- a/snorkel/models/context.py
+++ b/snorkel/models/context.py
@@ -180,9 +180,9 @@ class TemporaryContext(object):
 
 class TemporarySpan(TemporaryContext):
     """The TemporaryContext version of Span"""
-    def __init__(self, parent, char_start, char_end, meta=None):
+    def __init__(self, sentence, char_start, char_end, meta=None):
         super(TemporarySpan, self).__init__()
-        self.parent     = parent  # The parent Context of the Span
+        self.sentence     = sentence  # The sentence Context of the Span
         self.char_end   = char_end
         self.char_start = char_start
         self.meta       = meta
@@ -192,23 +192,23 @@ class TemporarySpan(TemporaryContext):
 
     def __eq__(self, other):
         try:
-            return self.parent == other.parent and self.char_start == other.char_start \
+            return self.sentence == other.sentence and self.char_start == other.char_start \
                 and self.char_end == other.char_end
         except AttributeError:
             return False
 
     def __ne__(self, other):
         try:
-            return self.parent != other.parent or self.char_start != other.char_start \
+            return self.sentence != other.sentence or self.char_start != other.char_start \
                 or self.char_end != other.char_end
         except AttributeError:
             return True
 
     def __hash__(self):
-        return hash(self.parent) + hash(self.char_start) + hash(self.char_end)
+        return hash(self.sentence) + hash(self.char_start) + hash(self.char_end)
 
     def get_stable_id(self):
-        return construct_stable_id(self.parent, self._get_polymorphic_identity(), self.char_start, self.char_end)
+        return construct_stable_id(self.sentence, self._get_polymorphic_identity(), self.char_start, self.char_end)
 
     def _get_table_name(self):
         return 'span'
@@ -217,10 +217,10 @@ class TemporarySpan(TemporaryContext):
         return 'span'
 
     def _get_insert_query(self):
-        return """INSERT INTO span VALUES(:id, :parent_id, :char_start, :char_end, :meta)"""
+        return """INSERT INTO span VALUES(:id, :sentence_id, :char_start, :char_end, :meta)"""
 
     def _get_insert_args(self):
-        return {'parent_id' : self.parent.id,
+        return {'sentence_id' : self.sentence.id,
                 'char_start': self.char_start,
                 'char_end'  : self.char_end,
                 'meta'      : self.meta}
@@ -237,7 +237,7 @@ class TemporarySpan(TemporaryContext):
     def char_to_word_index(self, ci):
         """Given a character-level index (offset), return the index of the **word this char is in**"""
         i = None
-        for i, co in enumerate(self.parent.char_offsets):
+        for i, co in enumerate(self.sentence.char_offsets):
             if ci == co:
                 return i
             elif ci < co:
@@ -246,17 +246,17 @@ class TemporarySpan(TemporaryContext):
 
     def word_to_char_index(self, wi):
         """Given a word-level index, return the character-level index (offset) of the word's start"""
-        return self.parent.char_offsets[wi]
+        return self.sentence.char_offsets[wi]
 
     def get_attrib_tokens(self, a='words'):
         """Get the tokens of sentence attribute _a_ over the range defined by word_offset, n"""
-        return self.parent.__getattribute__(a)[self.get_word_start():self.get_word_end() + 1]
+        return self.sentence.__getattribute__(a)[self.get_word_start():self.get_word_end() + 1]
 
     def get_attrib_span(self, a, sep=" "):
         """Get the span of sentence attribute _a_ over the range defined by word_offset, n"""
         # NOTE: Special behavior for words currently (due to correspondence with char_offsets)
         if a == 'words':
-            return self.parent.text[self.char_start:self.char_end + 1]
+            return self.sentence.text[self.char_start:self.char_end + 1]
         else:
             return sep.join(self.get_attrib_tokens(a))
 
@@ -279,13 +279,13 @@ class TemporarySpan(TemporaryContext):
                 char_end = self.char_start + key.stop - 1
             else:
                 char_end = self.char_end + key.stop
-            return self._get_instance(char_start=char_start, char_end=char_end, parent=self.parent)
+            return self._get_instance(char_start=char_start, char_end=char_end, sentence=self.sentence)
         else:
             raise NotImplementedError()
 
     def __repr__(self):
-        return u'%s("%s", parent=%s, chars=[%s,%s], words=[%s,%s])' \
-            % (self.__class__.__name__, self.get_span(), self.parent.id, self.char_start, self.char_end,
+        return u'%s("%s", sentence=%s, chars=[%s,%s], words=[%s,%s])' \
+            % (self.__class__.__name__, self.get_span(), self.sentence.id, self.char_start, self.char_end,
                self.get_word_start(), self.get_word_end())
 
     def _get_instance(self, **kwargs):
@@ -300,13 +300,13 @@ class Span(Context, TemporarySpan):
     """
     __tablename__ = 'span'
     id = Column(Integer, ForeignKey('context.id', ondelete='CASCADE'), primary_key=True)
-    parent_id = Column(Integer, ForeignKey('context.id', ondelete='CASCADE'))
+    sentence_id = Column(Integer, ForeignKey('sentence.id', ondelete='CASCADE'))
     char_start = Column(Integer, nullable=False)
     char_end = Column(Integer, nullable=False)
     meta = Column(PickleType)
 
     __table_args__ = (
-        UniqueConstraint(parent_id, char_start, char_end),
+        UniqueConstraint(sentence_id, char_start, char_end),
     )
 
     __mapper_args__ = {
@@ -314,10 +314,10 @@ class Span(Context, TemporarySpan):
         'inherit_condition': (id == Context.id)
     }
 
-    parent = relationship('Context', backref=backref('spans', cascade='all, delete-orphan'), order_by=char_start, foreign_keys=parent_id)
+    sentence = relationship('Sentence', backref=backref('spans', cascade='all, delete-orphan'), order_by=char_start, foreign_keys=sentence_id)
 
     def get_parent(self):
-        return self.parent
+        return self.sentence
 
     def get_children(self):
         return None

--- a/snorkel/viewer.py
+++ b/snorkel/viewer.py
@@ -72,7 +72,7 @@ class Viewer(widgets.DOMWidget):
         # We get the sorted candidates and all contexts required, either from unary or binary candidates
         self.gold       = list(gold)
         self.candidates = sorted(list(candidates), key=lambda c : c[0].char_start)
-        self.contexts   = list(set(c[0].parent for c in self.candidates + self.gold))
+        self.contexts   = list(set(c[0].get_parent() for c in self.candidates + self.gold))
         
         # If committed, sort contexts by id
         try:
@@ -159,7 +159,7 @@ class Viewer(widgets.DOMWidget):
                 context = self.contexts[j]
 
                 # Get the candidates in this context
-                candidates = [c for c in self.candidates if c[0].parent == context]
+                candidates = [c for c in self.candidates if c[0].get_parent() == context]
                 gold = [g for g in self.gold if g.context_id == context.id]
 
                 # Construct the <li> and page view elements

--- a/tutorials/intro/Intro_Tutorial_2.ipynb
+++ b/tutorials/intro/Intro_Tutorial_2.ipynb
@@ -279,8 +279,70 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Traversing the _Context Hierarchy_\n",
+    "\n",
+    "As you have already probably observed, in Snorkel, all `Candidate`s are basically just tuples of `Context`-type objects--in this (and most) cases, `Span`s. Given a `Candidate`, we can easily access its `Context`s:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "c = train_cands[0]\n",
+    "c.get_contexts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "These `Context` objects are part of a hierarchy of `Context` objects in Snorkel.  In our case, this hierarchy consists of `Document`s, `Sentence`s, and `Span`s.  We can traverse this hierarchy by using the specific names--e.g., `doc.sentences`--or by using the generic `get_parent()` and `get_children()` methods:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "span = c.get_contexts()[0]\n",
+    "print span\n",
+    "print span.get_parent()\n",
+    "print span.get_parent().get_parent()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Span`s and `Sentence`s have special attributes which you can explore further in the documentation, and in tutorial section 4, when you will use some of these to write labeling functions.  For example, we can get the raw text span, the words, and other token types comprising a span:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "print span.get_span()\n",
+    "print span.get_attrib_tokens()\n",
+    "print span.get_attrib_tokens('pos_tags')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Repeating for development and test corpora\n",
-    "We will rerun the same operations for the other two news corpora: development and test. All we do for each is load in the `Corpus` object, collect the `Sentence` objects, and run them through the `CandidateExtractor`."
+    "Finally, we will rerun the same operations for the other two news corpora: development and test. All we do for each is load in the `Corpus` object, collect the `Sentence` objects, and run them through the `CandidateExtractor`."
    ]
   },
   {
@@ -321,7 +383,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/tutorials/intro/Intro_Tutorial_2.ipynb
+++ b/tutorials/intro/Intro_Tutorial_2.ipynb
@@ -281,7 +281,7 @@
    "source": [
     "### Traversing the _Context Hierarchy_\n",
     "\n",
-    "As you have already probably observed, in Snorkel, all `Candidate`s are basically just tuples of `Context`-type objects--in this (and most) cases, `Span`s. Given a `Candidate`, we can easily access its `Context`s:"
+    "As you have already probably observed, in Snorkel, all `Candidate`s are basically just tuples of `Context`-type objects--in this (and most) cases, `Span`s. Given a `Candidate`, we can easily access its `Context`s by the names you've given them, or as a list:"
    ]
   },
   {
@@ -293,6 +293,17 @@
    "outputs": [],
    "source": [
     "c = train_cands[0]\n",
+    "c.person1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
     "c.get_contexts()"
    ]
   },

--- a/tutorials/intro/Intro_Tutorial_4.ipynb
+++ b/tutorials/intro/Intro_Tutorial_4.ipynb
@@ -138,7 +138,7 @@
     "    return 0\n",
     "\n",
     "def LF_no_spouse_in_sentence(c):\n",
-    "    return -1 if np.random.rand() < 0.25 and len(spouses.intersection(set(c[0].parent.words))) == 0 else 0\n",
+    "    return -1 if np.random.rand() < 0.25 and len(spouses.intersection(set(c.get_parent().words))) == 0 else 0\n",
     "\n",
     "def LF_and_married(c):\n",
     "    return 1 if 'and' in get_between_tokens(c) and 'married' in get_right_tokens(c) else 0\n",
@@ -649,7 +649,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Minor edits:
* Add `get_parent()` and `get_children()` methods to `Context`.  Having these be methods is both simple and allows for custom specification of e.g. how the children are sorted
* Adds a small section to tutorial 2