### PR TITLE
Adds psycopg2 dependency for PostgreSQL

### DIFF
--- a/python-package-requirement.txt
+++ b/python-package-requirement.txt
@@ -17,3 +17,4 @@ sqlalchemy>=1.0.14
 tensorflow>=1.0
 tika
 spacy
+psycopg2


### PR DESCRIPTION
First time trying to use PostgreSQL, the user is always given the following message:
```
ImportError: No module named psycopg2
```

This adds `psycopg2` to the list of dependencies 