### PR TITLE
[EASY] Fix .venv -> .env refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = '''
   | \.git
   | \.mypy_cache
   | \.tox
-  | \.venv
+  | \.env
   | _build
   | build
   | dist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ exclude = '''
   | \.mypy_cache
   | \.tox
   | \.env
+  | \.venv
   | _build
   | build
   | dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ exclude =
     .mypy_cache,
     .tox,
     .env,
+    .venv,
     _build,
     build,
     dist

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ exclude =
     .git,
     .mypy_cache,
     .tox,
-    .venv,
+    .env,
     _build,
     build,
     dist


### PR DESCRIPTION
Fix a bug introduced in #1144 where tox creates '.env' but black and isort ignore '.venv'