### PR TITLE
Add MTL Trainer

### DIFF
--- a/snorkel/mtl/data.py
+++ b/snorkel/mtl/data.py
@@ -19,18 +19,12 @@ class MultitaskDataset(Dataset):
     :param Y_dict: the label dict where key is the label name and value is
     the label
     :type Y_dict: dict
-    :param uid: the unique id key in the X_dict (default: None)
-    :type uid: str
     """
 
-    def __init__(self, name, X_dict, Y_dict, uid=None):
+    def __init__(self, name, X_dict, Y_dict):
         self.name = name
         self.X_dict = X_dict
         self.Y_dict = Y_dict
-        self.uid = uid
-
-        if self.uid and self.uid not in self.X_dict:
-            raise ValueError(f"Cannot find {self.uid} in X_dict.")
 
         for name, label in self.Y_dict.items():
             if not isinstance(label, torch.Tensor):

--- a/snorkel/mtl/loggers/log_manager.py
+++ b/snorkel/mtl/loggers/log_manager.py
@@ -6,18 +6,17 @@ from typing import Dict
 import torch
 
 from snorkel.mtl.utils import recursive_merge_dicts
-from snorkel.types import Config
 
 from .checkpointer import Checkpointer
 from .log_writer import LogWriter
 from .tensorboard_writer import TensorBoardWriter
 
 logger_default_config = {
-    "counter_unit": "batches",  # [points, batches, epochs]
     "log_dir": "logs",  # The path to the directory under which logs will be written
+    "counter_unit": "batches",  # [points, batches, epochs]
     "evaluation_freq": 2,  # Evaluate performance every this many counter_units
-    "writer_config": {"writer": "tensorboard", "verbose": True},  # [json, tensorboard]
-    "checkpointing": True,
+    "writer_config": {"writer": None, "verbose": True},  # [json, tensorboard]
+    "checkpointing": False,
     "checkpointer_config": {
         "checkpoint_dir": None,
         "checkpoint_factor": 1,  # Checkpoint every this many evaluations
@@ -38,9 +37,9 @@ class LogManager(object):
     :type verbose: bool
     """
 
-    def __init__(self, config: Config, n_batches_per_epoch: int) -> None:
+    def __init__(self, n_batches_per_epoch: int, **kwargs) -> None:
 
-        self.config = recursive_merge_dicts(logger_default_config, config)
+        self.config = recursive_merge_dicts(logger_default_config, kwargs)
         self.n_batches_per_epoch = n_batches_per_epoch
 
         # Create log directory for this run

--- a/snorkel/mtl/modules/utils.py
+++ b/snorkel/mtl/modules/utils.py
@@ -1,6 +1,6 @@
 """
-For compatibility with SuperGLUE tutorials, we we use these wrappers around
-standard pytorch functional operators.
+Commonly used loss and output functions for Task objects
+# TODO: move filtering of actives and pulling out modules before these functions
 """
 
 
@@ -8,8 +8,8 @@ import torch.nn.functional as F
 
 
 def ce_loss(module_name, outputs, Y, active):
-    # Subtract 1 from Ys to account for Snorkel reserving the label 0 for abstains
-    # (but F.cross_entropy() expect 0-indexed labels)
+    # Subtract 1 from hard labels in Y to account for Snorkel reserving the label 0 for
+    # abstains while F.cross_entropy() expects 0-indexed labels
     return F.cross_entropy(outputs[module_name][0][active], (Y.view(-1) - 1)[active])
 
 

--- a/snorkel/mtl/modules/utils.py
+++ b/snorkel/mtl/modules/utils.py
@@ -1,8 +1,6 @@
 """
 For compatibility with SuperGLUE tutorials, we we use these wrappers around
 standard pytorch functional operators.
-TODO: Redesign MTL model construction so that regular F.cross_entropy and
-F.softmax can be used directly.
 """
 
 
@@ -10,6 +8,8 @@ import torch.nn.functional as F
 
 
 def ce_loss(module_name, outputs, Y, active):
+    # Subtract 1 from Ys to account for Snorkel reserving the label 0 for abstains
+    # (but F.cross_entropy() expect 0-indexed labels)
     return F.cross_entropy(outputs[module_name][0][active], (Y.view(-1) - 1)[active])
 
 

