### PR TITLE
Add MTL model and task objects

### DIFF
--- a/snorkel/mtl/model.py
+++ b/snorkel/mtl/model.py
@@ -1,0 +1,402 @@
+import logging
+import os
+from collections import defaultdict
+from collections.abc import Iterable
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from snorkel.mtl.task import Task
+from snorkel.mtl.utils import move_to_device, prob_to_pred, recursive_merge_dicts
+
+model_default_config = {
+    "model_path": None,  # the path to a saved checkpoint to initialize with
+    "device": 0,  # gpu id (int) or -1 for cpu
+    "dataparallel": True,
+}
+
+
+class MultitaskModel(nn.Module):
+    """A class to build multi-task model.
+
+    :param name: Name of the model
+    :type name: str
+    :param tasks: a list of Task that trains jointly
+    :type tasks: list of Task project
+    """
+
+    def __init__(self, name=None, tasks=None, **kwargs):
+        super().__init__()
+        self.config = recursive_merge_dicts(
+            model_default_config, kwargs, misses="insert"
+        )
+        self.name = name if name is not None else type(self).__name__
+
+        # Initiate the model attributes
+        self.module_pool = nn.ModuleDict()
+        self.task_names = set()
+        self.task_flows = dict()
+        self.loss_funcs = dict()
+        self.output_funcs = dict()
+        self.scorers = dict()
+
+        # Build network with given tasks
+        if tasks is not None:
+            self._build_network(tasks)
+
+        logging.info(
+            f"Created multi-task model {self.name} that contains "
+            f"task {self.task_names}."
+        )
+
+        # Move model to specified device
+        self._move_to_device()
+
+    def _move_to_device(self):
+        """Move model to specified device."""
+
+        if self.config["device"] >= 0:
+            if torch.cuda.is_available():
+                logging.info(f"Moving model to GPU " f"(cuda:{self.config['device']}).")
+                self.to(torch.device(f"cuda:{self.config['device']}"))
+            else:
+                logging.info("No cuda device available. Switch to cpu instead.")
+
+    def _build_network(self, tasks):
+        """Build the MTL network using all tasks"""
+
+        if not isinstance(tasks, Iterable):
+            tasks = [tasks]
+        for task in tasks:
+            if task.name in self.task_names:
+                raise ValueError(
+                    f"Found duplicate task {task.name}, different task should use "
+                    f"different task name."
+                )
+            if not isinstance(task, Task):
+                raise ValueError(f"Unrecognized task type {task}.")
+            self.add_task(task)
+
+    def add_task(self, task):
+        """Add a single task into MTL network"""
+
+        # Combine module_pool from all tasks
+        for key in task.module_pool.keys():
+            if key in self.module_pool.keys():
+                if self.config["dataparallel"]:
+                    task.module_pool[key] = nn.DataParallel(self.module_pool[key])
+                else:
+                    task.module_pool[key] = self.module_pool[key]
+            else:
+                if self.config["dataparallel"]:
+                    self.module_pool[key] = nn.DataParallel(task.module_pool[key])
+                else:
+                    self.module_pool[key] = task.module_pool[key]
+        # Collect task names
+        self.task_names.add(task.name)
+        # Collect task flows
+        self.task_flows[task.name] = task.task_flow
+        # Collect loss functions
+        self.loss_funcs[task.name] = task.loss_func
+        # Collect output functions
+        self.output_funcs[task.name] = task.output_func
+        # Collect scorers
+        self.scorers[task.name] = task.scorer
+
+        # Move model to specified device
+        self._move_to_device()
+
+    def update_task(self, task):
+        """Update a existing task in MTL network"""
+
+        # Update module_pool with task
+        for key in task.module_pool.keys():
+            # Update the model's module with the task's module
+            if self.config["dataparallel"]:
+                self.module_pool[key] = nn.DataParallel(task.module_pool[key])
+            else:
+                self.module_pool[key] = task.module_pool[key]
+        # Update task flows
+        self.task_flows[task.name] = task.task_flow
+        # Update loss functions
+        self.loss_funcs[task.name] = task.loss_func
+        # Update output functions
+        self.output_funcs[task.name] = task.output_func
+        # Collect scorers
+        self.scorers[task.name] = task.scorer
+
+        # Move model to specified device
+        self._move_to_device()
+
+    def remove_task(self, task_name):
+        """Remove a existing task from MTL network"""
+        if task_name not in self.task_flows:
+            logging.info(f"Task ({task_name}) not in the current model, skip...")
+            return
+
+        # Remove task by task_name
+        logging.info(f"Removing Task {task_name}.")
+
+        self.task_names.remove(task_name)
+        del self.task_flows[task_name]
+        del self.loss_funcs[task_name]
+        del self.output_funcs[task_name]
+        del self.scorers[task_name]
+        # TODO: remove the modules only associate with that task
+
+    def __repr__(self):
+        cls_name = type(self).__name__
+        return f"{cls_name}(name={self.name})"
+
+    def forward(self, X_dict, task_names):
+        """Forward based on input and task
+        Note: We assume that all shared the modules from all tasks are based on the
+        the same input.
+
+        :param X_dict: The input data
+        :type X_dict: dict of tensor
+        :param task_names: The task names that needs to forward
+        :type task_names: list of str
+        :return: The output of all forwarded modules
+        :rtype: dict
+        """
+
+        X_dict = move_to_device(X_dict, self.config["device"])
+
+        outputs = dict()
+        outputs["_input_"] = X_dict
+
+        # Call forward for each task
+        for task_name in task_names:
+            task_flow = self.task_flows[task_name]
+
+            for action in task_flow:
+                if action["name"] not in outputs:
+                    if action["inputs"]:
+                        try:
+                            input = [
+                                outputs[action_name][output_index]
+                                for action_name, output_index in action["inputs"]
+                            ]
+                        except Exception:
+                            raise ValueError(f"Unrecognized action {action}.")
+                        output = self.module_pool[action["module"]].forward(*input)
+                    else:
+                        output = self.module_pool[action["module"]].forward(outputs)
+                    if isinstance(output, tuple):
+                        output = list(output)
+                    if not isinstance(output, list):
+                        output = [output]
+                    outputs[action["name"]] = output
+
+        return outputs
+
+    def calculate_loss(self, X_dict, Y_dict, task_to_label_dict, data_name, split):
+        """Calculate the loss
+
+        :param X_dict: The input data
+        :type X_dict: dict of tensors
+        :param Y_dict: The output data
+        :type Y_dict: dict of tensors
+        :param task_to_label_dict: The task to label mapping
+        :type task_to_label_dict: dict
+        :param data_name: The dataset name
+        :type data_name: str
+        :param split: The data split
+        :type split: str
+        :return: The loss and the number of samples in the batch of all tasks
+        :rtype: dict, dict
+        """
+
+        loss_dict = dict()
+        count_dict = dict()
+
+        outputs = self.forward(X_dict, task_to_label_dict.keys())
+
+        # Calculate loss for each task
+        for task_name, label_name in task_to_label_dict.items():
+            identifier = "/".join([task_name, data_name, split, "loss"])
+
+            Y = Y_dict[label_name]
+
+            # Select the active samples
+            if len(Y.size()) == 1:
+                active = Y.detach() != 0
+            else:
+                active = torch.any(Y.detach() != 0, dim=1)
+
+            # Only calculate the loss when active example exists
+            if 1 in active:
+                count_dict[identifier] = active.sum().item()
+
+                loss_dict[identifier] = self.loss_funcs[task_name](
+                    outputs,
+                    move_to_device(Y_dict[label_name], self.config["device"]),
+                    move_to_device(active, self.config["device"]),
+                )
+
+        return loss_dict, count_dict
+
+    @torch.no_grad()
+    def _calculate_probs(self, X_dict, task_names):
+        """Calculate the probs given the features
+
+        :param X_dict: The input data
+        :type X_dict: dict of tensor
+        :param task_names: The task names that needs to forward
+        :type task_names: list of str
+        """
+
+        self.eval()
+
+        prob_dict = dict()
+
+        outputs = self.forward(X_dict, task_names)
+
+        # Calculate prediction for each task
+        for task_name in task_names:
+            prob_dict[task_name] = self.output_funcs[task_name](outputs).cpu().numpy()
+
+        return prob_dict
+
+    @torch.no_grad()
+    def predict(self, dataloader, return_preds=False, return_uids=False):
+
+        self.eval()
+
+        gold_dict = defaultdict(list)
+        prob_dict = defaultdict(list)
+
+        for batch_num, (X_batch_dict, Y_batch_dict) in enumerate(dataloader):
+            prob_batch_dict = self._calculate_probs(
+                X_batch_dict, dataloader.task_to_label_dict.keys()
+            )
+            for task_name in dataloader.task_to_label_dict.keys():
+                prob_dict[task_name].extend(prob_batch_dict[task_name])
+                gold_dict[task_name].extend(
+                    Y_batch_dict[dataloader.task_to_label_dict[task_name]].cpu().numpy()
+                )
+        for task_name in gold_dict:
+            gold_dict[task_name] = np.array(gold_dict[task_name])
+            prob_dict[task_name] = np.array(prob_dict[task_name])
+            if len(gold_dict[task_name].shape) == 1:
+                active = (gold_dict[task_name] != 0).reshape(-1)
+            else:
+                active = np.sum(gold_dict[task_name] == 0, axis=1) > 0
+
+            if 0 in active:
+                gold_dict[task_name] = gold_dict[task_name][active]
+                prob_dict[task_name] = prob_dict[task_name][active]
+
+        if return_preds:
+            pred_dict = defaultdict(list)
+            for task_name, prob in prob_dict.items():
+                pred_dict[task_name] = prob_to_pred(prob)
+
+        results = {"golds": gold_dict, "probs": prob_dict}
+
+        if return_preds:
+            results["preds"] = pred_dict
+
+        return results
+
+    @torch.no_grad()
+    def score(self, dataloaders):
+        """Score the data from dataloader with the model
+
+        :param dataloaders: the dataloader that performs scoring
+        :type dataloaders: dataloader
+        """
+
+        self.eval()
+
+        if not isinstance(dataloaders, list):
+            dataloaders = [dataloaders]
+
+        metric_score_dict = dict()
+
+        for dataloader in dataloaders:
+            return_uids = True if dataloader.dataset.uid else False
+            preds = self.predict(dataloader, return_preds=True, return_uids=return_uids)
+            for task_name in preds["golds"].keys():
+                metric_score = self.scorers[task_name].score(
+                    preds["golds"][task_name],
+                    preds["probs"][task_name],
+                    preds["preds"][task_name],
+                    preds["uids"][task_name] if return_uids else None,
+                )
+                for metric_name, metric_value in metric_score.items():
+                    identifier = "/".join(
+                        [task_name, dataloader.data_name, dataloader.split, metric_name]
+                    )
+                    metric_score_dict[identifier] = metric_value
+
+        return metric_score_dict
+
+    def save(self, model_path):
+        """Save the current model
+        :param model_path: Saved model path.
+        :type model_path: str
+        """
+
+        # Check existence of model saving directory and create if does not exist.
+        if not os.path.exists(os.path.dirname(model_path)):
+            os.makedirs(os.path.dirname(model_path))
+
+        state_dict = {
+            "model": {"name": self.name, "module_pool": self.collect_state_dict()}
+        }
+
+        try:
+            torch.save(state_dict, model_path)
+        except BaseException:
+            logging.warning("Saving failed... continuing anyway.")
+
+        logging.info(f"[{self.name}] Model saved in {model_path}")
+
+    def load(self, model_path):
+        """Load model state_dict from file and reinitialize the model weights.
+        :param model_path: Saved model path.
+        :type model_path: str
+        """
+
+        if not os.path.exists(model_path):
+            logging.error("Loading failed... Model does not exist.")
+
+        try:
+            checkpoint = torch.load(model_path, map_location=torch.device("cpu"))
+        except BaseException:
+            logging.error(f"Loading failed... Cannot load model from {model_path}")
+            raise
+
+        self.load_state_dict(checkpoint["model"]["module_pool"])
+
+        logging.info(f"[{self.name}] Model loaded from {model_path}")
+
+        # Move model to specified device
+        self._move_to_device()
+
+    def collect_state_dict(self):
+        state_dict = defaultdict(list)
+
+        for module_name, module in self.module_pool.items():
+            if self.config["dataparallel"]:
+                state_dict[module_name] = module.module.state_dict()
+            else:
+                state_dict[module_name] = module.state_dict()
+
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+
+        for module_name, module_state_dict in state_dict.items():
+            if module_name in self.module_pool:
+                if self.config["dataparallel"]:
+                    self.module_pool[module_name].module.load_state_dict(
+                        module_state_dict
+                    )
+                else:
+                    self.module_pool[module_name].load_state_dict(module_state_dict)
+            else:
+                logging.info(f"Missing {module_name} in module_pool, skip it..")

