### PR TITLE
FIX make brat.utils compatible with python 3 (and 2.6+)

### DIFF
--- a/snorkel/contrib/brat/utils.py
+++ b/snorkel/contrib/brat/utils.py
@@ -4,7 +4,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from builtins import *
 
-from urllib2 import urlopen, URLError, HTTPError
+from six.moves.urllib.request import urlopen
+from six.moves.urllib.error import URLError, HTTPError
 
 def download(url, outfname):
     """
@@ -18,7 +19,7 @@ def download(url, outfname):
         data = urlopen(url)
         with open(outfname, "wb") as f:
             f.write(data.read())
-    except HTTPError, e:
+    except HTTPError as e:
         print("HTTP Error: {} {}".format(e.code, url))
-    except URLError, e:
+    except URLError as e:
         print("URL Error: {} {}".format(e.reason, url))


### PR DESCRIPTION
This PR makes `brat.utils` compatible with python 3 (and 2.6+).
It enforces the modern syntax for exceptions and uses six for urllib.