--- a/snorkel/mtl/schedulers/scheduler.py
+++ b/snorkel/mtl/schedulers/scheduler.py
@@ -1,0 +1,18 @@
+from abc import ABC, abstractmethod
+
+
+class Scheduler(ABC):
+    """Return batches from all dataloaders in a specified order
+    """
+
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def get_batches(self, dataloaders):
+        """Return batches in a specified order.
+
+        :param dataloaders: a list of dataloaders
+        :type dataloaders: list
+        """
+        pass

--- a/snorkel/mtl/schedulers/sequential_scheduler.py
+++ b/snorkel/mtl/schedulers/sequential_scheduler.py
@@ -1,0 +1,31 @@
+from snorkel.mtl.schedulers.scheduler import Scheduler
+
+
+class SequentialScheduler(Scheduler):
+    """Return batches from all dataloaders in sequential order."""
+
+    def __init__(self):
+        super().__init__()
+
+    def get_batches(self, dataloaders):
+        """Return batches in sequential order.
+
+        :param dataloaders: a list of dataloaders
+        :type dataloaders: list
+        :return: A generator of all batches
+        :rtype: genertor
+        """
+
+        task_to_label_dicts = [
+            dataloader.task_to_label_dict for dataloader in dataloaders
+        ]
+        data_names = [dataloader.data_name for dataloader in dataloaders]
+        batch_counts = [len(dataloader) for dataloader in dataloaders]
+        data_loaders = [iter(dataloader) for dataloader in dataloaders]
+        splits = [dataloader.split for dataloader in dataloaders]
+
+        for task_to_label_dict, data_name, batch_count, data_loader, split in zip(
+            task_to_label_dicts, data_names, batch_counts, data_loaders, splits
+        ):
+            for batch in range(batch_count):
+                yield next(data_loader), task_to_label_dict, data_name, split

--- a/snorkel/mtl/schedulers/shuffled_scheduler.py
+++ b/snorkel/mtl/schedulers/shuffled_scheduler.py
@@ -1,0 +1,38 @@
+import random
+
+from snorkel.mtl.schedulers.scheduler import Scheduler
+
+
+class ShuffledScheduler(Scheduler):
+    """Return batches from all dataloaders in shuffled order for each epoch"""
+
+    def __init__(self):
+        super().__init__()
+
+    def get_batches(self, dataloaders):
+        """Return batches in shuffled order.
+
+        :param dataloaders: a list of dataloaders
+        :type dataloaders: list
+        :return: A generator of all batches
+        :rtype: genertor
+        """
+
+        task_to_label_dicts = [
+            dataloader.task_to_label_dict for dataloader in dataloaders
+        ]
+        data_names = [dataloader.data_name for dataloader in dataloaders]
+        batch_counts = [len(dataloader) for dataloader in dataloaders]
+        data_loaders = [iter(dataloader) for dataloader in dataloaders]
+        splits = [dataloader.split for dataloader in dataloaders]
+
+        dataloader_indexer = []
+        for idx, count in enumerate(batch_counts):
+            dataloader_indexer.extend([idx] * count)
+
+        random.shuffle(dataloader_indexer)
+
+        for index in dataloader_indexer:
+            yield next(data_loaders[index]), task_to_label_dicts[index], data_names[
+                index
+            ], splits[index]

--- a/snorkel/mtl/trainer.py
+++ b/snorkel/mtl/trainer.py
@@ -8,8 +8,8 @@ from tqdm import tqdm
 
 from snorkel.mtl.loggers.log_manager import LogManager, logger_default_config
 from snorkel.mtl.model import MultitaskModel
-from snorkel.mtl.schedulers.round_robin_scheduler import RoundRobinScheduler
 from snorkel.mtl.schedulers.sequential_scheduler import SequentialScheduler
+from snorkel.mtl.schedulers.shuffled_scheduler import ShuffledScheduler
 from snorkel.mtl.utils import recursive_merge_dicts
 
 trainer_default_config = {
@@ -38,7 +38,7 @@ trainer_default_config = {
         "exponential_config": {"gamma": 0.9},
         "plateau_config": {"factor": 0.5, "patience": 10, "threshold": 0.0001},
     },
-    "task_scheduler": "round_robin",  # [sequential, round_robin, proportional]
+    "task_scheduler": "shuffled",  # [sequential, shuffled]
 }
 
 
