### PR TITLE
Finally fixing the dang unicode issues

### DIFF
--- a/snorkel/models/candidate.py
+++ b/snorkel/models/candidate.py
@@ -47,7 +47,7 @@ class Candidate(SnorkelBase):
         return self.get_contexts()[key]
 
     def __repr__(self):
-        return u"%s(%s)" % (self.__class__.__name__, u", ".join(map(unicode, self.get_contexts())))
+        return "%s(%s)" % (self.__class__.__name__, ", ".join(map(str, self.get_contexts())))
 
 
 def candidate_subclass(class_name, args, table_name=None):

--- a/snorkel/models/context.py
+++ b/snorkel/models/context.py
@@ -121,7 +121,7 @@ class Sentence(Context):
         yield self
 
     def __repr__(self):
-        return "Sentence" + str((self.document, self.position, self.text))
+        return "Sentence(%s,%s,%s)" % (self.document, self.position, self.text.encode('utf-8'))
 
 
 class TemporaryContext(object):
@@ -284,8 +284,8 @@ class TemporarySpan(TemporaryContext):
             raise NotImplementedError()
 
     def __repr__(self):
-        return u'%s("%s", sentence=%s, chars=[%s,%s], words=[%s,%s])' \
-            % (self.__class__.__name__, self.get_span(), self.sentence.id, self.char_start, self.char_end,
+        return '%s("%s", sentence=%s, chars=[%s,%s], words=[%s,%s])' \
+            % (self.__class__.__name__, self.get_span().encode('utf-8'), self.sentence.id, self.char_start, self.char_end,
                self.get_word_start(), self.get_word_end())
 
     def _get_instance(self, **kwargs):


### PR DESCRIPTION
Death to all UnicodeEncodeErrors!

TL;DR: This makes the unicode errors go away.

Once upon a time we made everything unicode inside snorkel, which is good, but now when we go to print it out, we need to tell it how to encode it so that python will print it correctly. So here, rather than simply building more unicode strings and passing them to print (which won't know what to do with them since it defaults to converting unicode to ascii, which not all of our strings can be represented in), we explicitly build strings (which we tell it are utf-8 rather than ascii) and return those to the print statement. 