### PR TITLE
Switch spacy installation to conda from pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
     --output-document=miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - source $HOME/miniconda/etc/profile.d/conda.sh
-  - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda info --all
 
@@ -28,6 +27,7 @@ install:
   - conda env create --quiet --file=environment.yml
   - conda activate snorkel
   - pip install .
+  - conda list
 
 script:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,19 +39,18 @@ script:
   - runipy test/learning/test_parallel_grid_search.ipynb
 
   # Runs intro tutorial notebooks
-  - cd tutorials
-  - runipy intro/Intro_Tutorial_1.ipynb
-  - runipy intro/Intro_Tutorial_2.ipynb
-  - runipy intro/Intro_Tutorial_3.ipynb
+  - runipy tutorials/intro/Intro_Tutorial_1.ipynb
+  - runipy tutorials/intro/Intro_Tutorial_2.ipynb
+  - runipy tutorials/intro/Intro_Tutorial_3.ipynb
 
   # Run advanced notebooks
-  - runipy advanced/Categorical_Classes.ipynb
-  - runipy advanced/Structure_Learning.ipynb
+  - runipy tutorials/advanced/Categorical_Classes.ipynb
+  - runipy tutorials/advanced/Structure_Learning.ipynb
 
   # Run CDR tutorials
-  - runipy cdr/CDR_Tutorial_1.ipynb
-  - runipy cdr/CDR_Tutorial_2.ipynb
-  - runipy cdr/CDR_Tutorial_3.ipynb
+  - runipy tutorials/cdr/CDR_Tutorial_1.ipynb
+  - runipy tutorials/cdr/CDR_Tutorial_2.ipynb
+  - runipy tutorials/cdr/CDR_Tutorial_3.ipynb
 
   # TODO check outputs, upload results, etc.
   # for more ideas, see: https://github.com/rossant/ipycache/issues/7

--- a/environment.yml
+++ b/environment.yml
@@ -19,10 +19,10 @@ dependencies:
   - runipy
   - scipy
   - six
+  - spacy
   - sqlalchemy>=1.0.14
   - tensorflow>=1.0
   - tika
   - pip:
     - git+https://github.com/HazyResearch/numbskull@master
     - git+https://github.com/HazyResearch/treedlib@master
-    - spacy==1.10.0

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - runipy
   - scipy
   - six
-  - spacy
+  - spacy<2
   - sqlalchemy>=1.0.14
   - tensorflow>=1.0
   - tika


### PR DESCRIPTION
Hopefully this will reduce the 550 second [install time](https://travis-ci.org/HazyResearch/snorkel/jobs/374664220#L1708) of the conda environment. It [looks like](https://travis-ci.org/HazyResearch/snorkel/jobs/374670307#L566) it reduces install time to 330 seconds.

Refs https://github.com/HazyResearch/snorkel/pull/876
Closes https://github.com/HazyResearch/snorkel/issues/724 (which actually has already been addressed).