### PR TITLE
Move _preprocess_data to parent Classifier class

### DIFF
--- a/snorkel/learning/classifier.py
+++ b/snorkel/learning/classifier.py
@@ -115,8 +115,15 @@ class Classifier(object):
         return s.score(test_marginals, train_marginals=None, b=b,
             display=display, set_unlabeled_as_neg=set_unlabeled_as_neg)
 
+    def _preprocess_data(self, X):
+        """Generic preprocessing subclass; may be called by external methods."""
+        return X
+
     def save(self):
         raise NotImplementedError()
 
     def load(self):
+        raise NotImplementedError()
+
+    def train(self):
         raise NotImplementedError()

--- a/snorkel/learning/disc_learning.py
+++ b/snorkel/learning/disc_learning.py
@@ -340,7 +340,3 @@ class TFNoiseAwareModel(Classifier):
         else:
             raise Exception("[{0}] No model found at <{1}>".format(
                 self.name, model_name))
-
-    def _preprocess_data(self, X):
-        """Generic preprocessing subclass; may be called by external methods."""
-        return X


### PR DESCRIPTION
This is a simple fix to a current bug in running multi-threaded `GridSearch` with models that don't have a `_preprocess_data` method, e.g. the `GenerativeModel` (which causes errors running scuba the whole way through with `n_threads > 1` for example).

Note that calling `._preprocess_data` in the grid search to pre-load data isn't the cleanest way to go about things but leave for now...