### PR TITLE
[EASY] Small patches to language tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Editors
+.vscode/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,5 @@
 
 repos:
--   repo: https://github.com/asottile/seed-isort-config
-    rev: master
-    hooks:
-    -   id: seed-isort-config
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: master
     hooks:

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,7 @@ ignore =
     E741,
     W503,
     W605,
-    F403,
-    F401
+    F403
 exclude = 
     .eggs,
     .git,
@@ -25,5 +24,14 @@ include_trailing_comma=True
 force_grid_wrap=0
 combine_as_imports=True
 line_length=88
-known_first_party=snorkel
-known_third_party=setuptools
+known_first_party=
+    snorkel,
+known_third_party=
+    numpy,
+    pandas,
+    pyarrow,
+    pyspark,
+    scipy,
+    setuptools,
+    tqdm,
+default_section=THIRDPARTY

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-import os
-
 from setuptools import find_packages, setup
 
 with open("README.md") as read_file:


### PR DESCRIPTION
Material changes:

* Remove seed-isort-config :/ . It adds new imports on the same line, which is a nightmare for merges/rebases
* Reactive flake8 F401 (unused imports)
* Add some known imports

**Test plan**
Travis? idk