### PR TITLE
Flag for non-mutually-exclusive categorical classification

### DIFF
--- a/snorkel/learning/classifier.py
+++ b/snorkel/learning/classifier.py
@@ -17,9 +17,13 @@ class Classifier(object):
     # otherwise assume X is an AnnotationMatrix
     representation = False
 
-    def __init__(self, cardinality=2, name=None):
+    def __init__(self, cardinality=2, name=None, single_value=True):
         self.name = name or self.__class__.__name__
         self.cardinality = cardinality
+
+        # Determine whether predicts single value or (potentially) multiple
+        # Only valid when cardinality > 2
+        self.single_value = single_value
 
     def marginals(self, X, batch_size=None, **kwargs):
         raise NotImplementedError()
@@ -32,7 +36,7 @@ class Classifier(object):
         """Return numpy array of elements in {-1,0,1}
         based on predicted marginal probabilities.
         """
-        if self.cardinality > 2:
+        if self.cardinality > 2 and self.single_value:
             return self.marginals(X, batch_size=batch_size).argmax(axis=1) + 1
         else:
             return np.array([1 if p > b else -1 if p < b else 0 

--- a/snorkel/learning/disc_learning.py
+++ b/snorkel/learning/disc_learning.py
@@ -65,7 +65,7 @@ class TFNoiseAwareModel(Classifier):
             - self.optimizer: Training operation
         """
         # Define loss and marginals ops
-        if self.cardinality > 2:
+        if self.cardinality > 2 and self.single_value:
             loss_fn = tf.nn.softmax_cross_entropy_with_logits
         else:
             loss_fn = tf.nn.sigmoid_cross_entropy_with_logits

--- a/snorkel/learning/disc_models/logistic_regression.py
+++ b/snorkel/learning/disc_models/logistic_regression.py
@@ -56,7 +56,10 @@ class LogisticRegression(TFNoiseAwareModel):
             self.logits = tf.squeeze(self.logits)
 
         # Define marginals op
-        marginals_fn = tf.nn.softmax if self.cardinality > 2 else tf.nn.sigmoid
+        if self.cardinality > 2 and self.single_value:
+            marginals_fn = tf.nn.softmax
+        else:
+            marginals_fn = tf.nn.sigmoid
         self.marginals_op = marginals_fn(self.logits)
 
     def _build_training_ops(self, l1_penalty=0.0, l2_penalty=0.0, **kwargs):
@@ -133,7 +136,10 @@ class SparseLogisticRegression(LogisticRegression):
             self.logits = tf.squeeze(self.logits)
 
         # Define marginals op
-        marginals_fn = tf.nn.softmax if self.cardinality > 2 else tf.nn.sigmoid
+        if self.cardinality > 2 and self.single_value:
+            marginals_fn = tf.nn.softmax
+        else:
+            marginals_fn = tf.nn.sigmoid
         self.marginals_op = marginals_fn(self.logits)
 
     def _check_input(self, X):

--- a/snorkel/learning/disc_models/rnn/rnn_base.py
+++ b/snorkel/learning/disc_models/rnn/rnn_base.py
@@ -122,7 +122,7 @@ class RNNBase(TFNoiseAwareModel):
                 stddev=SD, seed=s4))
             b = tf.Variable(np.zeros(self.cardinality), dtype=tf.float32)
             self.logits = tf.matmul(potentials, W) + b
-            self.marginals_op = tf.nn.softmax(self.logits)
+        
         else:
             self.Y = tf.placeholder(tf.float32, [None])
             W = tf.Variable(tf.random_normal((2*dim, 1), stddev=SD, seed=s4))
@@ -145,7 +145,12 @@ class RNNBase(TFNoiseAwareModel):
                 b = tf.Variable(0., dtype=tf.float32)
                 self.logits = tf.squeeze(tf.matmul(potentials, W)) + b
 
-            self.marginals_op = tf.nn.sigmoid(self.logits)
+        # Define marginals op
+        if self.cardinality > 2 and self.single_value:
+            marginals_fn = tf.nn.softmax
+        else:
+            marginals_fn = tf.nn.sigmoid
+        self.marginals_op = marginals_fn(self.logits)
 
     def _construct_feed_dict(self, X_b, Y_b, lr=0.01, dropout=None, **kwargs):
         X_b, len_b = self._make_tensor(X_b)

--- a/snorkel/learning/gen_learning.py
+++ b/snorkel/learning/gen_learning.py
@@ -63,6 +63,10 @@ class GenerativeModel(Classifier):
         self.rng.seed(seed)
         set_numba_seeds(seed)
 
+        # Determine whether predicts single value or (potentially) multiple
+        # For now: Fixed as true in generative model!
+        self.single_value = True
+
     # These names of factor types are for the convenience of several methods
     # that perform the same operations over multiple types, but this class's
     # behavior is not fully specified here. Other methods, such as marginals(),


### PR DESCRIPTION
Now, if `Classifier` subclass is initialized with cardinality > 2 and `single_value=True` (default), it will have the same behavior as before: the marginals will be the result of applying a softmax, i.e. the probabilities for all classes will sum to one for each datapoint.  This will also be used during training.

However, now if `single_value=False`, a sigmoid will be applied element-wise instead--i.e. classes are not mutually-exclusive; this will also be used during training.  @regoldman this should be the quick fix for your application!

With `single_value=False`, it will *almost* be equivalent to just training `k` separate binary classifiers... almost because the LFs still only give mutually-exclusive labels.  So e.g. if there are LFs that should say 'yes' to two different classes, they would currently need to be represented as two different LFs, which would presumably change the generative model... so we'll have to think about this more.  Either way this flag shouldn't hurt or change anything when left at it's default