### PR TITLE
Add static type checking via mypy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,7 @@ repos:
     rev: master
     hooks:
     - id: flake8
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: master
+    hooks:
+    - id: mypy

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ cache: pip
 dist: xenial
 
 env:
-  TOXENV=py,check
+  TOXENV=py,check,type
 
 jobs:
   include:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 black
 flake8
 isort
+mypy
 pre-commit
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py36,
     py37,
     check,
+    type,
 isolated_build = true
 
 [testenv]
@@ -18,6 +19,12 @@ commands =
     isort -rc -c .
     black --check .
     flake8 .
+
+[testenv:type]
+description = run static type checking
+basepython = python3
+usedevelop = True
+commands = mypy -p snorkel
 
 [testenv:dev]
 description = install dev tools


### PR DESCRIPTION
Adds mypy to
* pre-commit hooks
* requirements-dev.txt
* tox (dev setup and travis)

**Test plan**
* Local validation via `tox -e dev; tox`
* Manual verification that it runs in Travis

<img width="340" alt="Screen Shot 2019-06-13 at 12 50 42 PM" src="https://user-images.githubusercontent.com/7783678/59451644-e9b6c600-8dd9-11e9-80b9-2fab4a83803b.png">