--- a/snorkel/mtl/modules/utils.py
+++ b/snorkel/mtl/modules/utils.py
@@ -1,0 +1,17 @@
+"""
+For compatibility with SuperGLUE tutorials, we we use these wrappers around
+standard pytorch functional operators.
+TODO: Redesign MTL model construction so that regular F.cross_entropy and
+F.softmax can be used directly.
+"""
+
+
+import torch.nn.functional as F
+
+
+def ce_loss(module_name, outputs, Y, active):
+    return F.cross_entropy(outputs[module_name][0][active], (Y.view(-1) - 1)[active])
+
+
+def softmax(module_name, outputs):
+    return F.softmax(outputs[module_name][0], dim=1)

--- a/snorkel/mtl/task.py
+++ b/snorkel/mtl/task.py
@@ -1,0 +1,36 @@
+import logging
+
+from torch import nn
+
+
+class Task(object):
+    """A single Task in a multi-task problem
+
+    :param name: The name of the task (Primary key).
+    :type name: str
+    :param module_pool: A dict of all modules that uses in the task.
+    :type module_pool: nn.ModuleDict
+    :param task_flow: The task flow among modules to define how the data flows.
+    :type task_flow: list
+    :param loss_func: The function to calculate the loss.
+    :type loss_func: function
+    :param output_func: The function to generate the output.
+    :type output_func: function
+    :param scorer: The class of metrics to evaluate the task.
+    :type scorer: Scorer class
+    """
+
+    def __init__(self, name, module_pool, task_flow, loss_func, output_func, scorer):
+        self.name = name
+        assert isinstance(module_pool, nn.ModuleDict) is True
+        self.module_pool = module_pool
+        self.task_flow = task_flow
+        self.loss_func = loss_func
+        self.output_func = output_func
+        self.scorer = scorer
+
+        logging.info(f"Created task: {self.name}")
+
+    def __repr__(self):
+        cls_name = type(self).__name__
+        return f"{cls_name}(name={self.name})"

