### PR TITLE
Quick fix for memory efficient loading

### DIFF
--- a/snorkel/annotations.py
+++ b/snorkel/annotations.py
@@ -355,22 +355,31 @@ def load_matrix(matrix_class, annotation_key_class, annotation_class, session,
             kid_to_col[kid] = j
             col_to_kid[j]   = kid
 
-    # Create sparse matrix in LIL format for incremental construction
-    X = sparse.lil_matrix((len(cid_to_row), len(kid_to_col)), dtype=np.int64)
+    # Create sparse matrix in COO format for incremental construction
+    row = []
+    columns = []
+    data = []
 
     # NOTE: This is much faster as it allows us to skip the above join (which for some reason is
     # unreasonably slow) by relying on our symbol tables from above; however this will get slower with
     # The total number of annotations in DB which is weird behavior...
     q = session.query(annotation_class.candidate_id, annotation_class.key_id, annotation_class.value)
-    q = q.order_by(annotation_class.candidate_id)
 
     # Iteratively construct row index and output sparse matrix
-    for cid, kid, val in q.all():
-        if cid in cid_to_row and kid in kid_to_col:
-            # Optionally restricts val range to {0,1}, mapping -1 -> 0
-            if zero_one:
-                val = 1 if val == 1 else 0
-            X[cid_to_row[cid], kid_to_col[kid]] = int(val)
+    # Cycle through each key and rely on select rather than going through the entire table
+    for f_cid in cid_to_row.keys():
+
+        for cid, kid, val in q.filter(annotation_class.candidate_id == f_cid).all():
+
+            if cid in cid_to_row and kid in kid_to_col:
+                # Optionally restricts val range to {0,1}, mapping -1 -> 0
+                if zero_one:
+                    val = 1 if val == 1 else 0
+                row.append(cid_to_row[cid])
+                columns.append(kid_to_col[kid])
+                data.append(int(val))
+
+    X = sparse.coo_matrix((data, (row, columns)), shape=(len(cid_to_row), len(kid_to_col)))
 
     # Return as an AnnotationMatrix
     Xr = matrix_class(X, candidate_index=cid_to_row, row_index=row_to_cid,

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -126,10 +126,9 @@ class GenerativeModel(Classifier):
         step_size = step_size or 0.0001
 
         # Check to make sure matrix is int-valued
-        element_type = type(L[0,0])
-        if not element_type in [np.int64, np.int32, int]:
+        if not (isinstance(L[0,0], np.int64) or isinstance(L[0,0], np.int32) or isinstance(L[0,0], int)):
             raise ValueError("""Label matrix must have int-type elements, 
-                but elements have type %s""" % element_type)
+                but elements have type %s""" % type(L[0,0]))
 
         # Automatically infer cardinality
         # Binary: Values in {-1, 0, 1} [Default]


### PR DESCRIPTION
Greetings this PR is a patch for loading the annotation matrix in a memory efficiently. While using snorkel, I ran into a memory issue where sqlalchemy tried to read the entire feature table before constructing the lil matrix. This might not sound like a problem, but can be detrimental for a table of about >21M rows. As a result I revamped the algorithm to avoid reading the entire table in memory. Plus  [stack overflow](https://stackoverflow.com/questions/32743584/python-lil-matrix-vs-csr-matrix-in-extremely-large-sparse-matrices) advised that I change the lil matrix construction to a coo matrix to avoid possible memory issues in the future. Free to change this to a way you all prefer. Let me know.