@@ -296,8 +296,8 @@ class Trainer(object):
         # TODO: Restore ProportionalScheduler
         if opt == "sequential":
             self.task_scheduler = SequentialScheduler()
-        elif opt == "round_robin":
-            self.task_scheduler = RoundRobinScheduler()
+        elif opt == "shuffled":
+            self.task_scheduler = ShuffledScheduler()
         else:
             raise ValueError(f"Unrecognized task scheduler option '{opt}'")
 

--- a/snorkel/mtl/trainer.py
+++ b/snorkel/mtl/trainer.py
@@ -1,0 +1,380 @@
+import logging
+from collections import defaultdict
+from typing import Dict
+
+import torch
+import torch.optim as optim
+from tqdm import tqdm
+
+from snorkel.mtl.loggers.log_manager import LogManager, logger_default_config
+from snorkel.mtl.model import MultitaskModel
+from snorkel.mtl.schedulers.round_robin_scheduler import RoundRobinScheduler
+from snorkel.mtl.schedulers.sequential_scheduler import SequentialScheduler
+from snorkel.mtl.utils import recursive_merge_dicts
+
+trainer_default_config = {
+    "n_epochs": 1,  # total number of learning epochs
+    "train_split": "train",  # the split for training, accepts str or list of strs
+    "valid_split": "valid",  # the split for validation, accepts str or list of strs
+    "test_split": "test",  # the split for testing, accepts str or list of strs
+    "progress_bar": True,
+    "logger_config": logger_default_config,
+    "optimizer_config": {
+        "optimizer": "adam",  # [sgd, adam]
+        "lr": 0.001,  # learing rate
+        "l2": 0.0,  # l2 regularization
+        "grad_clip": 1.0,  # gradient clipping
+        "sgd_config": {"momentum": 0.9},
+        "adam_config": {"betas": (0.9, 0.999), "amsgrad": False},
+        "adamax_config": {"betas": (0.9, 0.999), "eps": 0.00000001},
+    },
+    "lr_scheduler_config": {
+        "lr_scheduler": "constant",  # [constant, linear, exponential, step, multi_step, reduce_on_plateau]
+        "warmup_steps": 0,  # warm up steps
+        "warmup_unit": "batches",  # [epochs, batches]
+        "warmup_percentage": 0.0,  # warm up percentage
+        "min_lr": 0.0,  # minimum learning rate
+        "linear_config": {"min_lr": 0.0},
+        "exponential_config": {"gamma": 0.9},
+        "plateau_config": {"factor": 0.5, "patience": 10, "threshold": 0.0001},
+    },
+    "task_scheduler": "round_robin",  # [sequential, round_robin, proportional]
+}
+
+
+class Trainer(object):
+    """A class for multi-task learning.
+
+    :param config: The learning config
+    :type config: dict
+    """
+
+    def __init__(self, name=None, **kwargs):
+        self.config = recursive_merge_dicts(
+            trainer_default_config, kwargs, misses="insert"
+        )
+        self.name = name if name is not None else type(self).__name__
+
+    def train_model(self, model: MultitaskModel, dataloaders):
+        """The learning procedure of MTL
+
+        :param model: The multi-task model that needs to learn
+        :type model: MultitaskModel
+        :param dataloaders: a list of dataloaders used to learn the model
+        :type dataloaders: list
+        """
+
+        # Generate the list of dataloaders for learning process
+        train_split = self.config["train_split"]
+        if isinstance(train_split, str):
+            train_split = [train_split]
+
+        train_dataloaders = [
+            dataloader for dataloader in dataloaders if dataloader.split in train_split
+        ]
+
+        if not train_dataloaders:
+            raise ValueError(
+                f"Cannot find the specified train_split "
+                f'{self.config["train_split"]} in datloaders.'
+            )
+
+        # Calculate the total number of batches per epoch
+        self.n_batches_per_epoch = sum(
+            [len(dataloader) for dataloader in train_dataloaders]
+        )
+
+        # Set training helpers
+        self._set_logging_manager()
+        self._set_optimizer(model)
+        self._set_lr_scheduler(model)
+        self._set_task_scheduler(model, dataloaders)
+
+        # Set to training mode
+        model.train()
+
+        logging.info(f"Start training...")
+
+        self.metrics: Dict[str, float] = dict()
+        self._reset_losses()
+
+        for epoch_num in range(self.config["n_epochs"]):
+            batches = tqdm(
+                enumerate(self.task_scheduler.get_batches(train_dataloaders)),
+                total=self.n_batches_per_epoch,
+                disable=(not self.config["progress_bar"]),
+                desc=f"Epoch {epoch_num}:",
+            )
+            for batch_num, (batch, task_to_label_dict, data_name, split) in batches:
+                X_dict, Y_dict = batch
+
+                total_batch_num = epoch_num * self.n_batches_per_epoch + batch_num
+                batch_size = len(next(iter(Y_dict.values())))
+
+                # Update lr using lr scheduler
+                self._update_lr_scheduler(model, total_batch_num)
+
+                # Set gradients of all model parameters to zero
+                self.optimizer.zero_grad()
+
+                # Perform forward pass and calcualte the loss and count
+                loss_dict, count_dict = model.calculate_loss(
+                    X_dict, Y_dict, task_to_label_dict, data_name, split
+                )
+
+                # Update running loss and count
+                for identifier in loss_dict.keys():
+                    self.running_losses[identifier] += (
+                        loss_dict[identifier].item() * count_dict[identifier]
+                    )
+                    self.running_counts[identifier] += count_dict[identifier]
+
+                # Skip the backward pass if no loss is calcuated
+                if not loss_dict:
+                    continue
+
+                # Calculate the average loss
+                loss = sum(loss_dict.values())
+
+                # Perform backward pass to calculate gradients
+                loss.backward()
+
+                # Clip gradient norm
+                if self.config["optimizer_config"]["grad_clip"]:
+                    torch.nn.utils.clip_grad_norm_(
+                        model.parameters(), self.config["optimizer_config"]["grad_clip"]
+                    )
+
+                # Update the parameters
+                self.optimizer.step()
+
+                self.metrics.update(self._logging(model, dataloaders, batch_size))
+
+                batches.set_postfix(self.metrics)
+
+        model = self.logging_manager.close(model)
+
+    def _set_logging_manager(self):
+        """Set logging manager."""
+        self.logging_manager = LogManager(
+            self.n_batches_per_epoch, **self.config["logger_config"]
+        )
+
+    def _set_optimizer(self, model):
+        """Set optimizer for learning process."""
+
+        # TODO: add more optimizer support and fp16
+        optimizer_config = self.config["optimizer_config"]
+        opt = optimizer_config["optimizer"]
+
+        parameters = filter(lambda p: p.requires_grad, model.parameters())
+
+        if opt == "sgd":
+            optimizer = optim.SGD(
+                parameters,
+                lr=optimizer_config["lr"],
+                **optimizer_config["sgd_config"],
+                weight_decay=optimizer_config["l2"],
+            )
+        elif opt == "adam":
+            optimizer = optim.Adam(
+                parameters,
+                lr=optimizer_config["lr"],
+                **optimizer_config["adam_config"],
+                weight_decay=optimizer_config["l2"],
+            )
+        elif opt == "adamax":
+            optimizer = optim.Adamax(
+                parameters,
+                lr=optimizer_config["lr"],
+                **optimizer_config["adamax_config"],
+                weight_decay=optimizer_config["l2"],
+            )
+        else:
+            raise ValueError(f"Unrecognized optimizer option '{opt}'")
+
+        logging.info(f"Using optimizer {optimizer}")
+
+        self.optimizer = optimizer
+
+    def _set_lr_scheduler(self, model):
+        """Set learning rate scheduler for learning process."""
+
+        # Set warmup scheduler
+        self._set_warmup_scheduler(model)
+
+        # Set lr scheduler
+        # TODO: add more lr scheduler support
+        opt = self.config["lr_scheduler_config"]["lr_scheduler"]
+        lr_scheduler_config = self.config["lr_scheduler_config"]
+
+        if opt == "constant":
+            lr_scheduler = None
+        elif opt == "linear":
+            total_steps = self.n_batches_per_epoch * self.config["n_epochs"]
+            linear_decay_func = lambda x: (total_steps - self.warmup_steps - x) / (
+                total_steps - self.warmup_steps
+            )
+            lr_scheduler = optim.lr_scheduler.LambdaLR(
+                self.optimizer, linear_decay_func
+            )
+        elif opt == "exponential":
+            lr_scheduler = optim.lr_scheduler.ExponentialLR(
+                self.optimizer, **lr_scheduler_config["exponential_config"]
+            )
+        elif opt == "step":
+            lr_scheduler = optim.lr_scheduler.StepLR(
+                self.optimizer, **lr_scheduler_config["step_config"]
+            )
+        elif opt == "multi_step":
+            lr_scheduler = optim.lr_scheduler.MultiStepLR(
+                self.optimizer, **lr_scheduler_config["multi_step_config"]
+            )
+        elif opt == "reduce_on_plateau":
+            lr_scheduler = optim.lr_scheduler.ReduceLROnPlateau(
+                self.optimizer,
+                min_lr=lr_scheduler_config["min_lr"],
+                **lr_scheduler_config["plateau_config"],
+            )
+        else:
+            raise ValueError(f"Unrecognized lr scheduler option '{opt}'")
+
+        self.lr_scheduler = lr_scheduler
+
+    def _set_warmup_scheduler(self, model):
+        """Set warmup learning rate scheduler for learning process."""
+
+        if self.config["lr_scheduler_config"]["warmup_steps"]:
+            warmup_steps = self.config["lr_scheduler_config"]["warmup_steps"]
+            if warmup_steps < 0:
+                raise ValueError(f"warmup_steps much greater or equal than 0.")
+            warmup_unit = self.config["lr_scheduler_config"]["warmup_unit"]
+            if warmup_unit == "epoch":
+                self.warmup_steps = int(warmup_steps * self.n_batches_per_epoch)
+            elif warmup_unit == "batch":
+                self.warmup_steps = int(warmup_steps)
+            else:
+                raise ValueError(
+                    f"warmup_unit must be 'batch' or 'epoch', but {warmup_unit} found."
+                )
+            linear_warmup_func = lambda x: x / self.warmup_steps
+            warmup_scheduler = optim.lr_scheduler.LambdaLR(
+                self.optimizer, linear_warmup_func
+            )
+            logging.info(f"Warmup {self.warmup_steps} batchs.")
+        elif self.config["lr_scheduler_config"]["warmup_percentage"]:
+            warmup_percentage = self.config["lr_scheduler_config"]["warmup_percentage"]
+            self.warmup_steps = int(
+                warmup_percentage * self.config["n_epochs"] * self.n_batches_per_epoch
+            )
+            linear_warmup_func = lambda x: x / self.warmup_steps
+            warmup_scheduler = optim.lr_scheduler.LambdaLR(
+                self.optimizer, linear_warmup_func
+            )
+            logging.info(f"Warmup {self.warmup_steps} batchs.")
+        else:
+            warmup_scheduler = None
+            self.warmup_steps = 0
+
+        self.warmup_scheduler = warmup_scheduler
+
+    def _update_lr_scheduler(self, model, step):
+        """Update the lr using lr_scheduler with each batch."""
+
+        if self.warmup_scheduler and step < self.warmup_steps:
+            self.warmup_scheduler.step()
+        elif self.lr_scheduler is not None:
+            self.lr_scheduler.step()
+            min_lr = self.config["lr_scheduler_config"]["min_lr"]
+            if min_lr and self.optimizer.param_groups[0]["lr"] < min_lr:
+                self.optimizer.param_groups[0]["lr"] = min_lr
+
+    def _set_task_scheduler(self, model, dataloaders):
+        """Set task scheduler for learning process"""
+        opt = self.config["task_scheduler"]
+
+        # TODO: Restore ProportionalScheduler
+        if opt == "sequential":
+            self.task_scheduler = SequentialScheduler()
+        elif opt == "round_robin":
+            self.task_scheduler = RoundRobinScheduler()
+        else:
+            raise ValueError(f"Unrecognized task scheduler option '{opt}'")
+
+    def _evaluate(self, model, dataloaders, split):
+        if not isinstance(split, list):
+            valid_split = [split]
+        else:
+            valid_split = split
+
+        valid_dataloaders = [
+            dataloader for dataloader in dataloaders if dataloader.split in valid_split
+        ]
+        return model.score(valid_dataloaders)
+
+    def _logging(self, model, dataloaders, batch_size):
+        """Checking if it's time to evaluting or checkpointing"""
+
+        # Switch to eval mode for evaluation
+        model.eval()
+
+        metric_dict = dict()
+
+        self.logging_manager.update(batch_size)
+
+        # Log the loss and lr
+        metric_dict.update(self._aggregate_losses())
+
+        # Evaluate the model and log the metric
+        if self.logging_manager.trigger_evaluation():
+
+            # Log task specific metric
+            metric_dict.update(
+                self._evaluate(model, dataloaders, self.config["valid_split"])
+            )
+
+            self.logging_manager.write_log(metric_dict)
+
+            self._reset_losses()
+
+        # Checkpoint the model
+        if self.logging_manager.trigger_checkpointing():
+            self.logging_manager.checkpoint_model(
+                model, self.optimizer, self.lr_scheduler, metric_dict
+            )
+
+            self.logging_manager.write_log(metric_dict)
+
+            self._reset_losses()
+
+        # Switch to train mode
+        model.train()
+
+        return metric_dict
+
+    def _aggregate_losses(self):
+        """Calculate the task specific loss, average micro loss and learning rate."""
+
+        metric_dict = dict()
+
+        # Log task specific loss
+        for identifier in self.running_losses.keys():
+            if self.running_counts[identifier] > 0:
+                metric_dict[identifier] = (
+                    self.running_losses[identifier] / self.running_counts[identifier]
+                )
+
+        # Calculate average micro loss
+        total_loss = sum(self.running_losses.values())
+        total_count = sum(self.running_counts.values())
+        if total_count > 0:
+            metric_dict["model/train/all/loss"] = total_loss / total_count
+
+        # Log the learning rate
+        metric_dict["model/train/all/lr"] = self.optimizer.param_groups[0]["lr"]
+
+        return metric_dict
+
+    def _reset_losses(self):
+        self.running_losses = defaultdict(float)
+        self.running_counts = defaultdict(int)