--- a/snorkel/mtl/task.py
+++ b/snorkel/mtl/task.py
@@ -1,26 +1,32 @@
 import logging
+from typing import Any, Callable, Dict, List
 
+import torch
 from torch import nn
 
+from snorkel.mtl.scorer import Scorer
 
-class Task(object):
+
+class Task:
     """A single Task in a multi-task problem
 
-    :param name: The name of the task (Primary key).
-    :type name: str
-    :param module_pool: A dict of all modules that uses in the task.
-    :type module_pool: nn.ModuleDict
-    :param task_flow: The task flow among modules to define how the data flows.
-    :type task_flow: list
-    :param loss_func: The function to calculate the loss.
-    :type loss_func: function
-    :param output_func: The function to generate the output.
-    :type output_func: function
-    :param scorer: The class of metrics to evaluate the task.
-    :type scorer: Scorer class
+    :param name: The name of the task (Primary key)
+    :param module_pool: A dict of all modules that are used by the task
+    :param task_flow: The task flow among modules to define how the data flows
+    :param loss_func: The function to calculate the loss
+    :param output_func: The function to generate the output
+    :param scorer: A Scorer defining the metrics to evaluate on the task
     """
 
-    def __init__(self, name, module_pool, task_flow, loss_func, output_func, scorer):
+    def __init__(
+        self,
+        name: str,
+        module_pool: nn.ModuleDict,
+        task_flow: List[Dict[str, Any]],
+        loss_func: Callable[..., torch.Tensor],
+        output_func: Callable[..., torch.Tensor],
+        scorer: Scorer,
+    ) -> None:
         self.name = name
         assert isinstance(module_pool, nn.ModuleDict) is True
         self.module_pool = module_pool
