### PR TITLE
Scoped categorical

### DIFF
--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -332,14 +332,8 @@ class LabelAnnotator(Annotator):
     """Apply labeling functions to the candidates, generating Label annotations
     
     :param lfs: A _list_ of labeling functions (LFs)
-    :param scoped_categorical: If True, remap the values of a categorical
-        label matrix so that the support for each candidate is a contiguous
-        range, so that only relevant values are sampled during learning / 
-        inference.
     """
-    def __init__(self, lfs, scoped_categorical=False):
-        self.scoped_categorical = scoped_categorical
-
+    def __init__(self, lfs):
         # Convert lfs to a generator function
         # In particular, catch verbose values and convert to integer ones
         def f_gen(c):
@@ -368,40 +362,8 @@ class LabelAnnotator(Annotator):
 
         super(LabelAnnotator, self).__init__(Label, LabelKey, f_gen)
 
-    def _remap(self, L):
-        """Remaps values of a categorical label matrix L for each row 
-        (candidate) so that the support for each candidate is a contiguous
-        range.
-
-        Simple example:
-        L = [[0, 5, 10, 5], [1, 4, 200, 1, 1]]
-        
-        gets mapped to:
-        L = [[0,1,2,1], [1,2,3,1,1]], maps = [[5,10], [1,4,200]].
-
-        :param support_sets: If provided, 
-        """
-        mappings = []
-        for i in range(L.shape[0]):
-            mapping = sorted(set(L[i].data))
-            mappings.append(vals)
-            for j in range(L[i].data.shape[0]):
-                L[i, L[i].indices[j]] = mapping.index(L[i].data[j]) + 1
-        return L, mappings
-
     def load_matrix(self, session, split, **kwargs):
-        L = load_label_matrix(session, split=split, **kwargs)
-
-        # Optionally remap the label matrix entries so that support is dense
-        if self.scoped_categorical:
-            L, mappings = self._remap(L)
-
-            # Note: L is stored in pre-remapped format in the DB, and the
-            # remapping operation is deterministic- therefore we don't need to
-            # store the mappings in the DB
-            return L, mappings
-        else:
-            return L
+        return load_label_matrix(session, split=split, **kwargs)
 
         
 class FeatureAnnotator(Annotator):

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -362,8 +362,25 @@ class LabelAnnotator(Annotator):
 
         super(LabelAnnotator, self).__init__(Label, LabelKey, f_gen)
 
+    def _remap(self, L):
+        """Remaps values of label matrix L for each row (candidate) so that
+        each candidate has dense support. Optionally takes a list of
+        pre-computed support sets for each candidate.
+
+        Simple example:
+        L = [[0, 5, 10, 5], [1, 4, 200, 1, 1]]
+        
+        gets mapped to:
+        L = [[0,1,2,1], [1,2,3,1,1]], maps = [[5,10], [1,4,200]].
+        """
+        # TODO
+        return L, []
+
     def load_matrix(self, session, split, **kwargs):
-        return load_label_matrix(session, split=split, **kwargs)
+        L, maps = self._remap(load_label_matrix(session, split=split, **kwargs))
+
+        # TODO: Store maps in db?
+        return L
 
         
 class FeatureAnnotator(Annotator):

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -771,7 +771,7 @@ class GenerativeModel(object):
         mappings = []
         for i in range(L.shape[0]):
             mapping = sorted(set(L[i].data))
-            mappings.append(vals)
+            mappings.append(mapping)
             for j in range(L[i].data.shape[0]):
                 L[i, L[i].indices[j]] = mapping.index(L[i].data[j]) + 1
         return L, mappings

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -183,7 +183,7 @@ class GenerativeModel(object):
             # Note this turns cardinality from an int -> a list
             self.cardinalities = map(len, self.mappings)
         else:
-            self.cardinalities = self.cardinality * np.ones(m)
+            self.cardinalities = self.cardinality * np.ones(m, np.int64)
 
         # Compile factor graph
         self._process_dependency_graph(L, deps)

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -254,8 +254,8 @@ class GenerativeModel(object):
 
         burnin = 500
         trials = 5000
