### PR TITLE
Add LF preprocessors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -8,6 +8,7 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
     def __repr__
+    SparkLFApplier
 ignore_errors = True
 omit =
     test/*

--- a/.coveragerc
+++ b/.coveragerc
@@ -8,7 +8,6 @@ exclude_lines =
     raise NotImplementedError
     if __name__ == .__main__.:
     def __repr__
-    SparkLFApplier
 ignore_errors = True
 omit =
     test/*

--- a/setup.cfg
+++ b/setup.cfg
@@ -51,5 +51,8 @@ ignore_missing_imports = True
 [mypy-pyspark]
 ignore_missing_imports = True
 
+[mypy-spacy]
+ignore_missing_imports = True
+
 [mypy-tqdm]
 ignore_missing_imports = True

--- a/snorkel/labeling/apply/lf_applier.py
+++ b/snorkel/labeling/apply/lf_applier.py
@@ -5,6 +5,7 @@ import scipy.sparse as sparse
 from tqdm import tqdm
 
 from snorkel.labeling.lf import LabelingFunction
+from snorkel.labeling.preprocess import PreprocessorMode
 from snorkel.types import DataPoint, DataPoints
 
 RowData = List[Tuple[int, int, int]]
@@ -18,6 +19,10 @@ class BaseLFApplier:
         row, col, data = zip(*chain.from_iterable(labels))
         n, m = len(labels), len(self._lfs)
         return sparse.csr_matrix((data, (row, col)), shape=(n, m))
+
+    def _set_lf_preprocessor_mode(self, mode: PreprocessorMode) -> None:
+        for lf in self._lfs:
+            lf.set_preprocessor_mode(mode)
 
     def apply(self, data_points: Any, *args: Any, **kwargs: Any) -> sparse.csr_matrix:
         raise NotImplementedError
@@ -36,6 +41,7 @@ def apply_lfs_to_data_point(
 
 class LFApplier(BaseLFApplier):
     def apply(self, data_points: DataPoints) -> sparse.csr_matrix:  # type: ignore
+        self._set_lf_preprocessor_mode(PreprocessorMode.NAMESPACE)
         labels = []
         for i, x in tqdm(enumerate(data_points)):
             labels.append(apply_lfs_to_data_point(x, i, self._lfs))

--- a/snorkel/labeling/apply/lf_applier_pandas.py
+++ b/snorkel/labeling/apply/lf_applier_pandas.py
@@ -6,6 +6,7 @@ from pandas import DataFrame
 from tqdm import tqdm
 
 from snorkel.labeling.lf import LabelingFunction
+from snorkel.labeling.preprocess import PreprocessorMode
 from snorkel.types import DataPoint
 
 from .lf_applier import BaseLFApplier
@@ -24,6 +25,7 @@ def apply_lfs_to_data_point(x: DataPoint, lfs: List[LabelingFunction]) -> Pandas
 
 class PandasLFApplier(BaseLFApplier):
     def apply(self, df: DataFrame) -> sparse.csr_matrix:  # type: ignore
+        self._set_lf_preprocessor_mode(PreprocessorMode.PANDAS)
         apply_fn = partial(apply_lfs_to_data_point, lfs=self._lfs)
         tqdm.pandas()
         labels = df.progress_apply(apply_fn, axis=1)

--- a/snorkel/labeling/apply/lf_applier_pandas.py
+++ b/snorkel/labeling/apply/lf_applier_pandas.py
@@ -27,8 +27,8 @@ class PandasLFApplier(BaseLFApplier):
         apply_fn = partial(apply_lfs_to_data_point, lfs=self._lfs)
         tqdm.pandas()
         labels = df.progress_apply(apply_fn, axis=1)
-        labels_with_index = [
-            [(index, j, y) for j, y in row_labels]
-            for index, row_labels in enumerate(labels)
-        ]
-        return self._matrix_from_row_data(labels_with_index)
+        L = sparse.lil_matrix((len(df), len(self._lfs)), dtype=int)
+        for i, row_labels in enumerate(labels):
+            for j, y in row_labels:
+                L[i, j] = y
+        return L.tocsr()

--- a/snorkel/labeling/apply/lf_applier_pandas.py
+++ b/snorkel/labeling/apply/lf_applier_pandas.py
@@ -27,8 +27,8 @@ class PandasLFApplier(BaseLFApplier):
         apply_fn = partial(apply_lfs_to_data_point, lfs=self._lfs)
         tqdm.pandas()
         labels = df.progress_apply(apply_fn, axis=1)
-        L = sparse.lil_matrix((len(df), len(self._lfs)), dtype=int)
-        for i, row_labels in enumerate(labels):
-            for j, y in row_labels:
-                L[i, j] = y
-        return L.tocsr()
+        labels_with_index = [
+            [(index, j, y) for j, y in row_labels]
+            for index, row_labels in enumerate(labels)
+        ]
+        return self._matrix_from_row_data(labels_with_index)

--- a/snorkel/labeling/apply/lf_applier_spark.py
+++ b/snorkel/labeling/apply/lf_applier_spark.py
@@ -5,6 +5,7 @@ from typing import Tuple
 import scipy.sparse as sparse
 from pyspark import RDD
 
+from snorkel.labeling.preprocess import PreprocessorMode
 from snorkel.types import DataPoint
 
 from .lf_applier import BaseLFApplier, RowData, apply_lfs_to_data_point
@@ -15,5 +16,6 @@ class SparkLFApplier(BaseLFApplier):
         def map_fn(args: Tuple[DataPoint, int]) -> RowData:
             return apply_lfs_to_data_point(*args, lfs=self._lfs)
 
+        self._set_lf_preprocessor_mode(PreprocessorMode.SPARK)
         labels = data_points.zipWithIndex().map(map_fn).collect()
         return self._matrix_from_row_data(labels)

--- a/snorkel/labeling/lf/__init__.py
+++ b/snorkel/labeling/lf/__init__.py
@@ -1,1 +1,0 @@
-from .core import LabelingFunction, labeling_function  # noqa: F401

--- a/snorkel/labeling/preprocess/__init__.py
+++ b/snorkel/labeling/preprocess/__init__.py
@@ -1,0 +1,1 @@
+from .core import Preprocessor, PreprocessorMode  # noqa: F401

--- a/snorkel/labeling/preprocess/core.py
+++ b/snorkel/labeling/preprocess/core.py
@@ -1,0 +1,84 @@
+from enum import Enum, auto
+from types import SimpleNamespace
+from typing import Any, Mapping, NamedTuple, Union
+
+from snorkel.types import Example, Field
+
+
+class PreprocessorMode(Enum):
+    NONE = auto()
+    NAMESPACE = auto()
+    PANDAS = auto()
+    DASK = auto()
+    SPARK = auto()
+
+
+def namespace_to_dict(x: Union[SimpleNamespace, NamedTuple]) -> dict:
+    """Convert a SimpleNamespace or NamedTuple to a dict"""
+    if isinstance(x, SimpleNamespace):
+        return vars(x)
+    return x._asdict()
+
+
+class Preprocessor:
+    def __init__(
+        self,
+        field_names: Mapping[str, str],
+        preprocessed_field_names: Mapping[str, str],
+        mode: PreprocessorMode = PreprocessorMode.NONE,
+    ) -> None:
+        """Preprocess training examples by adding additional information
+        or decomposing into primitives. A Preprocesser maps an example to
+        a new example, possibly with a different schema.
+        Subclasses of Preprocesser need to implement the `preprocess(...)`
+        method, which takes fields of the training example as input
+        and outputs new fields for the preprocessed training example.
+        For an example of a preprocessor, see
+            `snorkel.labeling.preprocess.nlp.SpacyPreprocessor`
+        Args:
+            * field_names: a map from attribute names of the incoming
+                training examples to the input argument names of the
+                `preprocess(...)` method
+            * preprocessed_field_names: a map from output keys of the
+                `preprocess(...)` method to attribute names of the
+                output training examples
+            * mode: a PreprocessorMode that specifies the type of the
+                output training examples
+        """
+        self.field_names = field_names
+        self.preprocessed_field_names = preprocessed_field_names
+        self.mode = mode
+
+    def set_mode(self, mode: PreprocessorMode) -> None:
+        self.mode = mode
+
+    def preprocess(self, **kwargs: Any) -> Mapping[str, Field]:
+        raise NotImplementedError
+
+    def __call__(self, example: Example) -> Example:
+        field_map = {k: getattr(example, v) for k, v in self.field_names.items()}
+        preprocessed_fields = self.preprocess(**field_map)
+        preprocessed_fields = {
+            v: preprocessed_fields[k] for k, v in self.preprocessed_field_names.items()
+        }
+        if self.mode == PreprocessorMode.NONE:
+            raise ValueError(
+                "No preprocessor mode set. Use `Preprocessor.set_mode(...)`."
+            )
+        if self.mode == PreprocessorMode.NAMESPACE:
+            values = namespace_to_dict(example)
+            values.update(preprocessed_fields)
+            return SimpleNamespace(**values)
+        if self.mode == PreprocessorMode.PANDAS:
+            preprocessed_example = example.copy()
+            for k, v in preprocessed_fields.items():
+                preprocessed_example.loc[k] = v
+            return preprocessed_example
+        if self.mode == PreprocessorMode.DASK:
+            raise NotImplementedError("Dask preprocessor mode not implemented")
+        if self.mode == PreprocessorMode.SPARK:
+            raise NotImplementedError("Spark preprocessor mode not implemented")
+        else:
+            raise ValueError(
+                f"Preprocessor mode {self.mode} not recognized. Options: {PreprocessorMode}."
+            )

--- a/snorkel/labeling/preprocess/core.py
+++ b/snorkel/labeling/preprocess/core.py
@@ -2,7 +2,7 @@ from enum import Enum, auto
 from types import SimpleNamespace
 from typing import Any, Mapping, NamedTuple, Union
 
-from snorkel.types import Example, Field
+from snorkel.types import DataPoint, FieldMap
 
 
 class PreprocessorMode(Enum):
@@ -27,23 +27,23 @@ class Preprocessor:
         preprocessed_field_names: Mapping[str, str],
         mode: PreprocessorMode = PreprocessorMode.NONE,
     ) -> None:
-        """Preprocess training examples by adding additional information
-        or decomposing into primitives. A Preprocesser maps an example to
-        a new example, possibly with a different schema.
+        """Preprocess data points by adding additional information
+        or decomposing into primitives. A Preprocesser maps an data point to
+        a new data point, possibly with a different schema.
         Subclasses of Preprocesser need to implement the `preprocess(...)`
-        method, which takes fields of the training example as input
-        and outputs new fields for the preprocessed training example.
-        For an example of a preprocessor, see
+        method, which takes fields of the data point as input
+        and outputs new fields for the preprocessed data point.
+        For an data point of a preprocessor, see
             `snorkel.labeling.preprocess.nlp.SpacyPreprocessor`
         Args:
             * field_names: a map from attribute names of the incoming
-                training examples to the input argument names of the
+                data points to the input argument names of the
                 `preprocess(...)` method
             * preprocessed_field_names: a map from output keys of the
                 `preprocess(...)` method to attribute names of the
-                output training examples
+                output data points
             * mode: a PreprocessorMode that specifies the type of the
-                output training examples
+                output data point
         """
         self.field_names = field_names
         self.preprocessed_field_names = preprocessed_field_names
@@ -52,11 +52,11 @@ class Preprocessor:
     def set_mode(self, mode: PreprocessorMode) -> None:
         self.mode = mode
 
-    def preprocess(self, **kwargs: Any) -> Mapping[str, Field]:
+    def preprocess(self, **kwargs: Any) -> FieldMap:
         raise NotImplementedError
 
-    def __call__(self, example: Example) -> Example:
-        field_map = {k: getattr(example, v) for k, v in self.field_names.items()}
+    def __call__(self, x: DataPoint) -> DataPoint:
+        field_map = {k: getattr(x, v) for k, v in self.field_names.items()}
         preprocessed_fields = self.preprocess(**field_map)
         preprocessed_fields = {
             v: preprocessed_fields[k] for k, v in self.preprocessed_field_names.items()
@@ -66,14 +66,14 @@ class Preprocessor:
                 "No preprocessor mode set. Use `Preprocessor.set_mode(...)`."
             )
         if self.mode == PreprocessorMode.NAMESPACE:
-            values = namespace_to_dict(example)
+            values = namespace_to_dict(x)
             values.update(preprocessed_fields)
             return SimpleNamespace(**values)
         if self.mode == PreprocessorMode.PANDAS:
-            preprocessed_example = example.copy()
+            x_preprocessed = x.copy()
             for k, v in preprocessed_fields.items():
-                preprocessed_example.loc[k] = v
-            return preprocessed_example
+                x_preprocessed.loc[k] = v
+            return x_preprocessed
         if self.mode == PreprocessorMode.DASK:
             raise NotImplementedError("Dask preprocessor mode not implemented")
         if self.mode == PreprocessorMode.SPARK:

--- a/snorkel/labeling/preprocess/nlp.py
+++ b/snorkel/labeling/preprocess/nlp.py
@@ -1,0 +1,25 @@
+from typing import List, Mapping
+
+import spacy
+
+from snorkel.types import Field
+
+from .core import Preprocessor
+
+DEFAULT_DISABLE = ["parser", "ner"]
+EN_CORE_WEB_SM = "en_core_web_sm"
+
+
+class SpacyPreprocessor(Preprocessor):
+    def __init__(
+        self,
+        text_field: str,
+        doc_field: str,
+        language: str = EN_CORE_WEB_SM,
+        disable: List[str] = DEFAULT_DISABLE,
+    ) -> None:
+        super().__init__(dict(text=text_field), dict(doc=doc_field))
+        self._nlp = spacy.load(language, disable=disable)
+
+    def preprocess(self, text: str) -> Mapping[str, Field]:  # type: ignore
+        return dict(doc=self._nlp(text))

--- a/snorkel/labeling/preprocess/nlp.py
+++ b/snorkel/labeling/preprocess/nlp.py
@@ -1,8 +1,8 @@
-from typing import List, Mapping
+from typing import List
 
 import spacy
 
-from snorkel.types import Field
+from snorkel.types import FieldMap
 
 from .core import Preprocessor
 
@@ -21,5 +21,5 @@ class SpacyPreprocessor(Preprocessor):
         super().__init__(dict(text=text_field), dict(doc=doc_field))
         self._nlp = spacy.load(language, disable=disable)
 
-    def preprocess(self, text: str) -> Mapping[str, Field]:  # type: ignore
+    def preprocess(self, text: str) -> FieldMap:  # type: ignore
         return dict(doc=self._nlp(text))

--- a/snorkel/types/__init__.py
+++ b/snorkel/types/__init__.py
@@ -1,1 +1,1 @@
-from .data import DataPoint, DataPoints  # noqa: F401
+from .data import DataPoint, DataPoints, Field  # noqa: F401

--- a/snorkel/types/__init__.py
+++ b/snorkel/types/__init__.py
@@ -1,1 +1,1 @@
-from .data import DataPoint, DataPoints, Field  # noqa: F401
+from .data import DataPoint, DataPoints, Field, FieldMap  # noqa: F401

--- a/snorkel/types/data.py
+++ b/snorkel/types/data.py
@@ -1,6 +1,7 @@
-from typing import Any, Collection
+from typing import Any, Collection, Mapping
 
 DataPoint = Any
 DataPoints = Collection[DataPoint]
 
 Field = Any
+FieldMap = Mapping[str, Field]

--- a/snorkel/types/data.py
+++ b/snorkel/types/data.py
@@ -2,3 +2,5 @@ from typing import Any, Collection
 
 DataPoint = Any
 DataPoints = Collection[DataPoint]
+
+Field = Any

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -9,11 +9,28 @@ import pyarrow.parquet as pq
 
 from snorkel.labeling.apply import LFApplier, PandasLFApplier
 from snorkel.labeling.lf import labeling_function
-from snorkel.types import DataPoint
+from snorkel.labeling.preprocess import Preprocessor
+from snorkel.types import DataPoint, FieldMap
+
+
+class SquarePreprocessor(Preprocessor):
+    def __init__(self, x_field: str, squared_x_field: str) -> None:
+        super().__init__(dict(x=x_field), dict(x=squared_x_field))
+
+    def preprocess(self, x: float) -> FieldMap:  # type: ignore
+        return dict(x=x ** 2)
+
+
+square = SquarePreprocessor(x_field="a", squared_x_field="a")
 
 
 @labeling_function()
 def f(x: DataPoint) -> int:
+    return 1 if x.a > 42 else 0
+
+
+@labeling_function(preprocessors=[square])
+def fp(x: DataPoint) -> int:
     return 1 if x.a > 42 else 0
 
 
@@ -24,6 +41,7 @@ def g(x: DataPoint, db: List[int]) -> int:
 
 DATA = [3, 43, 12, 9]
 L_EXPECTED = np.array([[0, 1], [1, 0], [0, 0], [0, 1]])
+L_PREPROCESS_EXPECTED = np.array([[0, 0], [1, 1], [0, 1], [0, 1]])
 
 
 class TestLFApplier(unittest.TestCase):
@@ -33,11 +51,23 @@ class TestLFApplier(unittest.TestCase):
         L = applier.apply(data_points)
         np.testing.assert_equal(L.toarray(), L_EXPECTED)
 
+    def test_lf_applier_preprocessor(self) -> None:
+        data_points = [SimpleNamespace(a=a) for a in DATA]
+        applier = LFApplier([f, fp])
+        L = applier.apply(data_points)
+        np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
+
     def test_lf_applier_pandas(self) -> None:
         df = pd.DataFrame(dict(a=DATA))
         applier = PandasLFApplier([f, g])
         L = applier.apply(df)
         np.testing.assert_equal(L.toarray(), L_EXPECTED)
+
+    def test_lf_applier_pandas_preprocessor(self) -> None:
+        df = pd.DataFrame(dict(a=DATA))
+        applier = PandasLFApplier([f, fp])
+        L = applier.apply(df)
+        np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
 
     def test_lf_applier_pandas_parquet(self) -> None:
         table_write = pa.Table.from_pandas(pd.DataFrame(dict(a=DATA)))

--- a/test/labeling/preprocess/test_core.py
+++ b/test/labeling/preprocess/test_core.py
@@ -1,9 +1,8 @@
 import unittest
 from types import SimpleNamespace
-from typing import Mapping
 
 from snorkel.labeling.preprocess import Preprocessor, PreprocessorMode
-from snorkel.types import Field
+from snorkel.types import FieldMap
 
 
 class SplitWordsPreprocessor(Preprocessor):
@@ -12,7 +11,7 @@ class SplitWordsPreprocessor(Preprocessor):
             dict(text=text_field), dict(lower=lower_field, words=words_field)
         )
 
-    def preprocess(self, text: str) -> Mapping[str, Field]:  # type: ignore
+    def preprocess(self, text: str) -> FieldMap:  # type: ignore
         return dict(lower=text.lower(), words=text.split())
 
 
@@ -20,35 +19,51 @@ class SquarePreprocessor(Preprocessor):
     def __init__(self, x_field: str, squared_x_field: str) -> None:
         super().__init__(dict(x=x_field), dict(x=squared_x_field))
 
-    def preprocess(self, x: float) -> Mapping[str, Field]:  # type: ignore
+    def preprocess(self, x: float) -> FieldMap:  # type: ignore
         return dict(x=x ** 2)
 
 
 class TestPreprocessorCore(unittest.TestCase):
-    def _get_example(self) -> SimpleNamespace:
+    def _get_x(self) -> SimpleNamespace:
         return SimpleNamespace(a=8, b="Henry has fun")
 
     def test_numeric_preprocessor(self) -> None:
         square = SquarePreprocessor("a", "c")
         square.set_mode(PreprocessorMode.NAMESPACE)
-        example_preprocessed = square(self._get_example())
-        self.assertEqual(example_preprocessed.a, 8)
-        self.assertEqual(example_preprocessed.b, "Henry has fun")
-        self.assertEqual(example_preprocessed.c, 64)
+        x_preprocessed = square(self._get_x())
+        self.assertEqual(x_preprocessed.a, 8)
+        self.assertEqual(x_preprocessed.b, "Henry has fun")
+        self.assertEqual(x_preprocessed.c, 64)
 
     def test_text_preprocessor(self) -> None:
         split_words = SplitWordsPreprocessor("b", "c", "d")
         split_words.set_mode(PreprocessorMode.NAMESPACE)
-        example_preprocessed = split_words(self._get_example())
-        self.assertEqual(example_preprocessed.a, 8)
-        self.assertEqual(example_preprocessed.b, "Henry has fun")
-        self.assertEqual(example_preprocessed.c, "henry has fun")
-        self.assertEqual(example_preprocessed.d, ["Henry", "has", "fun"])
+        x_preprocessed = split_words(self._get_x())
+        self.assertEqual(x_preprocessed.a, 8)
+        self.assertEqual(x_preprocessed.b, "Henry has fun")
+        self.assertEqual(x_preprocessed.c, "henry has fun")
+        self.assertEqual(x_preprocessed.d, ["Henry", "has", "fun"])
 
     def test_preprocessor_same_field(self) -> None:
         split_words = SplitWordsPreprocessor("b", "b", "c")
         split_words.set_mode(PreprocessorMode.NAMESPACE)
-        example_preprocessed = split_words(self._get_example())
-        self.assertEqual(example_preprocessed.a, 8)
-        self.assertEqual(example_preprocessed.b, "henry has fun")
-        self.assertEqual(example_preprocessed.c, ["Henry", "has", "fun"])
+        x_preprocessed = split_words(self._get_x())
+        self.assertEqual(x_preprocessed.a, 8)
+        self.assertEqual(x_preprocessed.b, "henry has fun")
+        self.assertEqual(x_preprocessed.c, ["Henry", "has", "fun"])
+
+    def test_preprocessor_mode(self) -> None:
+        square = SquarePreprocessor("a", "c")
+        x = self._get_x()
+
+        square.set_mode(18)  # type: ignore
+        with self.assertRaises(ValueError):
+            square(x)
+
+        square.set_mode(PreprocessorMode.DASK)
+        with self.assertRaises(NotImplementedError):
+            square(x)
+
+        square.set_mode(PreprocessorMode.SPARK)
+        with self.assertRaises(NotImplementedError):
+            square(x)

--- a/test/labeling/preprocess/test_core.py
+++ b/test/labeling/preprocess/test_core.py
@@ -1,0 +1,54 @@
+import unittest
+from types import SimpleNamespace
+from typing import Mapping
+
+from snorkel.labeling.preprocess import Preprocessor, PreprocessorMode
+from snorkel.types import Field
+
+
+class SplitWordsPreprocessor(Preprocessor):
+    def __init__(self, text_field: str, lower_field: str, words_field: str) -> None:
+        super().__init__(
+            dict(text=text_field), dict(lower=lower_field, words=words_field)
+        )
+
+    def preprocess(self, text: str) -> Mapping[str, Field]:  # type: ignore
+        return dict(lower=text.lower(), words=text.split())
+
+
+class SquarePreprocessor(Preprocessor):
+    def __init__(self, x_field: str, squared_x_field: str) -> None:
+        super().__init__(dict(x=x_field), dict(x=squared_x_field))
+
+    def preprocess(self, x: float) -> Mapping[str, Field]:  # type: ignore
+        return dict(x=x ** 2)
+
+
+class TestPreprocessorCore(unittest.TestCase):
+    def _get_example(self) -> SimpleNamespace:
+        return SimpleNamespace(a=8, b="Henry has fun")
+
+    def test_numeric_preprocessor(self) -> None:
+        square = SquarePreprocessor("a", "c")
+        square.set_mode(PreprocessorMode.NAMESPACE)
+        example_preprocessed = square(self._get_example())
+        self.assertEqual(example_preprocessed.a, 8)
+        self.assertEqual(example_preprocessed.b, "Henry has fun")
+        self.assertEqual(example_preprocessed.c, 64)
+
+    def test_text_preprocessor(self) -> None:
+        split_words = SplitWordsPreprocessor("b", "c", "d")
+        split_words.set_mode(PreprocessorMode.NAMESPACE)
+        example_preprocessed = split_words(self._get_example())
+        self.assertEqual(example_preprocessed.a, 8)
+        self.assertEqual(example_preprocessed.b, "Henry has fun")
+        self.assertEqual(example_preprocessed.c, "henry has fun")
+        self.assertEqual(example_preprocessed.d, ["Henry", "has", "fun"])
+
+    def test_preprocessor_same_field(self) -> None:
+        split_words = SplitWordsPreprocessor("b", "b", "c")
+        split_words.set_mode(PreprocessorMode.NAMESPACE)
+        example_preprocessed = split_words(self._get_example())
+        self.assertEqual(example_preprocessed.a, 8)
+        self.assertEqual(example_preprocessed.b, "henry has fun")
+        self.assertEqual(example_preprocessed.c, ["Henry", "has", "fun"])

--- a/test/labeling/preprocess/test_core.py
+++ b/test/labeling/preprocess/test_core.py
@@ -60,6 +60,10 @@ class TestPreprocessorCore(unittest.TestCase):
         with self.assertRaises(ValueError):
             square(x)
 
+        square.set_mode(PreprocessorMode.NONE)
+        with self.assertRaises(ValueError):
+            square(x)
+
         square.set_mode(PreprocessorMode.DASK)
         with self.assertRaises(NotImplementedError):
             square(x)

--- a/test/labeling/preprocess/test_nlp.py
+++ b/test/labeling/preprocess/test_nlp.py
@@ -1,0 +1,19 @@
+import unittest
+from types import SimpleNamespace
+
+from snorkel.labeling.preprocess import PreprocessorMode
+from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
+
+DATA = ["Jane", "Jane plays soccer."]
+
+
+class TestSpacyPreprocessor(unittest.TestCase):
+    def test_spacy_preprocessor(self) -> None:
+        example = SimpleNamespace(text=DATA[1])
+        preprocessor = SpacyPreprocessor("text", "doc")
+        preprocessor.set_mode(PreprocessorMode.NAMESPACE)
+        example_preprocessed = preprocessor(example)
+        self.assertEqual(len(example_preprocessed.doc), 4)
+        token = example_preprocessed.doc[0]
+        self.assertEqual(token.text, "Jane")
+        self.assertEqual(token.pos_, "PROPN")

--- a/test/labeling/preprocess/test_nlp.py
+++ b/test/labeling/preprocess/test_nlp.py
@@ -9,11 +9,11 @@ DATA = ["Jane", "Jane plays soccer."]
 
 class TestSpacyPreprocessor(unittest.TestCase):
     def test_spacy_preprocessor(self) -> None:
-        example = SimpleNamespace(text=DATA[1])
+        x = SimpleNamespace(text=DATA[1])
         preprocessor = SpacyPreprocessor("text", "doc")
         preprocessor.set_mode(PreprocessorMode.NAMESPACE)
-        example_preprocessed = preprocessor(example)
-        self.assertEqual(len(example_preprocessed.doc), 4)
-        token = example_preprocessed.doc[0]
+        x_preprocessed = preprocessor(x)
+        self.assertEqual(len(x_preprocessed.doc), 4)
+        token = x_preprocessed.doc[0]
         self.assertEqual(token.text, "Jane")
         self.assertEqual(token.pos_, "PROPN")

--- a/test/labeling/test_lf.py
+++ b/test/labeling/test_lf.py
@@ -5,14 +5,14 @@ from typing import List
 
 from snorkel.labeling.lf import LabelingFunction, labeling_function
 from snorkel.labeling.preprocess import Preprocessor, PreprocessorMode
-from snorkel.types import DataPoint
+from snorkel.types import DataPoint, FieldMap
 
 
 class SquarePreprocessor(Preprocessor):
     def __init__(self, x_field: str, squared_x_field: str) -> None:
         super().__init__(dict(x=x_field), dict(x=squared_x_field))
 
-    def preprocess(self, x: float) -> Mapping[str, Field]:  # type: ignore
+    def preprocess(self, x: float) -> FieldMap:  # type: ignore
         return dict(x=x ** 2)
 
 
@@ -55,6 +55,17 @@ class TestLabelingFunctionCore(unittest.TestCase):
         lf = LabelingFunction(name="my_lf", f=g, resources=dict(db=db))
         self._run_lf(lf)
         self._run_lf_no_raise(lf)
+
+    def test_labeling_function_preprocessor(self) -> None:
+        p = SquarePreprocessor(x_field="a", squared_x_field="a")
+        lf = LabelingFunction(name="my_lf", f=f, preprocessors=[p, p])
+        lf.set_preprocessor_mode(PreprocessorMode.NAMESPACE)
+        x_43 = SimpleNamespace(a=43)
+        x_6 = SimpleNamespace(a=6)
+        x_2 = SimpleNamespace(a=2)
+        self.assertEqual(lf(x_43), 1)
+        self.assertEqual(lf(x_6), 1)
+        self.assertEqual(lf(x_2), 0)
 
     def test_labeling_function_serialize(self) -> None:
         db = [3, 6, 43]

--- a/test/labeling/test_lf.py
+++ b/test/labeling/test_lf.py
@@ -1,12 +1,19 @@
 import pickle
 import unittest
-from collections import namedtuple
+from types import SimpleNamespace
 from typing import List
 
 from snorkel.labeling.lf import LabelingFunction, labeling_function
+from snorkel.labeling.preprocess import Preprocessor, PreprocessorMode
 from snorkel.types import DataPoint
 
-ExampleClass = namedtuple("ExampleClass", ("a",))
+
+class SquarePreprocessor(Preprocessor):
+    def __init__(self, x_field: str, squared_x_field: str) -> None:
+        super().__init__(dict(x=x_field), dict(x=squared_x_field))
+
+    def preprocess(self, x: float) -> Mapping[str, Field]:  # type: ignore
+        return dict(x=x ** 2)
 
 
 def f(x: DataPoint) -> int:
@@ -19,18 +26,18 @@ def g(x: DataPoint, db: List[int]) -> int:
 
 class TestLabelingFunctionCore(unittest.TestCase):
     def _run_lf(self, lf: LabelingFunction) -> None:
-        x_43 = ExampleClass(43)
-        x_19 = ExampleClass(19)
+        x_43 = SimpleNamespace(a=43)
+        x_19 = SimpleNamespace(a=19)
         self.assertEqual(lf(x_43), 1)
         self.assertEqual(lf(x_19), 0)
 
     def _run_lf_raise(self, lf: LabelingFunction) -> None:
-        x_none = ExampleClass(None)
+        x_none = SimpleNamespace(a=None)
         with self.assertRaises(TypeError):
             lf(x_none)
 
     def _run_lf_no_raise(self, lf: LabelingFunction) -> None:
-        x_none = ExampleClass(None)
+        x_none = SimpleNamespace(a=None)
         self.assertEqual(lf(x_none), 0)
 
     def test_labeling_function(self) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -10,11 +10,13 @@ isolated_build = true
 [testenv]
 description = run the test driver with {basepython}
 deps = -rrequirements-dev.txt
+commands_pre = python -m spacy download en_core_web_sm
 commands = python -m pytest test/
 
 [testenv:check]
 description = check the code style
 basepython = python3
+commands_pre =
 commands =
     isort -rc -c .
     black --check .
@@ -23,6 +25,7 @@ commands =
 [testenv:type]
 description = run static type checking
 basepython = python3
+commands_pre =
 commands = mypy -p snorkel
 
 [testenv:coverage]
@@ -35,12 +38,14 @@ commands = pytest --cov=snorkel test/
 description = install dev tools
 basepython = python3
 usedevelop = True
+commands_pre =
 commands = pre-commit install
 
 [testenv:fix]
 description = run code stylers
 basepython = python3
 usedevelop = True
+commands_pre =
 commands =
     isort -rc .
     black .

--- a/tutorials/drybell/nlp_lf.py
+++ b/tutorials/drybell/nlp_lf.py
@@ -1,0 +1,76 @@
+"""
+This example script replicates functionality from
+    Snorkel Drybell (https://arxiv.org/abs/1812.00417)
+
+Similar to Section 5.1, an NLP-based labeling function is
+authored using two preprocessors. The LF checks whether the
+title or body of an article contains a person mention. The
+LF is then executed using Spark, returning a label matrix.
+"""
+
+
+import logging
+
+from pyspark import SparkContext
+from pyspark.sql import Row
+
+from snorkel.labeling.apply.lf_applier_spark import SparkLFApplier
+from snorkel.labeling.lf import labeling_function
+from snorkel.labeling.preprocess import Preprocessor
+from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
+from snorkel.types import DataPoint, FieldMap
+
+logging.basicConfig(level=logging.INFO)
+
+
+ABSTAIN = 0
+NEGATIVE = 1
+POSITIVE = 2
+
+DATA = [
+    (
+        "The sports team won!",
+        "In a big sports game, the sports team won. The score is unknown.",
+    ),
+    (
+        "Jane Doe is great.",
+        "This article describes how great Jane Doe is. She is great.",
+    ),
+]
+
+
+class CombineTextPreprocessor(Preprocessor):
+    def __init__(self, title_field, body_field, article_field):
+        super().__init__(
+            dict(title=title_field, body=body_field), dict(article=article_field)
+        )
+
+    def preprocess(self, title: str, body: str) -> FieldMap:  # type: ignore
+        return dict(article=f"{title} {body}")
+
+
+combine_text_preprocessor = CombineTextPreprocessor("title", "body", "article")
+spacy_preprocessor = SpacyPreprocessor("article", "article")
+
+
+@labeling_function(preprocessors=[combine_text_preprocessor, spacy_preprocessor])
+def article_mentions_person(x: DataPoint) -> int:
+    for ent in x.article.ents:
+        if ent.label_ == "PERSON":
+            return ABSTAIN
+    return NEGATIVE
+
+
+def build_lf_matrix() -> None:
+    sc = SparkContext()
+    rdd = sc.parallelize(DATA)
+    rdd = rdd.map(lambda x: Row(title=x[0], body=x[1]))
+
+    applier = SparkLFApplier([article_mentions_person])
+    L = applier.apply(rdd)
+
+    logging.info(str(L))
+
+
+if __name__ == "__main__":
+    build_lf_matrix()


### PR DESCRIPTION
Preprocessors are shared resources that are applied to data points before they are subjected to the logic in labeling functions. The idea is that e.g. multiple LFs want to pass a text examples through SpaCy before executing, so the preprocessor is defined once and passed to all of the LFs.

* Examples of custom preprocessors are in the unit tests
* A SpaCy-based preprocessor is implemented
* The interface for TFs will be similar, so we can abstract out later (e.g. the logic for reconstructing data points with changed fields)
* We can later add caching, etc.

**Test plan**
* Added unit tests for preprocessors and everything that implements them upstream (LFs, appliers)