### PR TITLE
Optimize UDF

### DIFF
--- a/snorkel/udf.py
+++ b/snorkel/udf.py
@@ -162,15 +162,32 @@ class UDF(Process):
         This method is called when the UDF is run as a Process in a multiprocess setting
         The basic routine is: get from JoinableQueue, apply, put / add outputs, loop
         """
+        insert_batch = set()
+        # Every 2,000 objects, we trigger a bulk insert
+        INSERT_BATCH_SIZE = 2000
+
         while True:
             try:
                 x = self.in_queue.get_nowait()
                 for y in self.apply(x, **self.apply_kwargs):
                     # If there's no additional reduce step coming, add to session
                     if self.add_to_session:
-                        self.session.add(y)
+                        # Without batching, we'd just call
+                        #   self.session.add(y)
+                        # However, this seems to get everything inserted at the very end.
+                        insert_batch.add(y)
+
+                        if len(insert_batch) >= INSERT_BATCH_SIZE:
+                            self.session.bulk_save_objects(insert_batch)
+                            insert_batch.clear()
+
                     else:
                         self.out_queue.put(y)
+
+                # Insert the remaining items queued up
+                self.session.bulk_save_objects(insert_batch)
+                insert_batch.clear()
+
                 self.in_queue.task_done()
                 self.out_queue.put(UDF.TASK_DONE_SENTINEL)
 


### PR DESCRIPTION
This attempts to use `bulk_save_objects` at some batching interval on the process-level to stop UDF from inserting everything with single transactions at the end. This *feels* like something I really shouldn't be implementing but that should somehow be baked into SQLAlchemy.

@ajratner I must be missing something? Thoughts?