### PR TITLE
Allow Candidates to be arbitrary n-tuples

### DIFF
--- a/snorkel/learning/pytorch/rnn/rnn_base.py
+++ b/snorkel/learning/pytorch/rnn/rnn_base.py
@@ -56,16 +56,16 @@ class RNNBase(TorchNoiseAwareModel):
         outputs = torch.Tensor([])
 
         for batch in range(0, n, batch_size):
+            cur_minibatch = X[batch:batch+batch_size]
 
-            if batch_size > len(X[batch:batch+batch_size]):
-                batch_size = len(X[batch:batch+batch_size])
+            if batch_size > len(cur_minibatch):
+                batch_size = len(cur_minibatch)
 
             hidden_state = self.initialize_hidden_state(batch_size)
-            max_batch_length = max(len(cur_x)
-                                   for cur_x in X[batch:batch+batch_size])
+            max_batch_length = max(len(cur_x) for cur_x in cur_minibatch)
 
             padded_X = torch.zeros((batch_size, max_batch_length), dtype=torch.long)
-            for idx, seq in enumerate(X[batch:batch+batch_size]):
+            for idx, seq in enumerate(cur_minibatch):
                 # TODO: Don't instantiate tensor for each row
                 padded_X[idx, :len(seq)] = torch.LongTensor(seq)
 

--- a/snorkel/learning/pytorch/rnn/rnn_base.py
+++ b/snorkel/learning/pytorch/rnn/rnn_base.py
@@ -89,10 +89,8 @@ class RNNBase(TorchNoiseAwareModel):
             self.word_dict = SymbolTable()
         for candidate in candidates:
             # Mark sentence
-            args = [
-                (candidate[0].get_word_start(), candidate[0].get_word_end(), 1),
-                (candidate[1].get_word_start(), candidate[1].get_word_end(), 2)
-            ]
+            args = [(cur_part.get_word_start(), cur_part.get_word_end(), num+1)
+                    for num, cur_part in enumerate(candidate)]
             s = mark_sentence(candidate_to_tokens(candidate), args)
             # Either extend word table or retrieve from it
             f = self.word_dict.get if extend else self.word_dict.lookup

--- a/snorkel/learning/pytorch/rnn/rnn_base.py
+++ b/snorkel/learning/pytorch/rnn/rnn_base.py
@@ -51,7 +51,7 @@ class RNNBase(TorchNoiseAwareModel):
             batch_size = len(X)
 
         if isinstance(X[0], Candidate):
-            X = self._preprocess_data(X, extend=False)
+            X = list(self._preprocess_data(X, extend=False))
 
         outputs = torch.Tensor([])
 
@@ -87,7 +87,6 @@ class RNNBase(TorchNoiseAwareModel):
         """
         if not hasattr(self, 'word_dict'):
             self.word_dict = SymbolTable()
-        data = []
         for candidate in candidates:
             # Mark sentence
             args = [
@@ -97,15 +96,13 @@ class RNNBase(TorchNoiseAwareModel):
             s = mark_sentence(candidate_to_tokens(candidate), args)
             # Either extend word table or retrieve from it
             f = self.word_dict.get if extend else self.word_dict.lookup
-            data.append(np.array([f(cur_elem) for cur_elem in s]))
-
-        return data
+            yield np.array([f(cur_elem) for cur_elem in s])
 
     def train(self, X_train, Y_train, X_dev=None, **kwargs):
         # Preprocesses data, including constructing dataset-specific dictionary
-        X_train = self._preprocess_data(X_train, extend=True)
+        X_train = list(self._preprocess_data(X_train, extend=True))
         if X_dev is not None:
-            X_dev = self._preprocess_data(X_dev, extend=False)
+            X_dev = list(self._preprocess_data(X_dev, extend=False))
 
         # Note we pass word_dict through here so it gets saved...
         super(RNNBase, self).train(X_train, Y_train, X_dev=X_dev,

--- a/snorkel/learning/pytorch/rnn/rnn_base.py
+++ b/snorkel/learning/pytorch/rnn/rnn_base.py
@@ -61,7 +61,8 @@ class RNNBase(TorchNoiseAwareModel):
                 batch_size = len(X[batch:batch+batch_size])
 
             hidden_state = self.initialize_hidden_state(batch_size)
-            max_batch_length = max(map(len, X[batch:batch+batch_size]))
+            max_batch_length = max(len(cur_x)
+                                   for cur_x in X[batch:batch+batch_size])
 
             padded_X = torch.zeros((batch_size, max_batch_length), dtype=torch.long)
             for idx, seq in enumerate(X[batch:batch+batch_size]):
@@ -96,7 +97,7 @@ class RNNBase(TorchNoiseAwareModel):
             s = mark_sentence(candidate_to_tokens(candidate), args)
             # Either extend word table or retrieve from it
             f = self.word_dict.get if extend else self.word_dict.lookup
-            data.append(np.array(list(map(f, s))))
+            data.append(np.array([f(cur_elem) for cur_elem in s]))
 
         return data
 

--- a/snorkel/learning/pytorch/rnn/rnn_base.py
+++ b/snorkel/learning/pytorch/rnn/rnn_base.py
@@ -14,7 +14,7 @@ from snorkel.learning.pytorch.rnn.utils import candidate_to_tokens, SymbolTable
 
 def mark(l, h, idx):
     """Produce markers based on argument positions