-        cardinality = self.cardinality
-        count = np.zeros((self.nlf, self.cardinality, cardinality + 1))
+        cardinality = max(self.cardinalities)
+        count = np.zeros((self.nlf, cardinality, cardinality + 1))
 
         for true_label in range(cardinality):
             for i in range(self.nlf + 1):

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -365,6 +365,7 @@ class GenerativeModel(object):
                                 logp_false += self.weights.dep_reinforcing[j, k]
 
                 marginals[i] = 1 / (1 + np.exp(logp_false - logp_true))
+            return marginals
 
         # Categorical setting
         else:
@@ -402,7 +403,7 @@ class GenerativeModel(object):
                         M[i, self.mappings[j-1]] = p
             else:
                 M = np.vstack(all_marginals)
-        return M
+            return M
 
     def score(self, session, X_test, test_labels, gold_candidate_set=None, b=0.5, set_unlabeled_as_neg=True,
               display=True, scorer=MentionScorer, **kwargs):

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -258,12 +258,13 @@ class GenerativeModel(object):
         count = np.zeros((self.nlf, self.cardinality, cardinality + 1))
 
         for true_label in range(cardinality):
-            self.fg.factorGraphs[0].var_value[0, 0] = true_label
+            for i in range(self.nlf + 1):
+                self.fg.factorGraphs[0].var_value[0, i] = true_label
             self.fg.factorGraphs[0].inference(burnin, 0, True)
             for i in range(trials):
                 self.fg.factorGraphs[0].inference(0, 1, True)
+                y = self.fg.factorGraphs[0].var_value[0, 0]
                 for j in range(self.nlf):
-                    y = self.fg.factorGraphs[0].var_value[0, 0]
                     lf = self.fg.factorGraphs[0].var_value[0, j + 1]
                     count[j, y, lf] += 1
 

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -227,7 +227,10 @@ class GenerativeModel(object):
         self._process_learned_weights(L, fg, LF_acc_prior_weights, is_fixed)
 
         # Store info from factor graph
-        self.cardinality_for_stats = max(map(lambda x: len(x), self.mappings))
+        if self.scoped_categorical:
+            self.cardinality_for_stats = max(map(lambda x: len(x), self.mappings))
+        else:
+            self.cardinality_for_stats = self.cardinality
         self.learned_weights = fg.factorGraphs[0].weight_value
         weight, variable, factor, ftv, domain_mask, n_edges =\
             self._compile(sparse.coo_matrix((1, n), L.dtype), init_deps,

--- a/test/learning/test_categorical.py
+++ b/test/learning/test_categorical.py
@@ -20,6 +20,8 @@ class TestCategorical(unittest.TestCase):
     def _test_categorical(self, scoped_categorical=False, cardinality=4):
         # A set of true priors
         tol = 0.1
+        if scoped_categorical:
+            tol = 0.15
         cardinality = 4
         LF_acc_priors = [0.75, 0.75, 0.75, 0.75, 0.9]
         LF_acc_prior_weights = map(lambda x: 0.5 * np.log((cardinality - 1.0) * x / (1 - x)), LF_acc_priors)

--- a/test/learning/test_categorical.py
+++ b/test/learning/test_categorical.py
@@ -17,12 +17,11 @@ class TestCategorical(unittest.TestCase):
     def tearDownClass(cls):
         pass
 
-    def test_categorical(self):
+    def _test_categorical(self, scoped_categorical=False, cardinality=4):
         # A set of true priors
         tol = 0.1
         LF_acc_priors = [0.75, 0.75, 0.75, 0.75, 0.9]
         label_prior = 0.999
-        cardinality = 4
 
         def get_lf(label, cardinality, acc):
             if random.random() < acc:
@@ -65,7 +64,8 @@ class TestCategorical(unittest.TestCase):
             label_prior=label_prior,
             reg_type=2,
             reg_param=1,
-            epochs=0
+            epochs=0,
+            scoped_categorical=scoped_categorical
         )
         stats = gen_model.learned_lf_stats()
         accs = stats["Accuracy"]
