### PR TITLE
Refactor configs/loggers to enable SuperGLUE

### DIFF
--- a/snorkel/mtl/loggers/__init__.py
+++ b/snorkel/mtl/loggers/__init__.py
@@ -1,0 +1,4 @@
+from .checkpointer import Checkpointer  # noqa: F401
+from .log_manager import LogManager  # noqa: F401
+from .log_writer import LogWriter  # noqa: F401
+from .tensorboard_writer import TensorBoardWriter  # noqa: F401

--- a/snorkel/mtl/loggers/checkpointer.py
+++ b/snorkel/mtl/loggers/checkpointer.py
@@ -85,7 +85,7 @@ class Checkpointer(object):
         checkpoint_dir = f"{self.checkpoint_dir}/checkpoint_{iteration}.pth"
         torch.save(state_dict, checkpoint_dir)
         logging.info(
-            f"Save checkpoint of {iteration} {self.checkpoint_unit} "
+            f"Save checkpoint at {iteration} {self.checkpoint_unit} "
             f"at {checkpoint_dir}."
         )
 

--- a/snorkel/mtl/loggers/checkpointer.py
+++ b/snorkel/mtl/loggers/checkpointer.py
@@ -6,23 +6,33 @@ from typing import Dict, List
 
 import torch
 
-from snorkel.types import Config
+from snorkel.mtl.snorkel_config import default_config
+from snorkel.mtl.utils import recursive_merge_dicts
 
 
 class Checkpointer(object):
     """Checkpointing Training logging class to log train infomation"""
 
-    def __init__(self, config: Config):
+    def __init__(self, **kwargs):
 
-        self.logging_config = config
-        self.config = config["checkpointer_config"]
+        # Checkpointer requires both checkpointer_config and log_manager_config
+        checkpointer_config = recursive_merge_dicts(
+            default_config["checkpointer_config"],
+            default_config["log_manager_config"],
+            misses="insert",
+        )
+        self.config = recursive_merge_dicts(checkpointer_config, kwargs)
 
         # Pull out checkpoint settings
-        self.checkpoint_unit = self.logging_config["counter_unit"]
         self.checkpoint_dir = self.config["checkpoint_dir"]
+        self.checkpoint_unit = self.config["counter_unit"]
         self.checkpoint_clear = self.config["checkpoint_clear"]
         self.checkpoint_runway = self.config["checkpoint_runway"]
+        self.checkpoint_factor = self.config["checkpoint_factor"]
         self.checkpoint_condition_met = False
