### PR TITLE
Change LambdaMapper signature

### DIFF
--- a/snorkel/augmentation/apply/tf_applier.py
+++ b/snorkel/augmentation/apply/tf_applier.py
@@ -3,14 +3,17 @@ from typing import Any, List
 from tqdm import tqdm
 
 from snorkel.augmentation.policy import AugmentationPolicy
-from snorkel.augmentation.tf import TransformationFunction, TransformationFunctionMode
+from snorkel.augmentation.tf import (
+    BaseTransformationFunction,
+    TransformationFunctionMode,
+)
 from snorkel.types import DataPoint
 
 
 class BaseTFApplier:
     def __init__(
         self,
-        tfs: List[TransformationFunction],
+        tfs: List[BaseTransformationFunction],
         policy: AugmentationPolicy,
         k: int = 1,
         keep_original: bool = True,
@@ -32,7 +35,8 @@ class BaseTFApplier:
             x_t = x
             for tf_idx in self._policy.generate():
                 tf = self._tfs[tf_idx]
-                x_t = tf(x_t)
+                x_t_raw = tf(x_t)
+                x_t = x_t if x_t_raw is None else x_t_raw
             x_transformed.append(x_t)
         return x_transformed
 

--- a/snorkel/augmentation/tf.py
+++ b/snorkel/augmentation/tf.py
@@ -1,5 +1,6 @@
-from snorkel.map import LambdaMapper, Mapper, MapperMode, lambda_mapper
+from snorkel.map import BaseMapper, LambdaMapper, Mapper, MapperMode, lambda_mapper
 
+BaseTransformationFunction = BaseMapper
 TransformationFunction = Mapper
 LambdaTransformationFunction = LambdaMapper
 TransformationFunctionMode = MapperMode

--- a/snorkel/labeling/lf.py
+++ b/snorkel/labeling/lf.py
@@ -2,7 +2,7 @@ from typing import Any, Callable, List, Mapping, Optional, Tuple
 
 from snorkel.types import DataPoint
 
-from .preprocess import Preprocessor, PreprocessorMode
+from .preprocess import BasePreprocessor, PreprocessorMode
 
 
 class LabelingFunction:
@@ -13,7 +13,7 @@ class LabelingFunction:
         label_space: Optional[Tuple[int, ...]] = None,
         schema: Optional[Mapping[str, type]] = None,
         resources: Optional[Mapping[str, Any]] = None,
-        preprocessors: Optional[List[Preprocessor]] = None,
+        preprocessors: Optional[List[BasePreprocessor]] = None,
         fault_tolerant: bool = False,
     ) -> None:
         """Base object for labeling functions, containing metadata and extra
@@ -45,6 +45,8 @@ class LabelingFunction:
     def _preprocess_data_point(self, x: DataPoint) -> DataPoint:
         for preprocessor in self._preprocessors:
             x = preprocessor(x)
+            if x is None:
+                raise ValueError("Preprocessor should not return None")
         return x
 
     def __call__(self, x: DataPoint) -> int:
@@ -70,7 +72,7 @@ class labeling_function:
         label_space: Optional[Tuple[int, ...]] = None,
         schema: Optional[Mapping[str, type]] = None,
         resources: Optional[Mapping[str, Any]] = None,
-        preprocessors: Optional[List[Preprocessor]] = None,
+        preprocessors: Optional[List[BasePreprocessor]] = None,
         fault_tolerant: bool = False,
     ) -> None:
         """Decorator to define a LabelingFunction object from a function

