### PR TITLE
[EASY] Add slices in place

### DIFF
--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -16,11 +16,12 @@ from .modules.slice_combiner import SliceCombinerModule
 
 
 def add_slice_labels(
-    base_task: Task,
     dataloader: MultitaskDataLoader,
+    base_task: Task,
     slice_labels: csr_matrix,
     slice_names: List[str],
-) -> MultitaskDataLoader:
+) -> None:
+    """Modifies a dataloader in place, adding labels for slice tasks"""
     slice_labels = slice_labels.toarray()
     slice_labels, slice_names = _add_base_slice(slice_labels, slice_names)
     assert slice_labels.shape[1] == len(slice_names)
@@ -43,7 +44,6 @@ def add_slice_labels(
 
         dataloader.task_to_label_dict[ind_task_name] = ind_task_name
         dataloader.task_to_label_dict[pred_task_name] = pred_task_name
-    return dataloader
 
 
 def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task]:

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -65,8 +65,8 @@ class SlicingTest(unittest.TestCase):
         self.assertEqual(S_valid.shape, (N_VALID, len(slicing_functions)))
 
         # Add slice labels
-        dataloaders[0] = add_slice_labels(task1, dataloaders[0], S_train, slice_names)
-        dataloaders[1] = add_slice_labels(task1, dataloaders[1], S_valid, slice_names)
+        add_slice_labels(dataloaders[0], task1, S_train, slice_names)
+        add_slice_labels(dataloaders[1], task1, S_valid, slice_names)
 
         self.assertEqual(len(dataloaders[0].task_to_label_dict), 8)
         self.assertIn("task1", dataloaders[0].task_to_label_dict)


### PR DESCRIPTION
Make it more clear that add_slice_labels() modifies dataloaders in place by not returning anything and by having the dataloader be the first arg.

**Test plan:**
Minor refactor, all tests pass.