+
+        if self.checkpoint_dir is None:
+            raise Exception("Checkpointing is on but no checkpoint_dir was specified.")
 
         # Collect all metrics to checkpoint
         self.checkpoint_metric = self._make_metric_map(
@@ -39,7 +49,7 @@ class Checkpointer(object):
 
         # Set checkpoint frequency
         self.checkpoint_freq = (
-            self.logging_config["evaluation_freq"] * self.config["checkpoint_factor"]
+            self.config["evaluation_freq"] * self.config["checkpoint_factor"]
         )
         if self.checkpoint_freq <= 0:
             raise ValueError(

--- a/snorkel/mtl/loggers/checkpointer.py
+++ b/snorkel/mtl/loggers/checkpointer.py
@@ -16,11 +16,8 @@ class Checkpointer(object):
     def __init__(self, **kwargs):
 
         # Checkpointer requires both checkpointer_config and log_manager_config
-        checkpointer_config = recursive_merge_dicts(
-            default_config["checkpointer_config"],
-            default_config["log_manager_config"],
-            misses="insert",
-        )
+        checkpointer_config = default_config["checkpointer_config"]
+        checkpointer_config.update(default_config["log_manager_config"])
         self.config = recursive_merge_dicts(checkpointer_config, kwargs)
 
         # Pull out checkpoint settings
@@ -32,7 +29,7 @@ class Checkpointer(object):
         self.checkpoint_condition_met = False
 
         if self.checkpoint_dir is None:
-            raise Exception("Checkpointing is on but no checkpoint_dir was specified.")
+            raise ValueError("Checkpointing is on but no checkpoint_dir was specified.")
 
         # Collect all metrics to checkpoint
         self.checkpoint_metric = self._make_metric_map(
@@ -48,9 +45,7 @@ class Checkpointer(object):
             os.makedirs(self.checkpoint_dir)
 
         # Set checkpoint frequency
-        self.checkpoint_freq = (
-            self.config["evaluation_freq"] * self.config["checkpoint_factor"]
-        )
+        self.checkpoint_freq = self.config["evaluation_freq"] * self.checkpoint_factor
         if self.checkpoint_freq <= 0:
             raise ValueError(
                 f"Invalid checkpoint freq {self.checkpoint_freq}, "

--- a/snorkel/mtl/loggers/log_manager.py
+++ b/snorkel/mtl/loggers/log_manager.py
@@ -1,7 +1,12 @@
 import logging
+from typing import Any, Optional
 
+from snorkel.mtl.model import MultitaskModel
 from snorkel.mtl.snorkel_config import default_config
 from snorkel.mtl.utils import recursive_merge_dicts
+
+from .checkpointer import Checkpointer
+from .log_writer import LogWriter
 
 
 class LogManager(object):
@@ -14,7 +19,11 @@ class LogManager(object):
     """
 
     def __init__(
-        self, n_batches_per_epoch: int, log_writer=None, checkpointer=None, **kwargs
+        self,
+        n_batches_per_epoch: int,
+        log_writer: Optional[LogWriter] = None,
+        checkpointer: Optional[Checkpointer] = None,
+        **kwargs: Any,
     ) -> None:
 
         self.config = recursive_merge_dicts(
@@ -100,7 +109,7 @@ class LogManager(object):
         self.epoch_count = 0
         self.unit_count = 0
 
-    def close(self, model):
+    def close(self, model: MultitaskModel) -> MultitaskModel:
         if self.log_writer is not None:
             self.log_writer.close()
         if self.checkpointer is not None:

--- a/snorkel/mtl/loggers/log_manager.py
+++ b/snorkel/mtl/loggers/log_manager.py
@@ -1,31 +1,7 @@
 import logging
-import os
-from datetime import datetime
-from typing import Dict
 
-import torch
-
+from snorkel.mtl.snorkel_config import default_config
 from snorkel.mtl.utils import recursive_merge_dicts
-
-from .checkpointer import Checkpointer
-from .log_writer import LogWriter
-from .tensorboard_writer import TensorBoardWriter
-
-logger_default_config = {
-    "log_dir": "logs",  # The path to the directory under which logs will be written
-    "counter_unit": "batches",  # [points, batches, epochs]
-    "evaluation_freq": 2,  # Evaluate performance every this many counter_units
-    "writer_config": {"writer": None, "verbose": True},  # [json, tensorboard]
-    "checkpointing": False,
-    "checkpointer_config": {
-        "checkpoint_dir": None,
-        "checkpoint_factor": 1,  # Checkpoint every this many evaluations
-        "checkpoint_metric": "model/train/all/loss:min",
-        "checkpoint_task_metrics": None,  # task_metric_name:mode
-        "checkpoint_runway": 0,  # checkpointing runway (no checkpointing before k unit)
-        "checkpoint_clear": True,  # whether to clear intermediate checkpoints
-    },
-}
 
 
 class LogManager(object):
@@ -37,17 +13,17 @@ class LogManager(object):
     :type verbose: bool
     """
 
-    def __init__(self, n_batches_per_epoch: int, **kwargs) -> None:
+    def __init__(
+        self, n_batches_per_epoch: int, log_writer=None, checkpointer=None, **kwargs
+    ) -> None:
 
-        self.config = recursive_merge_dicts(logger_default_config, kwargs)
+        self.config = recursive_merge_dicts(
+            default_config["log_manager_config"], kwargs
+        )
         self.n_batches_per_epoch = n_batches_per_epoch
 
-        # Create log directory for this run
-        date = datetime.now().strftime("%Y_%m_%d")
-        time = datetime.now().strftime("%H_%M_%S")
-        self.log_path = os.path.join(self.config["log_dir"], date, time)
-        if not os.path.exists(self.log_path):
-            os.makedirs(self.log_path)
+        self.log_writer = log_writer
+        self.checkpointer = checkpointer
 
         # Set up counter unit
         self.counter_unit = self.config["counter_unit"]
@@ -57,10 +33,6 @@ class LogManager(object):
         # Set up evaluation frequency
         self.evaluation_freq = self.config["evaluation_freq"]
         logging.info(f"Evaluating every {self.evaluation_freq} {self.counter_unit}.")
-
-        # Set up writer and checkpointer
-        self._init_writer()
-        self._init_checkpointer()
 
         # Set up number of X passed since last evaluation/checkpointing and total
         self.point_count = 0
@@ -114,9 +86,9 @@ class LogManager(object):
 
     def trigger_checkpointing(self) -> bool:
         """Check if triggers the checkpointing"""
-        if not self.checkpointing:
+        if self.checkpointer is None:
             return False
-        satisfied = self.trigger_count >= self.checkpointing_freq
+        satisfied = self.trigger_count >= self.checkpointer.checkpoint_factor
         if satisfied:
             self.trigger_count = 0
         return satisfied
@@ -128,62 +100,10 @@ class LogManager(object):
         self.epoch_count = 0
         self.unit_count = 0
 
-    def write_log(self, metric_dict: Dict[str, float]) -> None:
-        if self.writer:
-            for metric_name, metric_value in metric_dict.items():
-                self.writer.add_scalar(metric_name, metric_value, self.batch_total)
-
-    def checkpoint_model(
-        self,
-        model,
-        optimizer: torch.optim.Optimizer,
-        lr_scheduler: torch.optim.lr_scheduler,
-        metric_dict: Dict[str, str],
-    ) -> None:
-        self.checkpointer.checkpoint(
-            self.unit_total, model, optimizer, lr_scheduler, metric_dict
-        )
-
     def close(self, model):
-        if self.writer:
-            self.writer.close()
-        if self.checkpointing:
+        if self.log_writer is not None:
+            self.log_writer.close()
+        if self.checkpointer is not None:
             self.checkpointer.clear()
             model = self.checkpointer.load_best_model(model)
         return model
-
-    def _init_checkpointer(self) -> None:
-        if self.config["checkpointing"]:
-            self.checkpointing = True
-
-            # Set up checkpointing frequency
-            self.checkpointing_freq = int(
-                self.config["checkpointer_config"]["checkpoint_factor"]
-            )
-            logging.info(
-                f"Checkpointing every "
-                f"{self.checkpointing_freq * self.evaluation_freq} {self.counter_unit}."
-            )
-
-            if not self.config["checkpointer_config"]["checkpoint_dir"]:
-                self.config["checkpointer_config"]["checkpoint_dir"] = os.path.join(
-                    self.log_path, "checkpoints"
-                )
-
-            # Set up checkpointer
-            self.checkpointer = Checkpointer(self.config)
-        else:
-            self.checkpointing = False
-            logging.info("No checkpointing.")
-
-    def _init_writer(self) -> None:
-        writer_opt = self.config["writer_config"]["writer"]
-
-        if writer_opt is None:
-            self.writer = None
-        elif writer_opt == "json":
-            self.writer = LogWriter(self.log_path)
-        elif writer_opt == "tensorboard":
-            self.writer = TensorBoardWriter(self.log_path)
-        else:
-            raise ValueError(f"Unrecognized writer option '{writer_opt}'")

--- a/snorkel/mtl/loggers/log_writer.py
+++ b/snorkel/mtl/loggers/log_writer.py
@@ -1,6 +1,10 @@
 import json
 import os
 from collections import defaultdict
+from datetime import datetime
+
+from snorkel.mtl.snorkel_config import default_config
+from snorkel.mtl.utils import recursive_merge_dicts
 
 
 class LogWriter:
@@ -10,8 +14,18 @@ class LogWriter:
     :type object: [type]
     """
 
-    def __init__(self, log_dir):
-        self.log_dir = log_dir
+    def __init__(self, **kwargs):
+        self.config = recursive_merge_dicts(default_config["log_writer_config"], kwargs)
+
+        date = datetime.now().strftime("%Y_%m_%d")
+        time = datetime.now().strftime("%H_%M_%S")
+        self.run_name = self.config["run_name"] or f"{date}/{time}/"
+
+        self.log_root = self.config["log_root"]
+        self.log_dir = os.path.join(self.log_root, self.run_name)
+        if not os.path.exists(self.log_dir):
+            os.makedirs(self.log_dir)
+
         self.run_log = defaultdict(list)
 
     def add_scalar(self, name, value, step):
@@ -19,16 +33,29 @@ class LogWriter:
         self.run_log[name].append((step, value))
 
     def write_config(self, config, config_filename="config.json"):
-        """Dump the config to file"""
-        config_path = os.path.join(self.log_dir, config_filename)
-        with open(config_path, "w") as f:
-            json.dump(config, f)
+        """Dump the config to file
 
-    def write_log(self, log_filename="log.json"):
+        This gets a special method for children classes that add functionality
+        """
+        self.write_json(config, config_filename)
+
+    def write_log(self, log_filename):
+        """Dump the run log to file"""
+        self.write_json(self.run_log, log_filename)
+
+    def write_text(self, text, filename):
+        """Dump user-provided text to filename (e.g., the launch command)"""
+        text_path = os.path.join(self.log_dir, filename)
+        with open(text_path, "w") as f:
+            f.write(text)
+
+    def write_json(self, dict_to_write, filename):
         """Dump the log to file"""
-        log_path = os.path.join(self.log_dir, log_filename)
+        if not filename.endswith(".json"):
+            filename += ".json"
+        log_path = os.path.join(self.log_dir, filename)
         with open(log_path, "w") as f:
-            json.dump(self.run_log, f)
+            json.dump(dict_to_write, f)
 
     def close(self):
         pass

--- a/snorkel/mtl/loggers/log_writer.py
+++ b/snorkel/mtl/loggers/log_writer.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from collections import defaultdict
 from datetime import datetime
@@ -8,11 +9,7 @@ from snorkel.mtl.utils import recursive_merge_dicts
 
 
 class LogWriter:
-    """A class for logging during training process.
-
-    :param object: [description]
-    :type object: [type]
-    """
+    """A class for writing logs"""
 
     def __init__(self, **kwargs):
         self.config = recursive_merge_dicts(default_config["log_writer_config"], kwargs)
@@ -52,7 +49,9 @@ class LogWriter:
     def write_json(self, dict_to_write, filename):
         """Dump the log to file"""
         if not filename.endswith(".json"):
-            filename += ".json"
+            logging.warning(
+                f"Using write_json() method with a filename without a .json extension: {filename}"
+            )
         log_path = os.path.join(self.log_dir, filename)
         with open(log_path, "w") as f:
             json.dump(dict_to_write, f)

--- a/snorkel/mtl/loggers/tensorboard_writer.py
+++ b/snorkel/mtl/loggers/tensorboard_writer.py
@@ -17,9 +17,9 @@ class TensorBoardWriter(LogWriter):
         self.writer.add_scalar(name, value, step)
 
     def write_config(self, config: Config, config_filename: str = "config.json"):
-        """Dump the config to file"""
+        """Dump the config to file and add it to TensorBoard"""
         super().write_config(config, config_filename)
-        self.writer.add_text(tag="config", text_string=f"{config}")
+        self.writer.add_text(tag="config", text_string=str(config))
 
     def close(self):
         self.writer.close()

--- a/snorkel/mtl/loggers/tensorboard_writer.py
+++ b/snorkel/mtl/loggers/tensorboard_writer.py
@@ -8,9 +8,9 @@ from .log_writer import LogWriter
 class TensorBoardWriter(LogWriter):
     """A class for logging to Tensorboard during training process."""
 
-    def __init__(self, log_dir):
-        super().__init__(log_dir)
-        self.writer = SummaryWriter(log_dir)
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.writer = SummaryWriter(self.log_dir)
 
     def add_scalar(self, name, value, step):
         """Log a scalar variable"""
@@ -19,7 +19,7 @@ class TensorBoardWriter(LogWriter):
     def write_config(self, config: Config, config_filename: str = "config.json"):
         """Dump the config to file"""
         super().write_config(config, config_filename)
-        self.writer.add_text(tag="config", text_string=config)
+        self.writer.add_text(tag="config", text_string=f"{config}")
 
     def close(self):
         self.writer.close()

--- a/snorkel/mtl/model.py
+++ b/snorkel/mtl/model.py
@@ -20,12 +20,12 @@ class MultitaskModel(nn.Module):
     :param tasks: a list of Tasks to be trained jointly
     """
 
-    def __init__(self, name: str, tasks: List[Task], **kwargs) -> None:
+    def __init__(self, tasks: List[Task], name=None, **kwargs) -> None:
         super().__init__()
         self.config = recursive_merge_dicts(
             default_config["model_config"], kwargs, misses="insert"
         )
-        self.name = name if name is not None else type(self).__name__
+        self.name = name or type(self).__name__
 
         # Initiate the model attributes
         self.module_pool = nn.ModuleDict()

--- a/snorkel/mtl/model.py
+++ b/snorkel/mtl/model.py
@@ -2,7 +2,7 @@ import logging
 import os
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -20,7 +20,9 @@ class MultitaskModel(nn.Module):
     :param tasks: a list of Tasks to be trained jointly
     """
 
-    def __init__(self, tasks: List[Task], name=None, **kwargs) -> None:
+    def __init__(
+        self, tasks: List[Task], name: Optional[str] = None, **kwargs: Any
+    ) -> None:
         super().__init__()
         self.config = recursive_merge_dicts(
             default_config["model_config"], kwargs, misses="insert"
@@ -60,7 +62,7 @@ class MultitaskModel(nn.Module):
             else:
                 logging.info("No cuda device available. Switch to cpu instead.")
 
-    def _build_network(self, tasks: List[Task]):
+    def _build_network(self, tasks: List[Task]) -> None:
         """Build the MTL network using all tasks"""
 
         if not isinstance(tasks, Iterable):

--- a/snorkel/mtl/snorkel_config.py
+++ b/snorkel/mtl/snorkel_config.py
@@ -1,0 +1,50 @@
+default_config = {
+    "n_epochs": 1,  # total number of learning epochs
+    "train_split": "train",  # the split for training, accepts str or list of strs
+    "valid_split": "valid",  # the split for validation, accepts str or list of strs
+    "test_split": "test",  # the split for testing, accepts str or list of strs
+    "progress_bar": True,
+    "model_config": {
+        "model_path": None,  # the path to a saved checkpoint to initialize with
+        "device": 0,  # gpu id (int) or -1 for cpu
+        "dataparallel": True,
+    },
+    "log_manager_config": {
+        "counter_unit": "epochs",  # [points, batches, epochs]
+        "evaluation_freq": 0.25,  # Evaluate performance every this many counter_units
+    },
+    "checkpointing": False,  # Whether to save checkpoints of best performing models
+    "checkpointer_config": {  # Note that checkpointer behavior also depends on log_manager_config
+        "checkpoint_dir": None,  # Trainer will set this to log_dir if None
+        "checkpoint_factor": 1,  # Checkpoint every this many evaluations
+        "checkpoint_metric": "model/train/all/loss:min",
+        "checkpoint_task_metrics": None,  # task_metric_name:mode
+        "checkpoint_runway": 0,  # checkpointing runway (no checkpointing before k unit)
+        "checkpoint_clear": True,  # whether to clear intermediate checkpoints
+    },
+    "logging": False,  # Whether to write logs (to json/tensorboard)
+    "log_writer_config": {
+        "writer": "tensorboard",  # [json, tensorboard]
+        "log_root": "logs",  # The path to the root of the directory where logs are written
+        "run_name": None,  # The name of this particular run (default to date/time)
+    },
+    "optimizer_config": {
+        "optimizer": "adam",  # [sgd, adam]
+        "lr": 0.001,  # learing rate
+        "l2": 0.0,  # l2 regularization
+        "grad_clip": 1.0,  # gradient clipping
+        "sgd_config": {"momentum": 0.9},
+        "adam_config": {"betas": (0.9, 0.999), "amsgrad": False},
+        "adamax_config": {"betas": (0.9, 0.999), "eps": 0.00000001},
+    },
+    "lr_scheduler_config": {
+        "lr_scheduler": "constant",  # [constant, linear, exponential, step, multi_step, reduce_on_plateau]
+        "warmup_steps": 0,  # warm up steps
+        "warmup_unit": "batches",  # [epochs, batches]
+        "warmup_percentage": 0.0,  # warm up percentage
+        "min_lr": 0.0,  # minimum learning rate
+        "exponential_config": {"gamma": 0.9},
+        "plateau_config": {"factor": 0.5, "patience": 10, "threshold": 0.0001},
+    },
+    "task_scheduler": "shuffled",  # [sequential, shuffled]
+}

--- a/snorkel/mtl/utils.py
+++ b/snorkel/mtl/utils.py
@@ -92,6 +92,7 @@ def recursive_merge_dicts(x, y, misses="report", verbose=None):
     Merge dictionary y into a copy of x, overwriting elements of x when there
     is a conflict, except if the element is a dictionary, in which case recurse.
 
+    # TODO: Make misses an Enum
     misses: what to do if a key in y is not in x
         'insert'    -> set x[key] = value
         'exception' -> raise an exception

--- a/test/mtl/loggers/test_log_manager.py
+++ b/test/mtl/loggers/test_log_manager.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import unittest
 
+from snorkel.mtl.loggers.checkpointer import Checkpointer
 from snorkel.mtl.loggers.log_manager import LogManager
 
 TEST_LOG_DIR = "test/mtl/loggers/logs"
@@ -19,31 +20,31 @@ class TestLogManager(unittest.TestCase):
             shutil.rmtree(TEST_LOG_DIR)
 
     def test_log_manager_points(self) -> None:
-        config = {
-            "log_dir": TEST_LOG_DIR,
-            "counter_unit": "points",
-            "evaluation_freq": 10,
-            "checkpointing": True,
-            "checkpointer_config": {"checkpoint_factor": 2},
-        }
+        """Unit test of log_manager (points)"""
+        log_manager_config = {"counter_unit": "points", "evaluation_freq": 10}
 
-        log_manager = LogManager(n_batches_per_epoch=10, **config)
-
-        log_manager.update(5)
-        assert log_manager.trigger_evaluation() is False
-        assert log_manager.trigger_checkpointing() is False
+        checkpointer = Checkpointer(
+            checkpoint_dir=TEST_LOG_DIR, checkpoint_factor=2, **log_manager_config
+        )
+        log_manager = LogManager(
+            n_batches_per_epoch=10, checkpointer=checkpointer, **log_manager_config
+        )
 
         log_manager.update(5)
-        assert log_manager.trigger_evaluation() is True
-        assert log_manager.trigger_checkpointing() is False
+        self.assertFalse(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
+
+        log_manager.update(5)
+        self.assertTrue(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
 
         log_manager.update(10)
-        assert log_manager.trigger_evaluation() is True
-        assert log_manager.trigger_checkpointing() is True
+        self.assertTrue(log_manager.trigger_evaluation())
+        self.assertTrue(log_manager.trigger_checkpointing())
 
         log_manager.update(5)
-        assert log_manager.trigger_evaluation() is False
-        assert log_manager.trigger_checkpointing() is False
+        self.assertFalse(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
 
         assert log_manager.point_count == 5
         assert log_manager.point_total == 25
@@ -52,31 +53,30 @@ class TestLogManager(unittest.TestCase):
 
     def test_log_manager_batch(self) -> None:
         """Unit test of log_manager (batches)"""
+        log_manager_config = {"counter_unit": "batches", "evaluation_freq": 2}
 
-        config = {
-            "counter_unit": "batches",
-            "evaluation_freq": 2,
-            "checkpointing": True,
-            "checkpointer_config": {"checkpoint_factor": 2},
-        }
-
-        log_manager = LogManager(n_batches_per_epoch=5, **config)
-
-        log_manager.update(5)
-        assert log_manager.trigger_evaluation() is False
-        assert log_manager.trigger_checkpointing() is False
+        checkpointer = Checkpointer(
+            checkpoint_dir=TEST_LOG_DIR, checkpoint_factor=2, **log_manager_config
+        )
+        log_manager = LogManager(
+            n_batches_per_epoch=5, checkpointer=checkpointer, **log_manager_config
+        )
 
         log_manager.update(5)
-        assert log_manager.trigger_evaluation() is True
-        assert log_manager.trigger_checkpointing() is False
+        self.assertFalse(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
+
+        log_manager.update(5)
+        self.assertTrue(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
 
         log_manager.update(10)
-        assert log_manager.trigger_evaluation() is False
-        assert log_manager.trigger_checkpointing() is False
+        self.assertFalse(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
 
         log_manager.update(5)
-        assert log_manager.trigger_evaluation() is True
-        assert log_manager.trigger_checkpointing() is True
+        self.assertTrue(log_manager.trigger_evaluation())
+        self.assertTrue(log_manager.trigger_checkpointing())
 
         assert log_manager.batch_count == 0
         assert log_manager.point_total == 25
@@ -85,26 +85,26 @@ class TestLogManager(unittest.TestCase):
 
     def test_log_manager_epoch(self) -> None:
         """Unit test of log_manager (epochs)"""
-        config = {
-            "counter_unit": "epochs",
-            "evaluation_freq": 1,
-            "checkpointing": True,
-            "checkpointer_config": {"checkpoint_factor": 2},
-        }
+        log_manager_config = {"counter_unit": "epochs", "evaluation_freq": 1}
 
-        log_manager = LogManager(n_batches_per_epoch=2, **config)
+        checkpointer = Checkpointer(
+            checkpoint_dir=TEST_LOG_DIR, checkpoint_factor=2, **log_manager_config
+        )
+        log_manager = LogManager(
+            n_batches_per_epoch=2, checkpointer=checkpointer, **log_manager_config
+        )
 
         log_manager.update(5)
-        assert log_manager.trigger_evaluation() is False
-        assert log_manager.trigger_checkpointing() is False
+        self.assertFalse(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
 
         log_manager.update(5)
         assert log_manager.trigger_evaluation() is True
-        assert log_manager.trigger_checkpointing() is False
+        self.assertFalse(log_manager.trigger_checkpointing())
 
         log_manager.update(10)
-        assert log_manager.trigger_evaluation() is False
-        assert log_manager.trigger_checkpointing() is False
+        self.assertFalse(log_manager.trigger_evaluation())
+        self.assertFalse(log_manager.trigger_checkpointing())
 
         log_manager.update(5)
         assert log_manager.trigger_evaluation() is True

--- a/test/mtl/test_model.py
+++ b/test/mtl/test_model.py
@@ -40,7 +40,7 @@ class TaskTest(unittest.TestCase):
 
     def test_onetask_model(self):
         task1 = self.create_task("task1", module_suffixes=["A", "A"])
-        model = MultitaskModel(name="MyOneTaskModel", tasks=[task1])
+        model = MultitaskModel(tasks=[task1])
         self.assertEqual(len(model.task_names), 1)
         self.assertEqual(len(model.task_flows), 1)
         self.assertEqual(len(model.module_pool), 2)
@@ -49,7 +49,7 @@ class TaskTest(unittest.TestCase):
         """Add two tasks with identical modules and flows"""
         task1 = self.create_task("task1", module_suffixes=["A", "A"])
         task2 = self.create_task("task2", module_suffixes=["A", "A"])
-        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        model = MultitaskModel(tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 2)
@@ -58,7 +58,7 @@ class TaskTest(unittest.TestCase):
         """Add two tasks with totally separate modules and flows"""
         task1 = self.create_task("task1", module_suffixes=["A", "A"])
         task2 = self.create_task("task2", module_suffixes=["B", "B"])
-        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        model = MultitaskModel(tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 4)
@@ -67,7 +67,7 @@ class TaskTest(unittest.TestCase):
         """Add two tasks with overlapping modules and flows"""
         task1 = self.create_task("task1", module_suffixes=["A", "A"])
         task2 = self.create_task("task2", module_suffixes=["A", "B"])
-        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        model = MultitaskModel(tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 3)

--- a/test/mtl/test_model.py
+++ b/test/mtl/test_model.py
@@ -19,10 +19,14 @@ class TaskTest(unittest.TestCase):
         )
 
         task_flow = [
-            {"name": "first_layer", "module": "linear1", "inputs": [("_input_", 0)]},
+            {
+                "name": "first_layer",
+                "module": f"linear1{module_suffixes[0]}",
+                "inputs": [("_input_", 0)],
+            },
             {
                 "name": "second_layer",
-                "module": "linear2",
+                "module": f"linear2{module_suffixes[1]}",
                 "inputs": [("first_layer", 0)],
             },
         ]

--- a/test/mtl/test_trainer.py
+++ b/test/mtl/test_trainer.py
@@ -26,7 +26,7 @@ class TrainerTest(unittest.TestCase):
         """Train a single-task model"""
         set_seed(SEED)
         task1 = create_task("task1", module_suffixes=["A", "A"])
-        model = MultitaskModel(name="MyOneTaskModel", tasks=[task1])
+        model = MultitaskModel(tasks=[task1])
         dataloaders = create_dataloaders(num_tasks=1)
         scores = model.score(dataloaders)
         self.assertLess(scores["task1/TestData/test/accuracy"], 0.7)
@@ -39,7 +39,7 @@ class TrainerTest(unittest.TestCase):
         """Train a model with overlapping modules and flows"""
         task1 = create_task("task1", module_suffixes=["A", "A"])
         task2 = create_task("task2", module_suffixes=["A", "B"])
-        model = MultitaskModel(name="MyTwoTaskModel", tasks=[task1, task2])
+        model = MultitaskModel(tasks=[task1, task2])
         dataloaders = create_dataloaders(num_tasks=2)
         scores = model.score(dataloaders)
         self.assertLess(scores["task1/TestData/test/accuracy"], 0.7)


### PR DESCRIPTION
All refactoring, no new material:

1. All configs (model_config, trainer_config, logger_config, checkpointer_config, etc.) are now found in `snorkel_config.py` for simplicity/cleanliness

2. Untangle Checkpointer, LogManager, and LogWriter for compatibility with SuperGLUE run scripts and general modularity. The LogManager dictates when logging or checkpointing trigger, but the LogWriter and Checkpointer can be now be initialized and used without first instantiating the LogManager.

3. Replace vanilla `assert` statements with unittest `assertTrue` and `assertFalse` for slightly more informative error messages.

**Test plan**
No new material was added. After the refactor, all tests still pass. 
Also, the SuperGLUE application code functions properly after this refactor.