### PR TITLE
Fix abstained TF behavior

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ known_third_party=
     setuptools,
     tqdm,
 default_section=THIRDPARTY
+skip=.env,.venv
 
 [mypy-numpy]
 ignore_missing_imports = True

--- a/snorkel/augmentation/apply/tf_applier.py
+++ b/snorkel/augmentation/apply/tf_applier.py
@@ -33,11 +33,15 @@ class BaseTFApplier:
             x_transformed.append(x)
         for _ in range(self._k):
             x_t = x
+            transform_applied = False
             for tf_idx in self._policy.generate():
                 tf = self._tfs[tf_idx]
                 x_t_raw = tf(x_t)
-                x_t = x_t if x_t_raw is None else x_t_raw
-            x_transformed.append(x_t)
+                if x_t_raw is not None:
+                    transform_applied = True
+                    x_t = x_t_raw
+            if transform_applied:
+                x_transformed.append(x_t)
         return x_transformed
 
     def apply(self, data_points: Any, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
* Fixes behavior where all TFs abstain from transforming, in which case we don't output the untransformed example. This is useful for text where e.g. you might not find a synonym to swap and so don't want to duplicate the original example.
* Also removes virtual env from isort

**Test plan**
Added unit test