### PR TITLE
Fix matcher typos. By default don't parse hidden files.

### DIFF
--- a/snorkel/matchers.py
+++ b/snorkel/matchers.py
@@ -116,7 +116,7 @@ class DictionaryMatch(NgramMatcher):
         p = self._stem(p) if self.stemmer is not None else p
         return (not self.reverse) if p in self.d else self.reverse
 
-class LambdaFunctionMatch(NgramMatcher):
+class LambdaFunctionMatcher(NgramMatcher):
     """Selects candidate Ngrams that output True when input to a function f."""
     def init(self):
         self.ignore_case = self.opts.get('ignore_case', True)

--- a/snorkel/matchers.py
+++ b/snorkel/matchers.py
@@ -117,14 +117,14 @@ class DictionaryMatch(NgramMatcher):
         return (not self.reverse) if p in self.d else self.reverse
 
 class LambdaFunctionMatch(NgramMatcher):
-    """Selects candidate Ngrams that match against a given list d"""
+    """Selects candidate Ngrams that output True when input to a function f."""
     def init(self):
         self.ignore_case = self.opts.get('ignore_case', True)
         self.attrib      = self.opts.get('attrib', WORDS)
         try:
             self.func = self.opts['func']
         except KeyError:
-            raise Exception("Please supply a dictionary (list of phrases) d as d=d.")
+            raise Exception("Please supply a function f as func=f.")
     
     def _f(self, c):
         """The internal (non-composed) version of filter function f"""

--- a/snorkel/matchers.py
+++ b/snorkel/matchers.py
@@ -117,7 +117,7 @@ class DictionaryMatch(NgramMatcher):
         return (not self.reverse) if p in self.d else self.reverse
 
 class LambdaFunctionMatcher(NgramMatcher):
-    """Selects candidate Ngrams that output True when input to a function f."""
+    """Selects candidate Ngrams that return True when input to a function f."""
     def init(self):
         self.ignore_case = self.opts.get('ignore_case', True)
         self.attrib      = self.opts.get('attrib', WORDS)

--- a/snorkel/matchers.py
+++ b/snorkel/matchers.py
@@ -117,7 +117,7 @@ class DictionaryMatch(NgramMatcher):
         return (not self.reverse) if p in self.d else self.reverse
 
 class LambdaFunctionMatcher(NgramMatcher):
-    """Selects candidate Ngrams that return True when input to a function f."""
+    """Selects candidate Ngrams that return True when fed to a function f."""
     def init(self):
         self.ignore_case = self.opts.get('ignore_case', True)
         self.attrib      = self.opts.get('attrib', WORDS)

--- a/snorkel/parser/doc_preprocessors.py
+++ b/snorkel/parser/doc_preprocessors.py
@@ -50,7 +50,7 @@ class DocPreprocessor(object):
         raise NotImplementedError()
 
     def _can_read(self, fpath):
-        return True
+        return not fpath.startswith('.')
 
     def _get_files(self, path):
         if os.path.isfile(path):


### PR DESCRIPTION
Matcher typos: updates doc string and error message for LambdaFunctionMatch.

Parsing hidden files: On Macs, for example, most directories include a .DS_Store file. By default, don't try to parse these. (This problem had blocked someone at office hours for a couple days).