### PR TITLE
[EASY] Change codecov settings

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%
+    patch:
+      default:
+        threshold: 2%


### PR DESCRIPTION
Default settings for failing a PR were too strict. This asserts that 1. the entire project must always have >= 90% coverage and 2. any diff cannot drop coverage on the effected lines by more than 2%