### PR TITLE
FIX restrict TemporarySpan.__contains__() to same sentence

### DIFF
--- a/snorkel/models/context.py
+++ b/snorkel/models/context.py
@@ -272,7 +272,8 @@ class TemporarySpan(TemporaryContext):
         return self.get_attrib_span('words', sep)
 
     def __contains__(self, other_span):
-        return other_span.char_start >= self.char_start and other_span.char_end <= self.char_end
+        return self.sentence == other_span.sentence and other_span.char_start >= self.char_start \
+            and other_span.char_end <= self.char_end
 
     def __getitem__(self, key):
         """


### PR DESCRIPTION
This PR prevents `TemporarySpan.__contains__()` from returning `True` for spans from different Sentence contexts.
This condition is already enforced elsewhere in this class, in particular in the related `__eq__` and `__ne__`.