--- a/snorkel/labeling/preprocess/__init__.py
+++ b/snorkel/labeling/preprocess/__init__.py
@@ -1,4 +1,5 @@
 from .core import (  # noqa: F401
+    BasePreprocessor,
     LambdaPreprocessor,
     Preprocessor,
     PreprocessorMode,

--- a/snorkel/labeling/preprocess/core.py
+++ b/snorkel/labeling/preprocess/core.py
@@ -1,5 +1,6 @@
-from snorkel.map import LambdaMapper, Mapper, MapperMode, lambda_mapper
+from snorkel.map import BaseMapper, LambdaMapper, Mapper, MapperMode, lambda_mapper
 
+BasePreprocessor = BaseMapper
 Preprocessor = Mapper
 LambdaPreprocessor = LambdaMapper
 PreprocessorMode = MapperMode

--- a/snorkel/map/__init__.py
+++ b/snorkel/map/__init__.py
@@ -1,1 +1,7 @@
-from .core import LambdaMapper, Mapper, MapperMode, lambda_mapper  # noqa: F401
+from .core import (  # noqa: F401
+    BaseMapper,
+    LambdaMapper,
+    Mapper,
+    MapperMode,
+    lambda_mapper,
+)

--- a/snorkel/synthetic/synthetic_data.py
+++ b/snorkel/synthetic/synthetic_data.py
@@ -4,9 +4,12 @@ from typing import List, Optional, Union
 import numpy as np
 import pandas as pd
 
-from snorkel.augmentation.tf import LambdaTransformationFunction, TransformationFunction
+from snorkel.augmentation.tf import (
+    BaseTransformationFunction,
+    LambdaTransformationFunction,
+)
 from snorkel.labeling.lf import LabelingFunction
-from snorkel.types import DataPoint, FieldMap
+from snorkel.types import DataPoint
 
 
 def generate_mog_dataset(
@@ -62,7 +65,7 @@ def generate_single_feature_lfs(
     input DataPoint x.x.
     """
     if isinstance(dims, int):
-        dims = range(dims)
+        dims = list(range(dims))
     return [
         LabelingFunction(
             f"LF_feature_{i}", partial(lf_template, index=i, abstain_rate=abstain_rate)
@@ -71,14 +74,14 @@ def generate_single_feature_lfs(
     ]
 
 
-def tf_template(x: np.ndarray, i: int) -> FieldMap:
-    x[i] = np.random.rand()
-    return dict(x=x)
+def tf_template(x: DataPoint, i: int) -> DataPoint:
+    x.x[i] = np.random.rand()
+    return x
 
 
 def generate_resampling_tfs(
     dims: Union[int, List[int]]
-) -> List[TransformationFunction]:
+) -> List[BaseTransformationFunction]:
     if isinstance(dims, int):
-        dims = range(dims)
+        dims = list(range(dims))
     return [LambdaTransformationFunction(partial(tf_template, i=i)) for i in dims]

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -1,24 +1,24 @@
 import unittest
 from types import SimpleNamespace
-from typing import Dict
 
 import pandas as pd
 
 from snorkel.augmentation.apply import PandasTFApplier, TFApplier
 from snorkel.augmentation.policy import RandomAugmentationPolicy
 from snorkel.augmentation.tf import transformation_function
-from snorkel.types import FieldMap
+from snorkel.types import DataPoint
 
 
 @transformation_function
-def square(num: int) -> FieldMap:
-    return dict(num=num ** 2)
+def square(x: DataPoint) -> DataPoint:
+    x.num = x.num ** 2
+    return x
 
 
 @transformation_function
-def modify_in_place(d: Dict[str, int]) -> FieldMap:
-    d["my_key"] = 0
-    return dict(d=d)
+def modify_in_place(x: DataPoint) -> DataPoint:
+    x.d["my_key"] = 0
+    return x
 
 
 policy = RandomAugmentationPolicy(1, sequence_length=2)

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -11,12 +11,13 @@ from snorkel.labeling.apply import LFApplier, PandasLFApplier
 from snorkel.labeling.lf import labeling_function
 from snorkel.labeling.preprocess import preprocessor
 from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
-from snorkel.types import DataPoint, FieldMap
+from snorkel.types import DataPoint
 
 
 @preprocessor
-def square(num: float) -> FieldMap:
-    return dict(num_squared=num ** 2)
+def square(x: DataPoint) -> DataPoint:
+    x.num_squared = x.num ** 2
+    return x
 
 
 spacy = SpacyPreprocessor(text_field="text", doc_field="doc")

--- a/test/labeling/test_lf.py
+++ b/test/labeling/test_lf.py
@@ -5,12 +5,18 @@ from typing import List
 
 from snorkel.labeling.lf import LabelingFunction, labeling_function
 from snorkel.labeling.preprocess import PreprocessorMode, preprocessor
-from snorkel.types import DataPoint, FieldMap
+from snorkel.types import DataPoint
 
 
 @preprocessor
-def square(num: float) -> FieldMap:
-    return dict(num=num ** 2)
+def square(x: DataPoint) -> DataPoint:
+    x.num = x.num ** 2
+    return x
+
+
+@preprocessor
+def returns_none(x: DataPoint) -> DataPoint:
+    return None
 
 
 def f(x: DataPoint) -> int:
@@ -62,6 +68,13 @@ class TestLabelingFunctionCore(unittest.TestCase):
         self.assertEqual(lf(x_43), 1)
         self.assertEqual(lf(x_6), 1)
         self.assertEqual(lf(x_2), 0)
+
+    def test_labeling_function_returns_none(self) -> None:
+        lf = LabelingFunction(name="my_lf", f=f, preprocessors=[square, returns_none])
+        lf.set_preprocessor_mode(PreprocessorMode.NAMESPACE)
+        x_43 = SimpleNamespace(num=43)
+        with self.assertRaises(ValueError):
+            lf(x_43)
 
     def test_labeling_function_serialize(self) -> None:
         db = [3, 6, 43]

--- a/tutorials/drybell/nlp_lf.py
+++ b/tutorials/drybell/nlp_lf.py
@@ -18,7 +18,7 @@ from snorkel.labeling.apply.lf_applier_spark import SparkLFApplier
 from snorkel.labeling.lf import labeling_function
 from snorkel.labeling.preprocess import preprocessor
 from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
-from snorkel.types import DataPoint, FieldMap
+from snorkel.types import DataPoint
 
 logging.basicConfig(level=logging.INFO)
 
@@ -40,8 +40,9 @@ DATA = [
 
 
 @preprocessor
-def combine_text_preprocessor(title: str, body: str) -> FieldMap:
-    return dict(article=f"{title} {body}")
+def combine_text_preprocessor(x: DataPoint) -> DataPoint:
+    x.article = f"{x.title} {x.body}"
+    return x
 
 
 spacy_preprocessor = SpacyPreprocessor("article", "article")

--- a/tutorials/synthetic/synthetic.py
+++ b/tutorials/synthetic/synthetic.py
@@ -44,7 +44,7 @@ plt.show()
 m = 4
 tfs = generate_resampling_tfs(list(range(d, d + n_noise_dim)))
 policy = RandomAugmentationPolicy(len(tfs), sequence_length=1)
-tf_applier = PandasTFApplier(tfs, policy, k=4, keep_original=True)
+tf_applier = PandasTFApplier(tfs, policy, k=1, keep_original=True)
 data_augmented = tf_applier.apply(data)
 
 


### PR DESCRIPTION
* LambdaMappers (Preprocessors/TFs) are now defined with a function`f: DataPoint -> DataPoint`. This cleans up signatures significantly, and after #1153 shouldn't cause issues cross-data-format.
* LambdaMappers (TFs) can now return None to abstain from transforming, e.g. if there's no possible transformation.

```
@preprocessor
def square(x: DataPoint) -> DataPoint:
    x.num_squared = x.num ** 2
    return x
```

**Test plan**
* Added new unit tests