@@ -31,6 +37,6 @@ class Task(object):
 
         logging.info(f"Created task: {self.name}")
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         cls_name = type(self).__name__
         return f"{cls_name}(name={self.name})"

--- a/test/mtl/test_model.py
+++ b/test/mtl/test_model.py
@@ -1,0 +1,73 @@
+import unittest
+from functools import partial
+
+import torch.nn as nn
+
+from snorkel.mtl.model import MultitaskModel
+from snorkel.mtl.modules.utils import ce_loss, softmax
+from snorkel.mtl.scorer import Scorer
+from snorkel.mtl.task import Task
+
+
+class TaskTest(unittest.TestCase):
+    def create_task(self, task_name, mod_suffixes):
+        module_pool = nn.ModuleDict(
+            {
+                f"linear1{mod_suffixes[0]}": nn.Linear(2, 10),
+                f"linear2{mod_suffixes[1]}": nn.Linear(10, 1),
+            }
+        )
+
+        task_flow = [
+            {"name": "first_layer", "module": "linear1", "inputs": [("_input_", 0)]},
+            {
+                "name": "second_layer",
+                "module": "linear2",
+                "inputs": [("first_layer", 0)],
+            },
+        ]
+
+        task = Task(
+            name=task_name,
+            module_pool=module_pool,
+            task_flow=task_flow,
+            loss_func=partial(ce_loss, "second_layer"),
+            output_func=partial(softmax, "second_layer"),
+            scorer=Scorer(metrics=["accuracy"]),
+        )
+
+        return task
+
+    def test_onetask_model(self):
+        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
+        model = MultitaskModel(name="MyOneTaskModel", tasks=[task1])
+        self.assertEqual(len(model.task_names), 1)
+        self.assertEqual(len(model.task_flows), 1)
+        self.assertEqual(len(model.module_pool), 2)
+
+    def test_twotask_all_overlap_model(self):
+        """Add two tasks with identical modules and flows"""
+        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
+        task2 = self.create_task("task2", mod_suffixes=["A", "A"])
+        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        self.assertEqual(len(model.task_names), 2)
+        self.assertEqual(len(model.task_flows), 2)
+        self.assertEqual(len(model.module_pool), 2)
+
+    def test_twotask_none_overlap_model(self):
+        """Add two tasks with totally separate modules and flows"""
+        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
+        task2 = self.create_task("task2", mod_suffixes=["B", "B"])
+        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        self.assertEqual(len(model.task_names), 2)
+        self.assertEqual(len(model.task_flows), 2)
+        self.assertEqual(len(model.module_pool), 4)
+
+    def test_twotask_partial_overlap_model(self):
+        """Add two tasks with overlapping modules and flows"""
+        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
+        task2 = self.create_task("task2", mod_suffixes=["A", "B"])
+        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        self.assertEqual(len(model.task_names), 2)
+        self.assertEqual(len(model.task_flows), 2)
+        self.assertEqual(len(model.module_pool), 3)