@@ -82,7 +82,8 @@ class TestCategorical(unittest.TestCase):
             labels=labels,
             label_prior=label_prior,
             reg_type=0,
-            reg_param=0.0
+            reg_param=0.0,
+            scoped_categorical=scoped_categorical
         )
         stats = gen_model.learned_lf_stats()
         accs = stats["Accuracy"]
@@ -96,7 +97,7 @@ class TestCategorical(unittest.TestCase):
         # Test without supervised
         print("\nTesting without supervised")
         gen_model = GenerativeModel(lf_propensity=True)
-        gen_model.train(L, reg_type=0)
+        gen_model.train(L, reg_type=0, scoped_categorical=scoped_categorical)
         stats = gen_model.learned_lf_stats()
         accs = stats["Accuracy"]
         coverage = stats["Coverage"]
@@ -113,7 +114,8 @@ class TestCategorical(unittest.TestCase):
             L,
             labels=labels,
             label_prior=label_prior,
-            reg_type=0
+            reg_type=0,
+            scoped_categorical=scoped_categorical
         )
         stats = gen_model.learned_lf_stats()
         accs = stats["Accuracy"]
@@ -131,7 +133,8 @@ class TestCategorical(unittest.TestCase):
         gen_model.train(
             L,
             LF_acc_priors=bad_prior,
-            reg_type=0
+            reg_type=0,
+            scoped_categorical=scoped_categorical
         )
         stats = gen_model.learned_lf_stats()
         accs = stats["Accuracy"]
@@ -148,13 +151,24 @@ class TestCategorical(unittest.TestCase):
             L,
             LF_acc_priors=bad_prior,
             reg_type=2,
-            reg_param=100 * n
+            reg_param=100 * n,
+            scoped_categorical=scoped_categorical
         )
         stats = gen_model.learned_lf_stats()
         accs = stats["Accuracy"]
         coverage = stats["Coverage"]
         print(accs)
         self.assertTrue(np.all(np.abs(accs - np.array(bad_prior)) < tol))
+
+    def test_categorical(self):
+        self._test_categorical()
+
+    def test_scoped_categorical(self):
+        # Repeat previous tests with scoped_categorical=True
+        print("\n\nTesting scoped categorical with cardinality=4")
+        self._test_categorical(scoped_categorical=True)
+        print("\n\nTesting scoped categorical with cardinality=100")
+        self._test_categorical(scoped_categorical=True, cardinality=100)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/learning/test_categorical.py
+++ b/test/learning/test_categorical.py
@@ -38,7 +38,7 @@ class TestCategorical(unittest.TestCase):
         L = sparse.lil_matrix((n, 5), dtype=np.int64)
 
         # Store the supervised gold labels separately
-        labels = np.zeros(n)
+        labels = np.zeros(n, np.int64)
 
         for i in range(n):
             y = random.randint(0, cardinality - 1)

--- a/test/learning/test_categorical.py
+++ b/test/learning/test_categorical.py
@@ -20,8 +20,10 @@ class TestCategorical(unittest.TestCase):
     def _test_categorical(self, scoped_categorical=False, cardinality=4):
         # A set of true priors
         tol = 0.1
+        cardinality = 4
         LF_acc_priors = [0.75, 0.75, 0.75, 0.75, 0.9]
-        label_prior = 0.999
+        LF_acc_prior_weights = map(lambda x: 0.5 * np.log((cardinality - 1.0) * x / (1 - x)), LF_acc_priors)
+        label_prior = 1
 
         def get_lf(label, cardinality, acc):
             if random.random() < acc:
