### PR TITLE
Fixing context equality check in viewer for gold candidates

### DIFF
--- a/snorkel/viewer/__init__.py
+++ b/snorkel/viewer/__init__.py
@@ -164,7 +164,7 @@ class Viewer(widgets.DOMWidget):
 
                 # Get the candidates in this context
                 candidates = [c for c in self.candidates if c[0].get_parent() == context]
-                gold = [g for g in self.gold if g.context_id == context.id]
+                gold = [g for g in self.gold if g.get_parent() == context]
 
                 # Construct the <li> and page view elements
                 li_data = self._tag_context(context, candidates, gold)


### PR DESCRIPTION
Fix for https://github.com/HazyResearch/snorkel/issues/1082 (cc: @bhancock8).

I'd like to add a unit test that at least validates that the viewer can be created, though I was a little unclear on what the strategy with tests is.  The spouses and crowdsourcing dbs that get used in the pytorch and tensorflow tests seem like they could probably be parts of test fixtures that don't necessarily have anything to do with PyTorch or TF functionality right?  It seemed to me like making test data a more generic resource could help with testing many things, including the viewer.  I'll gladly attempt that in another PR if there are no objections that it would be a worthwhile abstraction.