### PR TITLE
Annotation matrix slicing

### DIFF
--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -68,12 +68,7 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
                 idxs = np.arange(self.shape[axis])[s]
         elif isinstance(s, int):
             idxs = np.array([s])
-<<<<<<< HEAD
-        else:
-            # s is an array of ints
-=======
         else: # s is an array of ints
->>>>>>> 9b25520e... Make csr_AnnotationMatrix.__getitem__ return an int or a csr_AnnotationMatrix.
             idxs = s
             # If s is the entire slice, skip the remapping step
             if idxs == range(len(idxs)):
@@ -89,17 +84,6 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
     def __getitem__(self, key):
         X = super(csr_AnnotationMatrix, self).__getitem__(key)
 
-<<<<<<< HEAD
-        # Remap the row and column indexes if applicable.
-        if hasattr(X, 'row_index') and hasattr(X, 'col_index'):
-            X.annotation_key_cls = self.annotation_key_cls
-            
-            row_slice, col_slice = self._unpack_index(key)
-            X.row_index, X.candidate_index = self._get_sliced_indexes(
-                row_slice, 0, self.row_index, self.candidate_index)
-            X.col_index, X.key_index = self._get_sliced_indexes(
-                col_slice, 1, self.col_index, self.key_index)
-=======
         # If X is an integer, just return it
         if isinstance(X, int):
             return X
@@ -113,7 +97,6 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
             row_slice, 0, self.row_index, self.candidate_index)
         X.col_index, X.key_index = self._get_sliced_indexes(
             col_slice, 1, self.col_index, self.key_index)
->>>>>>> 9b25520e... Make csr_AnnotationMatrix.__getitem__ return an int or a csr_AnnotationMatrix.
         return X
 
     def stats(self):

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -68,9 +68,17 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
                 idxs = np.arange(self.shape[axis])[s]
         elif isinstance(s, int):
             idxs = np.array([s])
+<<<<<<< HEAD
         else:
             # s is an array of ints
+=======
+        else: # s is an array of ints
+>>>>>>> 9b25520e... Make csr_AnnotationMatrix.__getitem__ return an int or a csr_AnnotationMatrix.
             idxs = s
+            # If s is the entire slice, skip the remapping step
+            if idxs == range(len(idxs)):
+                return index, inv_index
+
         index_new, inv_index_new = {}, {}
         for i_new, i in enumerate(idxs):
             k = index[i]
@@ -81,6 +89,7 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
     def __getitem__(self, key):
         X = super(csr_AnnotationMatrix, self).__getitem__(key)
 
+<<<<<<< HEAD
         # Remap the row and column indexes if applicable.
         if hasattr(X, 'row_index') and hasattr(X, 'col_index'):
             X.annotation_key_cls = self.annotation_key_cls
@@ -90,6 +99,21 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
                 row_slice, 0, self.row_index, self.candidate_index)
             X.col_index, X.key_index = self._get_sliced_indexes(
                 col_slice, 1, self.col_index, self.key_index)
+=======
+        # If X is an integer, just return it
+        if isinstance(X, int):
+            return X
+        # If X is a matrix, make sure it stays a csr_AnnotationMatrix
+        elif not isinstance(X, csr_AnnotationMatrix):
+            X = csr_AnnotationMatrix(X)
+        # X must be a matrix, so update appropriate csr_AnnotationMatrix fields
+        X.annotation_key_cls = self.annotation_key_cls
+        row_slice, col_slice = self._unpack_index(key)
+        X.row_index, X.candidate_index = self._get_sliced_indexes(
+            row_slice, 0, self.row_index, self.candidate_index)
+        X.col_index, X.key_index = self._get_sliced_indexes(
+            col_slice, 1, self.col_index, self.key_index)
+>>>>>>> 9b25520e... Make csr_AnnotationMatrix.__getitem__ return an int or a csr_AnnotationMatrix.
         return X
 
     def stats(self):

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -66,9 +66,11 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
                 return index, inv_index
             else:
                 idxs = np.arange(self.shape[axis])[s]
-        # csr_matrix._get_submatrix only handles slice or int, so this is int
-        else:
+        elif isinstance(s, int):
             idxs = np.array([s])
