### PR TITLE
matching traditional and weak train numbers

### DIFF
--- a/snorkel/contrib/babble/pipelines/image_pipeline.py
+++ b/snorkel/contrib/babble/pipelines/image_pipeline.py
@@ -32,8 +32,7 @@ class ImagePipeline(BabblePipeline):
             num_candidates = self.session.query(self.candidate_class).filter(
                 self.candidate_class.split == split).count()
             print("Candidates [Split {}]: {}".format(split, num_candidates))
-
-
+    
     def classify(self, config=None, slim_ws_path=None):
         if config:
             self.config = config
@@ -77,10 +76,15 @@ class ImagePipeline(BabblePipeline):
                 mscoco_id = mscoco[image_id]
 
                 coco_ids[image_id] = int(mscoco_id)
+                
+                #HACK: sometimes marginals[idx] is a float, sometimes a matrix...
                 try:
                     labels[image_id] = max(labels[image_id], max(marginals[idx], 0))
                 except:
-                    import pdb; pdb.set_trace()
+                    try:
+                        labels[image_id] = max(labels[image_id], max(marginals[idx].todense(), 0))
+                    except:
+                        import pdb; pdb.set_trace()
 
             return coco_ids, labels
 
@@ -138,8 +142,8 @@ class ImagePipeline(BabblePipeline):
         if self.config['supervision'] == 'traditional':
             print("In 'traditional' supervision mode...grabbing candidate and gold label subsets.")  
             candidates_train = self.get_candidates(TRAIN)
-            L_gold_train = load_gold_labels(self.session, annotator_name='gold', split=TRAIN)
-            X_train, Y_train = self.traditional_supervision(candidates_train, L_gold_train)
+            Y_train = load_gold_labels(self.session, annotator_name='gold', split=TRAIN)
+            #Deleted call to traditional_supervision, which was pruning by number of non-zeros
             if self.config['display_marginals'] and not self.config['no_plots']:
                 plt.hist(Y_train, bins=20)
                 plt.show()
@@ -157,9 +161,7 @@ class ImagePipeline(BabblePipeline):
         # Convert to TFRecords Format
         if self.config.get('download_data', False):
             print ('Downloading and converting images...')
-            os.system('python ' + os.path.join(slim_ws_path, 'download_and_convert_data.py') + \
-                      ' --dataset_name mscoco ' + \
-                      ' --dataset_dir ' + dataset_dir)
+            os.system('python ' + os.path.join(slim_ws_path, 'download_and_convert_data.py') + ' --dataset_name mscoco ' + ' --dataset_dir ' + dataset_dir)
         else:
             print("Assuming MSCOCO data is already downloaded and converted (download_data = False).")
         
@@ -268,6 +270,7 @@ class ImagePipeline(BabblePipeline):
                  ' --dataset_split_name=test ' + \
                  ' --model_name=' + str(self.config['disc_model_class']) + \
                  ' | tee -a ' + test_file)
+                
         
         accuracy, precision, recall = scrape_output(test_file)
         p, r = precision, recall


### PR DESCRIPTION
we can't use the `traditional_supervision` function in snorkel pipeline for images...because of the candidate and image mismatch i believe

also a weird issue where the marginals are sometimes floats and sometimes sparse matrices, that was making it skip some images as well

in the notebook (not pushed), I'm hard coding`config['max_train'] = 15711` in order to make sure all the images get picked up, this is not necessary anymore since i don't even call the `traditional_supervision` function