--- a/snorkel/mtl/trainer.py
+++ b/snorkel/mtl/trainer.py
@@ -76,7 +76,7 @@ class Trainer(object):
         if not train_dataloaders:
             raise ValueError(
                 f"Cannot find the specified train_split "
-                f'{self.config["train_split"]} in datloaders.'
+                f'{self.config["train_split"]} in dataloaders.'
             )
 
         # Calculate the total number of batches per epoch

--- a/test/mtl/loggers/test_log_manager.py
+++ b/test/mtl/loggers/test_log_manager.py
@@ -23,10 +23,11 @@ class TestLogManager(unittest.TestCase):
             "log_dir": TEST_LOG_DIR,
             "counter_unit": "points",
             "evaluation_freq": 10,
+            "checkpointing": True,
             "checkpointer_config": {"checkpoint_factor": 2},
         }
 
-        log_manager = LogManager(config, n_batches_per_epoch=10)
+        log_manager = LogManager(n_batches_per_epoch=10, **config)
 
         log_manager.update(5)
         assert log_manager.trigger_evaluation() is False
@@ -55,10 +56,11 @@ class TestLogManager(unittest.TestCase):
         config = {
             "counter_unit": "batches",
             "evaluation_freq": 2,
+            "checkpointing": True,
             "checkpointer_config": {"checkpoint_factor": 2},
         }
 
