### PR TITLE
[EASY] Add missing ReLUs from tests

### DIFF
--- a/snorkel/mtl/data.py
+++ b/snorkel/mtl/data.py
@@ -120,10 +120,10 @@ class MultitaskDataLoader(DataLoader):
     dataset belongs to) information.
 
     :param task_to_label_dict: the task to label mapping where key is the task name and
-    value is the label(s) for that task and should be the key in Y_dict
+    value is the labels for that task and should be the key in Y_dict
     :type task_to_label_dict: dict
     :param dataset: the dataset to construct the dataloader
-    :type dataset: torch.utils.data.Datasetwe
+    :type dataset: torch.utils.data.Dataset
     :param split: the split information, defaults to "train"
     :param split: str, optional
     :param collate_fn: the function that merges a list of samples to form a

--- a/test/mtl/test_model.py
+++ b/test/mtl/test_model.py
@@ -15,7 +15,10 @@ class TaskTest(unittest.TestCase):
         module2_name = f"linear2{module_suffixes[1]}"
 
         module_pool = nn.ModuleDict(
-            {module1_name: nn.Linear(2, 10), module2_name: nn.Linear(10, 2)}
+            {
+                module1_name: nn.Sequential(nn.Linear(2, 10), nn.ReLU()),
+                module2_name: nn.Linear(10, 2),
+            }
         )
 
         op1 = Operation(module_name=module1_name, inputs=[("_input_", "coordinates")])

--- a/test/mtl/test_task.py
+++ b/test/mtl/test_task.py
@@ -13,7 +13,10 @@ TASK_NAME = "TestTask"
 class TaskTest(unittest.TestCase):
     def test_task_creation(self):
         module_pool = nn.ModuleDict(
-            {"linear1": nn.Linear(2, 10), "linear2": nn.Linear(10, 1)}
+            {
+                "linear1": nn.Sequential(nn.Linear(2, 10), nn.ReLU()),
+                "linear2": nn.Linear(10, 1),
+            }
         )
 
         task_flow = [

--- a/test/mtl/test_trainer.py
+++ b/test/mtl/test_trainer.py
@@ -95,7 +95,10 @@ def create_task(task_name, module_suffixes):
     module2_name = f"linear2{module_suffixes[1]}"
 
     module_pool = nn.ModuleDict(
-        {module1_name: nn.Linear(2, 10), module2_name: nn.Linear(10, 2)}
+        {
+            module1_name: nn.Sequential(nn.Linear(2, 10), nn.ReLU()),
+            module2_name: nn.Linear(10, 2),
+        }
     )
 
     op1 = Operation(module_name=module1_name, inputs=[("_input_", "coordinates")])

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -151,7 +151,10 @@ def create_task(task_name, module_suffixes):
     module2_name = f"linear2{module_suffixes[1]}"
 
     module_pool = nn.ModuleDict(
-        {module1_name: nn.Linear(2, 10), module2_name: nn.Linear(10, 2)}
+        {
+            module1_name: nn.Sequential(nn.Linear(2, 10), nn.ReLU()),
+            module2_name: nn.Linear(10, 2),
+        }
     )
 
     op1 = Operation(module_name=module1_name, inputs=[("_input_", "coordinates")])


### PR DESCRIPTION
The networks defined in our tests had linear modules but no activations. This adds activations between the first and second modules. (Also sneak in a docstring typo fix)

Whoever approves, feel free to merge immediately.

**Test plan**
All tests continue to pass, and ReLU shows up when printing the network
![image](https://user-images.githubusercontent.com/12646092/59974125-206ca900-955d-11e9-833b-f3d1a51a1aa7.png)