+        elif isinstance(np.ndarray):
+            # s is array of ints
+            idxs = s
         index_new, inv_index_new = {}, {}
         for i_new, i in enumerate(idxs):
             k = index[i]
@@ -76,13 +78,13 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
             inv_index_new[k] = i_new
         return index_new, inv_index_new
 
-    def _get_submatrix(self, row_slice, col_slice):
+    def __getitem__(self, key):
         # Get the slice of the matrix
-        X = super(csr_AnnotationMatrix, self)._get_submatrix(row_slice,
-            col_slice)
+        X = super(csr_AnnotationMatrix, self).__getitem__(key)
         X.annotation_key_cls = self.annotation_key_cls
+        row_slice, col_slice = self._unpack_index(key)
 
-        # # Remap the row and column indexes
+        # Remap the row and column indexes
         X.row_index, X.candidate_index = self._get_sliced_indexes(
             row_slice, 0, self.row_index, self.candidate_index)
         X.col_index, X.key_index = self._get_sliced_indexes(

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -81,7 +81,7 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
     def __getitem__(self, key):
         X = super(csr_AnnotationMatrix, self).__getitem__(key)
 
-        # Remap the row and column indexes if applicable
+        # Remap the row and column indexes if applicable.
         if hasattr(X, 'row_index') and hasattr(X, 'col_index'):
             X.annotation_key_cls = self.annotation_key_cls
             

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -81,8 +81,10 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
     def __getitem__(self, key):
         # Get the slice of the matrix
         X = super(csr_AnnotationMatrix, self).__getitem__(key)
-        X.annotation_key_cls = self.annotation_key_cls
         row_slice, col_slice = self._unpack_index(key)
+        if isinstance(row_slice, int) and isinstance(col_slice, int):
+            return X
+        X.annotation_key_cls = self.annotation_key_cls
 
         # Remap the row and column indexes
         X.row_index, X.candidate_index = self._get_sliced_indexes(

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -71,7 +71,7 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
         else: # s is an array of ints
             idxs = s
             # If s is the entire slice, skip the remapping step
-            if idxs == range(len(idxs)):
+            if np.array_equal(idxs, range(len(idxs))):
                 return index, inv_index
 
         index_new, inv_index_new = {}, {}

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -79,18 +79,17 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
         return index_new, inv_index_new
 
     def __getitem__(self, key):
-        # Get the slice of the matrix
         X = super(csr_AnnotationMatrix, self).__getitem__(key)
-        row_slice, col_slice = self._unpack_index(key)
-        if isinstance(row_slice, int) and isinstance(col_slice, int):
-            return X
-        X.annotation_key_cls = self.annotation_key_cls
 
-        # Remap the row and column indexes
-        X.row_index, X.candidate_index = self._get_sliced_indexes(
-            row_slice, 0, self.row_index, self.candidate_index)
-        X.col_index, X.key_index = self._get_sliced_indexes(
-            col_slice, 1, self.col_index, self.key_index)
+        # Remap the row and column indexes if applicable
+        if hasattr(X, 'row_index') and hasattr(X, 'col_index'):
+            X.annotation_key_cls = self.annotation_key_cls
+            
+            row_slice, col_slice = self._unpack_index(key)
+            X.row_index, X.candidate_index = self._get_sliced_indexes(
+                row_slice, 0, self.row_index, self.candidate_index)
+            X.col_index, X.key_index = self._get_sliced_indexes(
+                col_slice, 1, self.col_index, self.key_index)
         return X
 
     def stats(self):

--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -68,8 +68,8 @@ class csr_AnnotationMatrix(sparse.csr_matrix):
                 idxs = np.arange(self.shape[axis])[s]
         elif isinstance(s, int):
             idxs = np.array([s])
-        elif isinstance(np.ndarray):
-            # s is array of ints
+        else:
+            # s is an array of ints
             idxs = s
         index_new, inv_index_new = {}, {}
         for i_new, i in enumerate(idxs):

--- a/snorkel/learning/disc_learning.py
+++ b/snorkel/learning/disc_learning.py
@@ -3,6 +3,7 @@ import numpy as np
 from time import time
 import os
 from six.moves.cPickle import dump, load
+import scipy.sparse as sparse
 
 from .classifier import Classifier
 from .utils import reshape_marginals, LabelBalancer

--- a/snorkel/learning/disc_learning.py
+++ b/snorkel/learning/disc_learning.py
@@ -7,7 +7,7 @@ import scipy.sparse as sparse
 
 from .classifier import Classifier
 from .utils import reshape_marginals, LabelBalancer
-from ...models import csr_AnnotationMatrix
+from ..annotations import csr_AnnotationMatrix
 
 class TFNoiseAwareModel(Classifier):
     """

--- a/snorkel/learning/disc_learning.py
+++ b/snorkel/learning/disc_learning.py
@@ -164,7 +164,7 @@ class TFNoiseAwareModel(Classifier):
             diffs = Y_train.max(axis=1) - Y_train.min(axis=1)
             train_idxs = np.where(diffs > 1e-6)[0]
         X_train = [X_train[j] for j in train_idxs] if self.representation \
-            else X_train[train_idxs, :]
+            else sparse.csr_matrix(X_train[train_idxs, :])
         Y_train = Y_train[train_idxs]
 
         # Create new graph, build network, and start session

--- a/snorkel/learning/disc_learning.py
+++ b/snorkel/learning/disc_learning.py
@@ -3,11 +3,9 @@ import numpy as np
 from time import time
 import os
 from six.moves.cPickle import dump, load
-import scipy.sparse as sparse
 
 from .classifier import Classifier
 from .utils import reshape_marginals, LabelBalancer
-from ..annotations import csr_AnnotationMatrix
 
 class TFNoiseAwareModel(Classifier):
     """
@@ -166,8 +164,6 @@ class TFNoiseAwareModel(Classifier):
             train_idxs = np.where(diffs > 1e-6)[0]
         X_train = [X_train[j] for j in train_idxs] if self.representation \
             else X_train[train_idxs, :]
-        if isinstance(X_train, csr_AnnotationMatrix):
-            X_train = sparse.csr_matrix(X_train[train_idxs, :])
         Y_train = Y_train[train_idxs]
 
         # Create new graph, build network, and start session

--- a/snorkel/learning/disc_learning.py
+++ b/snorkel/learning/disc_learning.py
@@ -7,7 +7,7 @@ import scipy.sparse as sparse
 
 from .classifier import Classifier
 from .utils import reshape_marginals, LabelBalancer
-
+from ...models import csr_AnnotationMatrix
 
 class TFNoiseAwareModel(Classifier):
     """
@@ -165,7 +165,9 @@ class TFNoiseAwareModel(Classifier):
             diffs = Y_train.max(axis=1) - Y_train.min(axis=1)
             train_idxs = np.where(diffs > 1e-6)[0]
         X_train = [X_train[j] for j in train_idxs] if self.representation \
-            else sparse.csr_matrix(X_train[train_idxs, :])
+            else X_train[train_idxs, :]
+        if isinstance(X_train, csr_AnnotationMatrix):
+            X_train = sparse.csr_matrix(X_train[train_idxs, :])
         Y_train = Y_train[train_idxs]
 
         # Create new graph, build network, and start session

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -175,11 +175,8 @@ class GenerativeModel(Classifier):
             LF_acc_prior_weights.append(label_prior_weight)
             n += 1
 
-        # Make sure is CSR sparse matrix
-        # NB: Can clean up all this copying / etc but is necessary at least once
-        L = L.copy()
-        if not isinstance(L, sparse.csr_matrix):
-            L = sparse.csr_matrix(L)
+        # Reduce overhead of tracking indices by converting L to a CSR sparse matrix.
+        L = sparse.csr_matrix(L).copy()
 
         # If candidate_ranges is provided, remap the values of L using
         # candidate_ranges. This "scoped categorical" approach allows learning


### PR DESCRIPTION
This modification enables the full range of normal numpy slicing on annotations matrices. 

Instead of just replacing _get_submatrix, replace the higher level built-in function __getitem__, and for instances where the result it not a matrix (e.g., L_train[x,y] returns a scalar), it recognizes that the row_index and col_index are gone and won't try to keep up with the extra bookkeeping.

Further extends/fixes #582 and #688.