--- a/test/mtl/test_task.py
+++ b/test/mtl/test_task.py
@@ -1,0 +1,43 @@
+import unittest
+from functools import partial
+
+import torch.nn as nn
+
+from snorkel.mtl.modules.utils import ce_loss, softmax
+from snorkel.mtl.scorer import Scorer
+from snorkel.mtl.task import Task
+
+TASK_NAME = "TestTask"
+
+
+class TaskTest(unittest.TestCase):
+    def test_task_creation(self):
+        module_pool = nn.ModuleDict(
+            {"linear1": nn.Linear(2, 10), "linear2": nn.Linear(10, 1)}
+        )
+
+        task_flow = [
+            {
+                "name": "the_first_layer",
+                "module": "linear1",
+                "inputs": [("_input_", 0)],
+            },
+            {
+                "name": "the_second_layer",
+                "module": "linear2",
+                "inputs": [("the_first_layer", 0)],
+            },
+        ]
+
+        task = Task(
+            name=TASK_NAME,
+            module_pool=module_pool,
+            task_flow=task_flow,
+            loss_func=partial(ce_loss, "the_second_layer"),
+            output_func=partial(softmax, "the_second_layer"),
+            scorer=Scorer(metrics=["accuracy"]),
+        )
+
+        # Task has no functionality on its own
+        # Here we only confirm that the object was initialized
+        self.assertEqual(task.name, TASK_NAME)


### PR DESCRIPTION
Add MTL Model and Task objects.

Each Task defines:
- a pool of modules
- a flow through those modules (a sequence of modules to go through, with a map of what fields to pull out of the intermediate outputs dictionary to use as input for each module). Importantly, the flow can reuse the same module multiple times (e.g., as in multi-hop frameworks or multiple-choice setups where multiple candidates are passed through the network before making predictions)
- a loss function
- an output function (e.g., a final softmax)
- a scorer (a bundle of metrics that are defined and meaningful for that task)
A Task doesn't do much by itself.

Each Model is built from a collection of Tasks. The model pools all modules from the tasks (merging shared modules based on their keys), and defines a forward pass that respects the flows defined in the tasks, with appropriate caching of intermediate results.

**Test plan**
- `test_task.py` confirms that a Task object can be initialized; there's not much more to test in isolation
- `test_model.py` confirms that a Model can be created from a single task, or two two tasks that overlap completely, not at all, or partially. In each case, we confirm that the model contains the proper number of tasks and modules (i.e., is sharing modules where it should).
- Additional tests will be included when the `Trainer` object is added