### PR TITLE
[EASY] Standardize set_seed()

### DIFF
--- a/snorkel/model/classifier.py
+++ b/snorkel/model/classifier.py
@@ -1,5 +1,4 @@
 import os
-import random
 
 import numpy as np
 import torch

--- a/snorkel/model/classifier.py
+++ b/snorkel/model/classifier.py
@@ -11,7 +11,7 @@ from torch.utils.data import DataLoader, Dataset, TensorDataset
 from .analysis import confusion_matrix
 from .logging import Checkpointer, Logger, LogWriter, TensorBoardWriter
 from .metrics import metric_score
-from .utils import place_on_gpu, recursive_merge_dicts
+from .utils import place_on_gpu, recursive_merge_dicts, set_seed
 
 # Import tqdm_notebook if in Jupyter notebook
 try:
@@ -65,7 +65,8 @@ class Classifier(nn.Module):
         # Set random seed
         if self.config["seed"] is None:
             self.config["seed"] = np.random.randint(1e6)
-        self._set_seed(self.config["seed"])
+        self.seed = self.config["seed"]
+        set_seed(self.seed)
 
         # Confirm that cuda is available if config is using CUDA
         if self.config["device"] != "cpu" and not torch.cuda.is_available():
@@ -408,15 +409,6 @@ class Classifier(nn.Module):
             return DataLoader(self._create_dataset(*data), **config)
         else:
             raise ValueError("Input data type not recognized.")
-
-    def _set_seed(self, seed):
-        self.seed = seed
-        if self.config["device"] != "cpu":
-            torch.backends.cudnn.enabled = True
-            torch.cuda.manual_seed(seed)
-        torch.manual_seed(seed)
-        np.random.seed(seed)
-        random.seed(seed)
 
     def _set_writer(self, train_config):
         if train_config["writer"] is None:

--- a/snorkel/model/utils.py
+++ b/snorkel/model/utils.py
@@ -509,8 +509,7 @@ def move_to_device(obj, device=-1):
         return obj
 
 
-def set_seed(seed):
-    seed = int(seed)
+def set_seed(seed: int):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)

--- a/snorkel/mtl/utils.py
+++ b/snorkel/mtl/utils.py
@@ -5,12 +5,6 @@ import numpy as np
 import torch
 
 
-def set_seed(seed):
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-
-
 def prob_to_pred(probs):
     """Identify the class with the maximum probability (add 1 since we assume label
     class starts from 1)

--- a/snorkel/mtl/utils.py
+++ b/snorkel/mtl/utils.py
@@ -1,5 +1,4 @@
 import copy
-import random
 
 import numpy as np
 import torch

--- a/test/labeling/model/test_class_balance.py
+++ b/test/labeling/model/test_class_balance.py
@@ -8,7 +8,6 @@ from snorkel.model.utils import set_seed
 
 
 class ClassBalanceModelTest(unittest.TestCase):
-
     def _generate_class_balance(self, k):
         """Generate class balance"""
         p_Y = np.random.random(k)

--- a/test/labeling/model/test_class_balance.py
+++ b/test/labeling/model/test_class_balance.py
@@ -4,12 +4,10 @@ import numpy as np
 import torch
 
 from snorkel.labeling.model.class_balance import ClassBalanceModel
+from snorkel.model.utils import set_seed
 
 
 class ClassBalanceModelTest(unittest.TestCase):
-    def _set_seed(self, seed):
-        torch.manual_seed(seed)
-        np.random.seed(seed)
 
     def _generate_class_balance(self, k):
         """Generate class balance"""
@@ -101,24 +99,24 @@ class ClassBalanceModelTest(unittest.TestCase):
         self._test_model(model, p_Y, C, L=L, tol=1e-2)
 
     def test_class_balance_estimation_2(self):
-        self._set_seed(123)
+        set_seed(123)
         self._test_class_balance_estimation(2, 25)
 
     def test_class_balance_estimation_3(self):
-        self._set_seed(123)
+        set_seed(123)
         self._test_class_balance_estimation(3, 25)
 
     # Note: This should pass! However, commented out because too slow...
     # def test_class_balance_estimation_5(self):
-    #     self._set_seed(123)
+    #     set_seed(123)
     #     self._test_class_balance_estimation(5, 25)
 
     def test_class_balance_estimation_2_abstains(self):
-        self._set_seed(123)
+        set_seed(123)
         self._test_class_balance_estimation(2, 25, abstains=True)
 
     def test_class_balance_estimation_2_noisy(self):
-        self._set_seed(123)
+        set_seed(123)
         self._test_class_balance_estimation_noisy(2, 25, 10000, abstains=True)
 
 

--- a/test/mtl/test_trainer.py
+++ b/test/mtl/test_trainer.py
@@ -5,13 +5,13 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from snorkel.model.utils import set_seed
 from snorkel.mtl.data import MultitaskDataLoader, MultitaskDataset
 from snorkel.mtl.model import MultitaskModel
 from snorkel.mtl.modules.utils import ce_loss, softmax
 from snorkel.mtl.scorer import Scorer
 from snorkel.mtl.task import Task
 from snorkel.mtl.trainer import Trainer
-from snorkel.mtl.utils import set_seed
 
 SEED = 123
 


### PR DESCRIPTION
Method set_seed() was added to mtl.utils and was redefined as a class method in a test and Classifier(). Now all use the version in snorkel.model.utils.