### PR TITLE
Parser: really remove HTML comments.

### DIFF
--- a/snorkel/parser.py
+++ b/snorkel/parser.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 import atexit
 from bs4 import BeautifulSoup
+from bs4 import element
 import codecs
 from collections import defaultdict
 import glob
 import json
 import lxml.etree as et
 import os
-import re
 import requests
 import signal
 from subprocess import Popen
@@ -140,7 +140,7 @@ class HTMLDocPreprocessor(DocPreprocessor):
     def _cleaner(self, s):
         if s.parent.name in ['style', 'script', '[document]', 'head', 'title']:
             return False
-        elif re.match('<!--.*-->', unicode(s)):
+        elif isinstance(s, element.Comment):
             return False
         return True
 


### PR DESCRIPTION
The current regex never matches anything. 

(Also see the comments to the first answer on http://stackoverflow.com/questions/1936466/beautifulsoup-grab-visible-webpage-text )