### PR TITLE
Fix CoreNLP Divergence Bug

### DIFF
--- a/snorkel/parser.py
+++ b/snorkel/parser.py
@@ -271,6 +271,7 @@ class CoreNLPHandler(object):
                 dep_lab.append(deps['dep'])
                 dep_order.append(deps['dependent'])
 
+            parts['text'] = ''.join(t['originalText'] + t['after'] for t in block['tokens'])
             # make char_offsets relative to start of sentence
             abs_sent_offset = parts['char_offsets'][0]
             parts['char_offsets'] = [p - abs_sent_offset for p in parts['char_offsets']]


### PR DESCRIPTION
A previous issue (#368) identified that at times the raw text and the CoreNLP parse for a sentence diverged, and we had a check in place to go with the CoreNLP parse when this happened. The cause of this bug was not accounting for the fact that Penn Tree Bank tokens (e.g., ')') were being converted from 1 character long to 5 characters long (e.g., '-RRB-'), with offsets treating them as 1 and summing of word lengths counting them as 5. This fix replaces the PTB characters immediately, before character counting begins, so the extra divergence check is no longer required and our code can be simplified.