### PR TITLE
Add basic NLP LF example from Drybell

### DIFF
--- a/tutorials/drybell/nlp_lf.py
+++ b/tutorials/drybell/nlp_lf.py
@@ -1,0 +1,65 @@
+import logging
+
+from pyspark import SparkContext
+from pyspark.sql import Row
+
+from snorkel.labeling.apply.lf_applier_spark import SparkLFApplier
+from snorkel.labeling.lf import labeling_function
+from snorkel.labeling.preprocess import Preprocessor
+from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
+from snorkel.types import DataPoint, FieldMap
+
+logging.basicConfig(level=logging.INFO)
+
+
+ABSTAIN = 0
+NEGATIVE = 1
+POSITIVE = 2
+
+DATA = [
+    (
+        "The sports team won!",
+        "In a big sports game, the sports team won. The score is unknown.",
+    ),
+    (
+        "Jane Doe is great.",
+        "This article describes how great Jane Doe is. She is great.",
+    ),
+]
+
+
+class CombineTextPreprocessor(Preprocessor):
+    def __init__(self, title_field, body_field, article_field):
+        super().__init__(
+            dict(title=title_field, body=body_field), dict(article=article_field)
+        )
+
+    def preprocess(self, title: str, body: str) -> FieldMap:  # type: ignore
+        return dict(article=f"{title} {body}")
+
+
+combine_text_preprocessor = CombineTextPreprocessor("title", "body", "article")
+spacy_preprocessor = SpacyPreprocessor("article", "article")
+
+
+@labeling_function(preprocessors=[combine_text_preprocessor, spacy_preprocessor])
+def article_mentions_person(x: DataPoint) -> int:
+    for ent in x.article.ents:
+        if ent.label_ == "PERSON":
+            return ABSTAIN
+    return NEGATIVE
+
+
+def build_lf_matrix() -> None:
+    sc = SparkContext()
+    rdd = sc.parallelize(DATA)
+    rdd = rdd.map(lambda x: Row(title=x[0], body=x[1]))
+
+    applier = SparkLFApplier([article_mentions_person])
+    L = applier.apply(rdd)
+
+    logging.info(str(L))
+
+
+if __name__ == "__main__":
+    build_lf_matrix()

--- a/tutorials/drybell/nlp_lf.py
+++ b/tutorials/drybell/nlp_lf.py
@@ -1,3 +1,14 @@
+"""
+This example script replicates functionality from
+    Snorkel Drybell (https://arxiv.org/abs/1812.00417)
+
+Similar to Section 5.1, an NLP-based labeling function is
+authored using two preprocessors. The LF checks whether the
+title or body of an article contains a person mention. The
+LF is then executed using Spark, returning a label matrix.
+"""
+
+
 import logging
 
 from pyspark import SparkContext


### PR DESCRIPTION
Add a short example replicating functionality from Snorkel Drybell Section 5.1 using the Spacy preprocessor

As a side note, the `CombineTextPreprocessor` definition feels heavy-handed. Having a LambdaPreprocessor class that is defined with a single function would be useful, and we can add a decorator version (similar to `@labeling_function`).

**Test plan**
Running test on EMR cluster...standby