### PR TITLE
Pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ You can also check out all the great [materials](https://simtk.org/frs/?group_id
 
 ### Major changes in v0.7:
 * [PyTorch](https://pytorch.org/) classifiers
-* Installation now via [Conda](https://conda.io/) and `pip`
+* Installation now via [Conda](https://conda.io/)
 * Now [spaCy](https://spacy.io/) is the default parser (v1), with support for v2
 * And many more fixes, additions, and new material!
 
@@ -118,9 +118,7 @@ You can also check out all the great [materials](https://simtk.org/frs/?group_id
 
 ## Installation
 
-Starting with version 0.7.0, Snorkel should be installed as a Python package using `pip`.
-However, installing Snorkel via `pip` will not install dependencies, which are required for Snorkel to run.
-To manage its dependencies, Snorkel uses [conda](https://conda.io/), which allows specifying an environment via an `environment.yml` file.
+Starting with version 0.7.0, Snorkel should be installed as a Python package using [Conda](https://conda.io/).
 
 This documentation covers two common cases (usage and development) for setting up conda environments for Snorkel.
 In both cases, the environment can be activated using `conda activate snorkel` and deactivated using `conda deactivate`
@@ -141,7 +139,7 @@ Versioned specification of your environment is critical to reproducibility and e
 When first setting your package versions, you likely want to start with the latest versions available on the [conda-forge](https://anaconda.org/conda-forge/) channel, unless you have a reason to do otherwise.
 2. Adding other packages to your environment as required by your use case.
 Consider maintaining alphabetical sorting of packages in `environment.yml` to assist with maintainability.
-In addition, we recommend installing packages via pip, only if they are not available in the conda-forge channel.
+In addition, we recommend installing packages via pip only if they are not available in the conda-forge channel.
 3. Add the `snorkel` package installation to your `environment.yml`, under the `- pip` section.
 Of course, we suggest versioning snorkel, which you can do via a release number or commit hash (to access more bleeding edge functionality)
   ```yml

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,9 @@
-# This setup script is provided as an unofficial alternative to installing Snorkel using Conda. (See README.md for
-# the recommended installation instructions.) This script will not work on all systems. If you encounter errors, you
-# might be able to resolve them by installing any packages that prefer Conda, such as PyTorch or Numba, before running.
+# This setup script is intended to be used when installing Snorkel using Conda. See README.md for
+# the recommended installation instructions.
+#
+# Unofficially, this script can also be used by pip outside of Conda, but this might not work on all systems. If you
+# encounter errors, you might be able to resolve them by installing any packages that prefer Conda, such as PyTorch
+# or Numba, before running.
 import os
 import re
 

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,9 @@ version = pattern.search(text).group(1)
 path = os.path.join(directory, 'README.md')
 with open(path) as read_file:
     long_description = read_file.read()
+    # Changes image URLs to have absolute paths
+    long_description = long_description.replace(
+            '<img src="figs/', '<img src="https://github.com/HazyResearch/snorkel/raw/master/figs/')
 
 # Extract package requirements from Conda environment.yml
 install_requires = []
@@ -70,6 +73,7 @@ setuptools.setup(
     keywords='machine-learning weak-supervision information-extraction',
     classifiers=[
         'Intended Audience :: Science/Research',
+        'Topic :: Scientific/Engineering :: Artificial Intelligence',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
         'Topic :: Scientific/Engineering :: Information Analysis',
         'License :: OSI Approved :: Apache Software License',

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,14 @@ with open(path) as read_file:
         elif line == "pip:":
             state = "PIP_DEPS"
         elif state == "CONDA_DEPS":
-            # PyTorch requires substituting the recommended pip dependencies
             requirement = Requirement(line)
+            # PyTorch requires substituting the recommended pip dependencies
             if requirement.key == "pytorch":
                 install_requires.append(line.replace("pytorch", "torch", 1))
                 install_requires.append("torchvision")
+            # Python is a valid dependency for Conda but not setuptools, so skip it
+            elif requirement.key == "python":
+                pass
             else:
                 # Appends to dependencies
                 install_requires.append(line)


### PR DESCRIPTION
Note the caveats added at the top of setup.py. Packages like PyTorch and Numba recommend installation via Conda. On my Mac, with this PR, I can install Snorkel in an empty environment using just `pip install .` from inside the repo. This working depends on PyPI having the right binaries for torch and llvmlite. In particular, based on PyTorch's website, I think it won't work on Linux without manually installing PyTorch separately.

I therefore have removed "and pip" from the 0.7 release notes to clarify that the Conda installation is the recommended way of installing Snorkel, but the comments in setup.py point out users can also try just pip and how to get around common errors.

I will also try uploading Snorkel to PyPI now.