-        log_manager = LogManager(config, n_batches_per_epoch=5)
+        log_manager = LogManager(n_batches_per_epoch=5, **config)
 
         log_manager.update(5)
         assert log_manager.trigger_evaluation() is False
@@ -86,10 +88,11 @@ class TestLogManager(unittest.TestCase):
         config = {
             "counter_unit": "epochs",
             "evaluation_freq": 1,
+            "checkpointing": True,
             "checkpointer_config": {"checkpoint_factor": 2},
         }
 
-        log_manager = LogManager(config, n_batches_per_epoch=2)
+        log_manager = LogManager(n_batches_per_epoch=2, **config)
 
         log_manager.update(5)
         assert log_manager.trigger_evaluation() is False

--- a/test/mtl/test_model.py
+++ b/test/mtl/test_model.py
@@ -10,11 +10,11 @@ from snorkel.mtl.task import Task
 
 
 class TaskTest(unittest.TestCase):
-    def create_task(self, task_name, mod_suffixes):
+    def create_task(self, task_name, module_suffixes):
         module_pool = nn.ModuleDict(
             {
-                f"linear1{mod_suffixes[0]}": nn.Linear(2, 10),
-                f"linear2{mod_suffixes[1]}": nn.Linear(10, 1),
+                f"linear1{module_suffixes[0]}": nn.Linear(2, 10),
+                f"linear2{module_suffixes[1]}": nn.Linear(10, 2),
             }
         )
 