@@ -59,9 +61,8 @@ class TestCategorical(unittest.TestCase):
         gen_model = GenerativeModel(lf_propensity=True)
         gen_model.train(
             L,
-            LF_acc_priors=LF_acc_priors,
+            LF_acc_prior_weights=LF_acc_prior_weights,
             labels=labels,
-            label_prior=label_prior,
             reg_type=2,
             reg_param=1,
             epochs=0,
@@ -78,9 +79,8 @@ class TestCategorical(unittest.TestCase):
         print("\nTesting estimated LF accs (TOL=%s)" % tol)
         gen_model.train(
             L,
-            LF_acc_priors=LF_acc_priors,
+            LF_acc_prior_weights=LF_acc_prior_weights,
             labels=labels,
-            label_prior=label_prior,
             reg_type=0,
             reg_param=0.0,
             scoped_categorical=scoped_categorical
@@ -113,7 +113,6 @@ class TestCategorical(unittest.TestCase):
         gen_model.train(
             L,
             labels=labels,
-            label_prior=label_prior,
             reg_type=0,
             scoped_categorical=scoped_categorical
         )
@@ -130,9 +129,10 @@ class TestCategorical(unittest.TestCase):
         print("\nTesting without supervised, with bad priors (weak)")
         gen_model = GenerativeModel(lf_propensity=True)
         bad_prior = [0.9, 0.8, 0.7, 0.6, 0.5]
+        bad_prior_weights = map(lambda x: 0.5 * np.log((cardinality - 1.0) * x / (1 - x)), bad_prior)
         gen_model.train(
             L,
-            LF_acc_priors=bad_prior,
+            LF_acc_prior_weights=bad_prior_weights,
             reg_type=0,
             scoped_categorical=scoped_categorical
         )
@@ -149,7 +149,7 @@ class TestCategorical(unittest.TestCase):
         gen_model = GenerativeModel(lf_propensity=True)
         gen_model.train(
             L,
-            LF_acc_priors=bad_prior,
+            LF_acc_prior_weights=bad_prior_weights,
             reg_type=2,
             reg_param=100 * n,
             scoped_categorical=scoped_categorical

--- a/test/learning/test_gen_learning.py
+++ b/test/learning/test_gen_learning.py
@@ -39,11 +39,13 @@ class TestGenLearning(unittest.TestCase):
             lf_propensity=False, lf_class_propensity=False)
         gen_model._process_dependency_graph(L, ())
         m, n = L.shape
-        LF_priors = [0.7 for _ in range(n)]
+        LF_acc_prior_weights = [1.0 for _ in range(n)]
         is_fixed = [False for _ in range(n)]
+        gen_model.cardinality = 2
+        cardinalities = 2 * np.ones(5)
         weight, variable, factor, ftv, domain_mask, n_edges =\
-            gen_model._compile(L, 0.5, 0.0, LF_priors, is_fixed, 2)
-
+            gen_model._compile(L, 0.5, 0.0, LF_acc_prior_weights, is_fixed, 
+                cardinalities)
         #
         # Weights
         #
@@ -56,7 +58,7 @@ class TestGenLearning(unittest.TestCase):
         # The LF priors
         for i in range(1,7,2):
             self.assertTrue(weight[i]['isFixed'])
-            self.assertEqual(weight[i]['initialValue'], np.float64(0.5 * np.log(0.7 / (1 - 0.7))))
+            self.assertEqual(weight[i]['initialValue'], 1.0)
 
         # The LF weights
         for i in range(2,7,2):
@@ -172,10 +174,13 @@ class TestGenLearning(unittest.TestCase):
             lf_propensity=True, lf_class_propensity=False)
         gen_model._process_dependency_graph(L, deps)
         m, n = L.shape
-        LF_priors = [0.7 for _ in range(n)]
+        LF_acc_prior_weights = [1.0 for _ in range(n)]
         is_fixed = [False for _ in range(n)]
+        gen_model.cardinality = 2
+        cardinalities = 2 * np.ones(5)
         weight, variable, factor, ftv, domain_mask, n_edges =\
-            gen_model._compile(L, 0.5, -1.0, LF_priors, is_fixed, 2)
+            gen_model._compile(L, 0.5, -1.0, LF_acc_prior_weights, is_fixed,
+                cardinalities)
 
         #
         # Weights
@@ -187,7 +192,7 @@ class TestGenLearning(unittest.TestCase):
         # The LF priors
         for i in range(0,6,2):
             self.assertTrue(weight[i]['isFixed'])
-            self.assertEqual(weight[i]['initialValue'], np.float64(0.5 * np.log(0.7 / (1 - 0.7))))
+            self.assertEqual(weight[i]['initialValue'], 1.0)
 
         # The LF weights
         for i in range(1,6,2):

--- a/test/learning/test_supervised.py
+++ b/test/learning/test_supervised.py
@@ -23,7 +23,9 @@ class TestSupervised(unittest.TestCase):
         # A set of true priors
         tol = 0.1
         LF_acc_priors = [0.75, 0.75, 0.75, 0.75, 0.9]
-        label_prior = 0.999
+        cardinality = 2
+        LF_acc_prior_weights = map(lambda x: 0.5 * np.log((cardinality - 1.0) * x / (1 - x)), LF_acc_priors)
+        label_prior = 1
 
         # Defines a label matrix
         n = 10000
@@ -53,9 +55,8 @@ class TestSupervised(unittest.TestCase):
         gen_model = GenerativeModel(lf_propensity=True)
         gen_model.train(
             L,
-            LF_acc_priors=LF_acc_priors,
+            LF_acc_prior_weights=LF_acc_prior_weights,
             labels=labels,
-            label_prior=label_prior,
             reg_type=2,
             reg_param=1,
             epochs=0
@@ -71,9 +72,8 @@ class TestSupervised(unittest.TestCase):
         print("\nTesting estimated LF accs (TOL=%s)" % tol)
         gen_model.train(
             L,
-            LF_acc_priors=LF_acc_priors,
+            LF_acc_prior_weights=LF_acc_prior_weights,
             labels=labels,
-            label_prior=label_prior,
             reg_type=0,
             reg_param=0.0,
         )
@@ -105,7 +105,6 @@ class TestSupervised(unittest.TestCase):
         gen_model.train(
             L,
             labels=labels,
-            label_prior=label_prior,
             reg_type=0
         )
         stats = gen_model.learned_lf_stats()
@@ -121,9 +120,10 @@ class TestSupervised(unittest.TestCase):
         print("\nTesting without supervised, with bad priors (weak)")
         gen_model = GenerativeModel(lf_propensity=True)
         bad_prior = [0.9, 0.8, 0.7, 0.6, 0.5]
+        bad_prior_weights = map(lambda x: 0.5 * np.log((cardinality - 1.0) * x / (1 - x)), bad_prior)
         gen_model.train(
             L,
-            LF_acc_priors=bad_prior,
+            LF_acc_prior_weights=bad_prior_weights,
             reg_type=0,
         )
         stats = gen_model.learned_lf_stats()
@@ -139,7 +139,7 @@ class TestSupervised(unittest.TestCase):
         gen_model = GenerativeModel(lf_propensity=True)
         gen_model.train(
             L,
-            LF_acc_priors=bad_prior,
+            LF_acc_prior_weights=bad_prior_weights,
             reg_type=2,
             reg_param=100 * n,
         )

--- a/test/learning/test_supervised.py
+++ b/test/learning/test_supervised.py
@@ -32,7 +32,7 @@ class TestSupervised(unittest.TestCase):
         L = sparse.lil_matrix((n, 5), dtype=np.int64)
 
         # Store the supervised gold labels separately
-        labels = np.zeros(n)
+        labels = np.zeros(n, np.int64)
 
         for i in range(n):
             y = 2 * random.randint(0, 1) - 1


### PR DESCRIPTION
Adds support for "scoped" categorical mode in `GenerativeModel` by setting `GenerativeModel.train(..., scoped_categorical=True)`.  In this setting, we assume there is a large cardinality but that each candidate has a much smaller effective cardinality; entries are re-mapped to row-specific values so that sampling is not massively inefficient.

Notes:
* No support currently for pre-specified per-candidate support sets; these are inferred as the union of all LF labels applied to a given candidate
* +1 smoothing is used w.r.t. cardinality: when computing the LF accuracies, we add +1 to the inferred cardinality to avoid weirdness when e.g. inferred cardinality would be 1 (could be quite common)
* A sparse matrix is returned (re-mapped to the correct original value range)