-    
+
     :param l: sentence position of first word in argument
     :param h: sentence position of last word in argument
     :param idx: argument index (1 or 2)
@@ -24,12 +24,12 @@ def mark(l, h, idx):
 
 def mark_sentence(s, args):
     """Insert markers around relation arguments in word sequence
-    
+
     :param s: list of tokens in sentence
     :param args: list of triples (l, h, idx) as per @_mark(...) corresponding
                to relation arguments
-    
-    Example: Then Barack married Michelle.  
+
+    Example: Then Barack married Michelle.
          ->  Then ~~[[1 Barack 1]]~~ married ~~[[2 Michelle 2]]~~.
     """
     marks = sorted([y for m in args for y in mark(*m)], reverse=True)
@@ -41,28 +41,28 @@ def mark_sentence(s, args):
 
 class RNNBase(TorchNoiseAwareModel):
     representation = True
-    
+
     def initialize_hidden_state(self, batch_size):
         raise NotImplementedError
-    
+
     def _pytorch_outputs(self, X, batch_size):
         n = len(X)
         if not batch_size:
             batch_size = len(X)
-        
+
         if isinstance(X[0], Candidate):
             X = self._preprocess_data(X, extend=False)
-        
+
         outputs = torch.Tensor([])
-        
+
         for batch in range(0, n, batch_size):
-            
+
             if batch_size > len(X[batch:batch+batch_size]):
                 batch_size = len(X[batch:batch+batch_size])
-    
+
             hidden_state = self.initialize_hidden_state(batch_size)
             max_batch_length = max(map(len, X[batch:batch+batch_size]))
-            
+
             padded_X = torch.zeros((batch_size, max_batch_length), dtype=torch.long)
             for idx, seq in enumerate(X[batch:batch+batch_size]):
                 # TODO: Don't instantiate tensor for each row
@@ -80,7 +80,7 @@ class RNNBase(TorchNoiseAwareModel):
 
     def _preprocess_data(self, candidates, extend=False):
         """Convert candidate sentences to lookup sequences
-        
+
         :param candidates: candidates to process
         :param extend: extend symbol table for tokens (train), or lookup (test)?
         """
@@ -97,7 +97,7 @@ class RNNBase(TorchNoiseAwareModel):
             # Either extend word table or retrieve from it
             f = self.word_dict.get if extend else self.word_dict.lookup
             data.append(np.array(list(map(f, s))))
-            
+
         return data
 
     def train(self, X_train, Y_train, X_dev=None, **kwargs):


### PR DESCRIPTION
Due to a hidden assumption in the code candidates had to consist of two entries. This made it impossible to adapt the intro tutorial to NER or relation extraction for more than two entries.

This merge provides (1) minor improvements in the edited file and (2) a fix to allow arbitrary n-tuples. The code is already used for initial NER experiments successfully.