@@ -39,7 +39,7 @@ class TaskTest(unittest.TestCase):
         return task
 
     def test_onetask_model(self):
-        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
+        task1 = self.create_task("task1", module_suffixes=["A", "A"])
         model = MultitaskModel(name="MyOneTaskModel", tasks=[task1])
         self.assertEqual(len(model.task_names), 1)
         self.assertEqual(len(model.task_flows), 1)
@@ -47,8 +47,8 @@ class TaskTest(unittest.TestCase):
 
     def test_twotask_all_overlap_model(self):
         """Add two tasks with identical modules and flows"""
-        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
-        task2 = self.create_task("task2", mod_suffixes=["A", "A"])
+        task1 = self.create_task("task1", module_suffixes=["A", "A"])
+        task2 = self.create_task("task2", module_suffixes=["A", "A"])
         model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
@@ -56,8 +56,8 @@ class TaskTest(unittest.TestCase):
 
     def test_twotask_none_overlap_model(self):
         """Add two tasks with totally separate modules and flows"""
-        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
-        task2 = self.create_task("task2", mod_suffixes=["B", "B"])
+        task1 = self.create_task("task1", module_suffixes=["A", "A"])
+        task2 = self.create_task("task2", module_suffixes=["B", "B"])
         model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
@@ -65,8 +65,8 @@ class TaskTest(unittest.TestCase):
 
     def test_twotask_partial_overlap_model(self):
         """Add two tasks with overlapping modules and flows"""
