### PR TITLE
Update typos in Categorical_Classes.ipynb

### DIFF
--- a/tutorials/advanced/Categorical_Classes.ipynb
+++ b/tutorials/advanced/Categorical_Classes.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "from snorkel.models import candidate_subclass\n",
-    "Spouse = candidate_subclass('Spouse', ['person1', 'person2'], values=['Married', 'Employs', False])"
+    "Relationship = candidate_subclass('Relationship', ['person1', 'person2'], values=['Married', 'Employs', False])"
    ]
   },
   {
@@ -106,7 +106,7 @@
     "ngrams = Ngrams(n_max=3)\n",
     "person_matcher = PersonMatcher(longest_match_only=True)\n",
     "cand_extractor = CandidateExtractor(\n",
-    "    Spouse, \n",
+    "    Relationship, \n",
     "    [ngrams, ngrams],\n",
     "    [person_matcher, person_matcher],\n",
     "    symmetric_relations=False\n",
@@ -127,7 +127,7 @@
    },
    "outputs": [],
    "source": [
-    "train_cands = session.query(Spouse).filter(Spouse.split == 0).all()\n",
+    "train_cands = session.query(Relationship).filter(Relationship.split == 0).all()\n",
     "print \"Number of candidates:\", len(train_cands)"
    ]
   },
@@ -170,7 +170,7 @@
     "**The _categorical_ labeling functions (LFs) we now write can output the following values:**\n",
     "\n",
     "* Abstain: `None` OR 0\n",
-    "* Categorical values: The literal values in `Spouse.values` OR their integer indices.\n",
+    "* Categorical values: The literal values in `Relationship.values` OR their integer indices.\n",
     "\n",
     "We'll write two simple LFs to illustrate.\n",
     "\n",
@@ -368,7 +368,7 @@
    "outputs": [],
    "source": [
     "from snorkel.learning import SparseLogisticRegression\n",
-    "disc_model_sparse = SparseLogisticRegression(cardinality=Spouse.cardinality)\n",
+    "disc_model_sparse = SparseLogisticRegression(cardinality=Relationship.cardinality)\n",
     "\n",
     "disc_model_sparse.train(F_train, train_marginals, n_epochs=100, print_freq=10, lr=0.001)"
    ]


### PR DESCRIPTION
Since there are more relationships involved, consider renaming the variable name.