### PR TITLE
Spacy 2.0 Compatibility

### DIFF
--- a/snorkel/parser/rule_parser.py
+++ b/snorkel/parser/rule_parser.py
@@ -43,7 +43,7 @@ class RegexTokenizer(Tokenizer):
         for t in self.rgx.split(s):
             while t < len(s) and t != s[offset:len(t)]:
                 offset += 1
-                tokens += [(t,offset)]
+            tokens += [(t,offset)]
             offset += len(t)
         return tokens
 

--- a/snorkel/parser/rule_parser.py
+++ b/snorkel/parser/rule_parser.py
@@ -13,7 +13,6 @@ try:
     import spacy
     from spacy.cli import download
     from spacy import util
-    from spacy.deprecated import resolve_model_name
 except:
     raise Exception("spacy not installed. Use `pip install spacy`.")
 
@@ -44,7 +43,7 @@ class RegexTokenizer(Tokenizer):
         for t in self.rgx.split(s):
             while t < len(s) and t != s[offset:len(t)]:
                 offset += 1
-            tokens += [(t,offset)]
+                tokens += [(t,offset)]
             offset += len(t)
         return tokens
 
@@ -69,10 +68,8 @@ class SpacyTokenizer(Tokenizer):
         :return:
         '''
         data_path = util.get_data_path()
-        model_name = resolve_model_name(name)
-        model_path = data_path / model_name
+        model_path = data_path / name
         if not model_path.exists():
-            lang_name = util.get_lang_class(name).lang
             return False
         return True
 

--- a/snorkel/parser/rule_parser.py
+++ b/snorkel/parser/rule_parser.py
@@ -92,7 +92,7 @@ class SpacyTokenizer(Tokenizer):
         :param lang:
         :return:
         '''
-        if SpacyTokenizer.model_installed:
+        if SpacyTokenizer.model_installed(lang):
             model = spacy.load(lang)
         else:
             download(lang)

--- a/snorkel/parser/spacy_parser.py
+++ b/snorkel/parser/spacy_parser.py
@@ -64,7 +64,8 @@ class Spacy(Parser):
             for proc in annotators:
                 self.pipeline += [self.model.__dict__[proc]]
         else:
-            for i,proc in enumerate(['tagger','parser','ner']):
+            annotators=[i if i!='entity' else 'ner' for i in annotators]
+            for i,proc in enumerate(annotators):
                 self.pipeline += [self.model.pipeline[i][1]]
 
     @staticmethod

--- a/snorkel/parser/spacy_parser.py
+++ b/snorkel/parser/spacy_parser.py
@@ -12,7 +12,10 @@ try:
     import spacy
     from spacy.cli import download
     from spacy import util
-    from spacy.deprecated import resolve_model_name
+    try:
+        spacy_version=int(spacy.__version__[0])
+    except:
+        spacy_version=1
 except:
     raise Exception("spaCy not installed. Use `pip install spacy`.")
 
@@ -57,8 +60,12 @@ class Spacy(Parser):
         self.num_threads = num_threads
 
         self.pipeline = []
-        for proc in annotators:
-            self.pipeline += [self.model.__dict__[proc]]
+        if spacy_version==1:
+            for proc in annotators:
+                self.pipeline += [self.model.__dict__[proc]]
+        else:
+            for i,proc in enumerate(['tagger','parser','ner']):
+                self.pipeline += [self.model.pipeline[i][1]]
 
     @staticmethod
     def model_installed(name):
@@ -68,8 +75,7 @@ class Spacy(Parser):
         :return:
         '''
         data_path = util.get_data_path()
-        model_name = resolve_model_name(name)
-        model_path = data_path / model_name
+        model_path = data_path / name
         return model_path.exists()
 
     @staticmethod


### PR DESCRIPTION
There are a few small changes in this pull request.  
1.  A minor bug fix that resulted in a failure to download the spacy language model if it doesn't exist.
2. Some extraneous code was removed in the code used to test
3. This update checks for the spacy version (1.x or 2.x) and updates the api calls as appropriate.

The changes were tested with both spacy version 1 and 2 using the tutorial code.  I have also tested using spacy 2.0 more thoroughly at work.