-        task1 = self.create_task("task1", mod_suffixes=["A", "A"])
-        task2 = self.create_task("task2", mod_suffixes=["A", "B"])
+        task1 = self.create_task("task1", module_suffixes=["A", "A"])
+        task2 = self.create_task("task2", module_suffixes=["A", "B"])
         model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)

--- a/test/mtl/test_trainer.py
+++ b/test/mtl/test_trainer.py
@@ -1,0 +1,129 @@
+import random
+import unittest
+from functools import partial
+
+import numpy as np
+import torch
+import torch.nn as nn
+
+from snorkel.mtl.data import MultitaskDataLoader, MultitaskDataset
+from snorkel.mtl.model import MultitaskModel
+from snorkel.mtl.modules.utils import ce_loss, softmax
+from snorkel.mtl.scorer import Scorer
+from snorkel.mtl.task import Task
+from snorkel.mtl.trainer import Trainer
+
+SEED = 123
+
+
+class TrainerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.trainer_config = {"n_epochs": 2, "progress_bar": False}
+        cls.logger_config = {"counter_unit": "epochs", "evaluation_freq": 0.25}
+
+    def test_trainer_onetask(self):
+        """Train a single-task model"""
+        set_seed(SEED)
+        task1 = create_task("task1", module_suffixes=["A", "A"])
+        model = MultitaskModel(name="MyOneTaskModel", tasks=[task1])
+        dataloaders = create_dataloaders(num_tasks=1)
+        scores = model.score(dataloaders)
+        self.assertLess(scores["task1/TestData/test/accuracy"], 0.7)
+        trainer = Trainer(**self.trainer_config, **self.logger_config)
+        trainer.train_model(model, dataloaders)
+        scores = model.score(dataloaders)
+        self.assertGreater(scores["task1/TestData/test/accuracy"], 0.9)
+
+    def test_trainer_twotask(self):
+        """Train a model with overlapping modules and flows"""
+        task1 = create_task("task1", module_suffixes=["A", "A"])
+        task2 = create_task("task2", module_suffixes=["A", "B"])
+        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        dataloaders = create_dataloaders(num_tasks=2)
+        scores = model.score(dataloaders)
+        self.assertLess(scores["task1/TestData/test/accuracy"], 0.7)
+        self.assertLess(scores["task2/TestData/test/accuracy"], 0.7)
+        trainer = Trainer(**self.trainer_config, **self.logger_config)
+        trainer.train_model(model, dataloaders)
+        scores = model.score(dataloaders)
+        self.assertGreater(scores["task1/TestData/test/accuracy"], 0.9)
+        self.assertGreater(scores["task2/TestData/test/accuracy"], 0.9)
+
+
+def set_seed(seed):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+
+def create_dataloaders(num_tasks=1):
+    n = 1200
+
+    X = np.random.random((n, 2)) * 2 - 1
+    Y = np.zeros((n, 2))
+    Y[:, 0] = (X[:, 0] > X[:, 1] + 0.5).astype(int) + 1
+    Y[:, 1] = (X[:, 0] > X[:, 1] + 0.25).astype(int) + 1
+
+    X = torch.tensor(X, dtype=torch.float)
+    Y = torch.tensor(Y, dtype=torch.long)
+
+    Xs = [X[:1000], X[1000:1100], X[1100:]]
+    Ys = [Y[:1000], Y[1000:1100], Y[1100:]]
+
+    dataloaders = []
+    splits = ["train", "valid", "test"]
+    for X_split, Y_split, split in zip(Xs, Ys, splits):
+
+        Y_dict = {"task1_labels": Y_split[:, 0]}
+        task_to_label_dict = {"task1": "task1_labels"}
+        if num_tasks == 2:
+            Y_dict["task2_labels"] = Y_split[:, 1]
+            task_to_label_dict["task2"] = "task2_labels"
+
+        dataset = MultitaskDataset(
+            name="TestData", X_dict={"coordinates": X_split}, Y_dict=Y_dict
+        )
+
+        dataloader = MultitaskDataLoader(
+            task_to_label_dict=task_to_label_dict,
+            dataset=dataset,
+            split=split,
+            batch_size=4,
+            shuffle=(split == "train"),
+        )
+        dataloaders.append(dataloader)
+    return dataloaders
+
+
+def create_task(task_name, module_suffixes):
+    module_pool = nn.ModuleDict(
+        {
+            f"linear1{module_suffixes[0]}": nn.Linear(2, 10),
+            f"linear2{module_suffixes[1]}": nn.Linear(10, 2),
+        }
+    )
+
+    task_flow = [
+        {
+            "name": "first_layer",
+            "module": f"linear1{module_suffixes[0]}",
+            "inputs": [("_input_", "coordinates")],
+        },
+        {
+            "name": "second_layer",
+            "module": f"linear2{module_suffixes[1]}",
+            "inputs": [("first_layer", 0)],
+        },
+    ]
+
+    task = Task(
+        name=task_name,
+        module_pool=module_pool,
+        task_flow=task_flow,
+        loss_func=partial(ce_loss, "second_layer"),
+        output_func=partial(softmax, "second_layer"),
+        scorer=Scorer(metrics=["accuracy"]),
+    )
+
+    return task


### PR DESCRIPTION
This PR includes:
- (Primary) Adds the Trainer class which operates on a model and dataloaders
- A little cleanup of other pieces that touch training (see commit messages). This includes adjusting the defaults so that by default no logs or checkpoints are written (so users' workspaces aren't spammed with logs if they don't want them)


**Test plan**
Unit tests build a single-task model and multi-task model and confirms that for both, the initial accuracy is below a threshold and final accuracy is above a threshold, confirming both that the model trained and that we're successfully evaluating/returning scores. We set random seeds so that each run is deterministic (i.e., there won't be rare outlier runs that spontaneously fail the unit test).
