### PR TITLE
Add testing and typing to analysis.py

### DIFF
--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -1,35 +1,51 @@
 from collections import Counter, defaultdict
+from typing import (
+    Any,
+    Mapping,
+    Tuple,
+    Sequence,
+    List,
+    Union,
+    Optional,
+    Counter as CounterType,
+)
 
 import numpy as np
 import scipy.sparse as sparse
+import torch
 from pandas import DataFrame, Series
 
 from snorkel.model.utils import arraylike_to_numpy
+from snorkel.types import ArrayLike
+
+
+Matrix = Union[np.ndarray, sparse.csr_matrix]
+Tensor = Union[np.ndarray, torch.Tensor]
 
 
 ############################################################
 # Label Matrix Diagnostics
 ############################################################
-def _covered_data_points(L):
+def _covered_data_points(L: Matrix) -> np.ndarray:
     """Returns an indicator vector where ith element = 1 if x_i is labeled by at
     least one LF."""
     return np.ravel(np.where(L.sum(axis=1) != 0, 1, 0))
 
 
-def _overlapped_data_points(L):
+def _overlapped_data_points(L: Matrix) -> np.ndarray:
     """Returns an indicator vector where ith element = 1 if x_i is labeled by
     more than one LF."""
     return np.where(np.ravel((L != 0).sum(axis=1)) > 1, 1, 0)
 
 
-def _conflicted_data_points(L):
+def _conflicted_data_points(L: sparse.spmatrix) -> np.ndarray:
     """Returns an indicator vector where ith element = 1 if x_i is labeled by
     at least two LFs that give it disagreeing labels."""
     m = sparse.diags(np.ravel(L.max(axis=1).todense()))
     return np.ravel(np.max(m @ (L != 0) != L, axis=1).astype(int).todense())
 
 
-def label_coverage(L):
+def label_coverage(L: Matrix) -> float:
     """Returns the **fraction of data points with > 0 (non-zero) labels**
     Args:
         L: an n x m scipy.sparse matrix where L_{i,j} is the label given by the
@@ -38,7 +54,7 @@ def label_coverage(L):
     return _covered_data_points(L).sum() / L.shape[0]
 
 
-def label_overlap(L):
+def label_overlap(L: Matrix) -> float:
     """Returns the **fraction of data points with > 1 (non-zero) labels**
     Args:
         L: an n x m scipy.sparse matrix where L_{i,j} is the label given by the
@@ -47,9 +63,9 @@ def label_overlap(L):
     return _overlapped_data_points(L).sum() / L.shape[0]
 
 
-def label_conflict(L):
+def label_conflict(L: sparse.spmatrix) -> float:
     """Returns the **fraction of data points with conflicting (disagreeing)
-    lablels.**
+    labels.**
     Args:
         L: an n x m scipy.sparse matrix where L_{i,j} is the label given by the
             jth LF to the ith item
@@ -57,7 +73,7 @@ def label_conflict(L):
     return _conflicted_data_points(L).sum() / L.shape[0]
 
 
-def lf_polarities(L):
+def lf_polarities(L: Matrix) -> List[Union[int, List[int]]]:
     """Return the polarities of each LF based on evidence in a label matrix.
 
     Args:
@@ -68,7 +84,7 @@ def lf_polarities(L):
     return [p[0] if len(p) == 1 else p for p in polarities]
 
 
-def lf_coverages(L):
+def lf_coverages(L: Matrix) -> np.ravel:
     """Return the **fraction of data points that each LF labels.**
     Args:
         L: an n x m scipy.sparse matrix where L_{i,j} is the label given by the
@@ -77,7 +93,7 @@ def lf_coverages(L):
     return np.ravel((L != 0).sum(axis=0)) / L.shape[0]
 
 
-def lf_overlaps(L, normalize_by_coverage=False):
+def lf_overlaps(L: Matrix, normalize_by_coverage: bool = False) -> np.ndarray:
     """Return the **fraction of items each LF labels that are also labeled by at
      least one other LF.**
 
@@ -96,7 +112,7 @@ def lf_overlaps(L, normalize_by_coverage=False):
     return np.nan_to_num(overlaps)
 
 
-def lf_conflicts(L, normalize_by_overlaps=False):
+def lf_conflicts(L: sparse.spmatrix, normalize_by_overlaps: bool = False) -> np.ndarray:
     """Return the **fraction of items each LF labels that are also given a
     different (non-abstain) label by at least one other LF.**
 
@@ -116,7 +132,7 @@ def lf_conflicts(L, normalize_by_overlaps=False):
     return np.nan_to_num(conflicts)
 
 
-def lf_empirical_accuracies(L, Y):
+def lf_empirical_accuracies(L: Matrix, Y: ArrayLike) -> np.ndarray:
     """Return the **empirical accuracy** against a set of labels Y (e.g. dev
     set) for each LF.
     Args:
@@ -128,10 +144,15 @@ def lf_empirical_accuracies(L, Y):
     Y = arraylike_to_numpy(Y)
     L = L.toarray()
     X = np.where(L == 0, 0, np.where(L == np.vstack([Y] * L.shape[1]).T, 1, -1))
-    return 0.5 * (X.sum(axis=0) / (L != 0).sum(axis=0) + 1)
+    return np.nan_to_num(0.5 * (X.sum(axis=0) / (L != 0).sum(axis=0) + 1))
 
 
-def lf_summary(L, Y=None, lf_names=None, est_accs=None):
+def lf_summary(
+    L: Matrix,
+    Y: Optional[ArrayLike] = None,
+    lf_names: Optional[Union[List[str], List[int]]] = None,
+    est_accs: Optional[np.ndarray] = None,
+) -> DataFrame:
     """Returns a pandas DataFrame with the various per-LF statistics.
 
     Args:
@@ -177,7 +198,7 @@ def lf_summary(L, Y=None, lf_names=None, est_accs=None):
     return DataFrame(data=d, index=lf_names)[col_names]
 
 
-def single_lf_summary(Y_p, Y=None):
+def single_lf_summary(Y_p: ArrayLike, Y: Optional[Tensor] = None) -> DataFrame:
     """Calculates coverage, overlap, conflicts, and accuracy for a single LF
 
     Args:
@@ -185,10 +206,13 @@ def single_lf_summary(Y_p, Y=None):
         Y: a np.array or torch.Tensor of true labels (if known)
     """
     L = sparse.csr_matrix(arraylike_to_numpy(Y_p).reshape(-1, 1))
-    return lf_summary(L, Y)
+    summary = lf_summary(L, Y)
+    return summary[["Polarity", "Coverage", "Correct", "Incorrect", "Emp. Acc."]]
 
 
-def error_buckets(gold, pred, X=None):
+def error_buckets(
+    gold: ArrayLike, pred: ArrayLike, X: Optional[Sequence[Any]] = None
+) -> Mapping[Tuple[int, int], Any]:
     """Group items by error buckets
 
     Args:
@@ -206,17 +230,22 @@ def error_buckets(gold, pred, X=None):
         buckets[2,1] = false negatives
         buckets[2,2] = true negatives
     """
-    buckets = defaultdict(list)
+    buckets: Mapping[Tuple[int, int], List[Any]] = defaultdict(list)
     gold = arraylike_to_numpy(gold)
     pred = arraylike_to_numpy(pred)
     for i, (y, l) in enumerate(zip(pred, gold)):
         buckets[y, l].append(X[i] if X is not None else i)
-    return buckets
+    return dict(buckets)
 
 
 def confusion_matrix(
-    gold, pred, null_pred=False, null_gold=False, normalize=False, pretty_print=True
-):
+    gold: ArrayLike,
+    pred: ArrayLike,
+    null_pred: bool = False,
+    null_gold: bool = False,
+    normalize: bool = False,
+    pretty_print: bool = True,
+) -> np.ndarray:
     """A shortcut method for building a confusion matrix all at once.
 
     Args:
@@ -242,14 +271,14 @@ def confusion_matrix(
     return mat
 
 
-class ConfusionMatrix(object):
+class ConfusionMatrix:
     """
     An iteratively built abstention-aware confusion matrix with pretty printing
 
     Assumed axes are true label on top, predictions on the side.
     """
 
-    def __init__(self, null_pred=False, null_gold=False):
+    def __init__(self, null_pred: bool = False, null_gold: bool = False) -> None:
         """
         Args:
             null_pred: If True, include the row corresponding to null
@@ -258,17 +287,17 @@ class ConfusionMatrix(object):
                 labels
 
         """
-        self.counter = Counter()
+        self.counter: CounterType = Counter()
         self.mat = None
         self.null_pred = null_pred
         self.null_gold = null_gold
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         if self.mat is None:
             self.compile()
         return str(self.mat)
 
-    def add(self, gold, pred):
+    def add(self, gold: np.ndarray, pred: np.ndarray) -> np.ndarray:
         """
         Args:
             gold: a np.ndarray of gold labels (ints)
@@ -276,7 +305,7 @@ class ConfusionMatrix(object):
         """
         self.counter.update(zip(gold, pred))
 
-    def compile(self, trim=True):
+    def compile(self, trim: bool = True) -> np.ndarray:
         k = max([max(tup) for tup in self.counter.keys()]) + 1  # include 0
 
         mat = np.zeros((k, k), dtype=int)
@@ -291,7 +320,14 @@ class ConfusionMatrix(object):
         self.mat = mat
         return mat
 
-    def display(self, normalize=False, indent=0, spacing=2, decimals=3, mark_diag=True):
+    def display(  # pragma: no cover
+        self,
+        normalize: bool = False,
+        indent: int = 0,
+        spacing: int = 2,
+        decimals: int = 3,
+        mark_diag: bool = True,
+    ):
         mat = self.compile(trim=False)
         m, n = mat.shape
         tab = " " * spacing

--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -12,14 +12,12 @@ from typing import (
 
 import numpy as np
 import scipy.sparse as sparse
-import torch
 from pandas import DataFrame, Series
 
 from snorkel.model.utils import arraylike_to_numpy
 from snorkel.types import ArrayLike
 
 Matrix = Union[np.ndarray, sparse.csr_matrix]
-Tensor = Union[np.ndarray, torch.Tensor]
 
 
 ############################################################
@@ -197,7 +195,7 @@ def lf_summary(
     return DataFrame(data=d, index=lf_names)[col_names]
 
 
-def single_lf_summary(Y_p: ArrayLike, Y: Optional[Tensor] = None) -> DataFrame:
+def single_lf_summary(Y_p: ArrayLike, Y: Optional[ArrayLike] = None) -> DataFrame:
     """Calculates coverage, overlap, conflicts, and accuracy for a single LF
 
     Args:

--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -1,13 +1,13 @@
 from collections import Counter, defaultdict
 from typing import (
     Any,
-    Mapping,
-    Tuple,
-    Sequence,
-    List,
-    Union,
-    Optional,
     Counter as CounterType,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
 )
 
 import numpy as np
@@ -17,7 +17,6 @@ from pandas import DataFrame, Series
 
 from snorkel.model.utils import arraylike_to_numpy
 from snorkel.types import ArrayLike
-
 
 Matrix = Union[np.ndarray, sparse.csr_matrix]
 Tensor = Union[np.ndarray, torch.Tensor]

--- a/snorkel/model/utils.py
+++ b/snorkel/model/utils.py
@@ -4,8 +4,8 @@ import random
 from collections import defaultdict
 
 import numpy as np
-import torch
 import scipy.sparse as sparse
+import torch
 from torch.utils.data import Dataset
 
 from snorkel.types import ArrayLike

--- a/snorkel/model/utils.py
+++ b/snorkel/model/utils.py
@@ -1,13 +1,14 @@
 import argparse
 import copy
 import random
-import warnings
 from collections import defaultdict
 
 import numpy as np
 import torch
-from scipy.sparse import issparse
+import scipy.sparse as sparse
 from torch.utils.data import Dataset
+
+from snorkel.types import ArrayLike
 
 
 class MetalDataset(Dataset):
@@ -66,7 +67,7 @@ def pred_to_prob(Y_h, k):
     return Y_s
 
 
-def arraylike_to_numpy(array_like):
+def arraylike_to_numpy(array_like: ArrayLike) -> np.ndarray:
     """Convert a 1d array-like (e.g,. list, tensor, etc.) to an np.ndarray"""
 
     orig_type = type(array_like)
@@ -76,7 +77,7 @@ def arraylike_to_numpy(array_like):
         pass
     elif isinstance(array_like, list):
         array_like = np.array(array_like)
-    elif issparse(array_like):
+    elif isinstance(array_like, sparse.spmatrix):
         array_like = array_like.toarray()
     elif isinstance(array_like, torch.Tensor):
         array_like = array_like.numpy()
@@ -452,25 +453,6 @@ def padded_tensor(items, pad_idx=0, left_padded=False, max_len=None):
     return output
 
 
-global warnings_given
-warnings_given = set([])
-
-
-def warn_once(self, msg, msg_name=None):
-    """Prints a warning statement just once
-
-    Args:
-        msg: The warning message
-        msg_name: [optional] The name of the warning. If None, the msg_name
-            will be the msg itself.
-    """
-    assert isinstance(msg, str)
-    msg_name = msg_name if msg_name else msg
-    if msg_name not in warnings_given:
-        warnings.warn(msg)
-    warnings_given.add(msg_name)
-
-
 # DEPRECATION: This is replaced by move_to_device
 def place_on_gpu(data):
     """Utility to place data on GPU, where data could be a torch.Tensor, a tuple
@@ -514,5 +496,6 @@ def set_seed(seed: int):
     np.random.seed(seed)
     torch.manual_seed(seed)
     if torch.cuda.is_available():
-        torch.backends.cudnn.enabled = True  # Is this necessary?
-        torch.cuda.manual_seed(seed)
+        # Is this necessary?
+        torch.backends.cudnn.enabled = True  # type: ignore
+        torch.cuda.manual_seed(seed)  # type: ignore

--- a/snorkel/types/__init__.py
+++ b/snorkel/types/__init__.py
@@ -1,2 +1,2 @@
-from .data import DataPoint, DataPoints, Field, FieldMap  # noqa: F401
+from .data import ArrayLike, DataPoint, DataPoints, Field, FieldMap  # noqa: F401
 from .logger import Config  # noqa: F401

--- a/snorkel/types/data.py
+++ b/snorkel/types/data.py
@@ -1,7 +1,13 @@
-from typing import Any, Collection, Mapping
+from typing import Any, Collection, Mapping, Union
+
+import numpy as np
+import scipy.sparse as sparse
+import torch
 
 DataPoint = Any
 DataPoints = Collection[DataPoint]
 
 Field = Any
 FieldMap = Mapping[str, Field]
+
+ArrayLike = Union[np.ndarray, list, sparse.spmatrix, torch.Tensor]

--- a/snorkel/types/data.py
+++ b/snorkel/types/data.py
@@ -2,7 +2,7 @@ from typing import Any, Collection, Mapping, Union
 
 import numpy as np
 import scipy.sparse as sparse
-import torch
+from torch import Tensor
 
 DataPoint = Any
 DataPoints = Collection[DataPoint]
@@ -10,4 +10,4 @@ DataPoints = Collection[DataPoint]
 Field = Any
 FieldMap = Mapping[str, Field]
 
-ArrayLike = Union[np.ndarray, list, sparse.spmatrix, torch.Tensor]
+ArrayLike = Union[np.ndarray, list, sparse.spmatrix, Tensor]

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -107,7 +107,7 @@ class TestPandasTFApplier(unittest.TestCase):
         applier = PandasTFApplier([square], policy, k=1, keep_original=False)
         df_augmented = applier.apply(df)
         df_expected = pd.DataFrame(dict(num=[1, 16, 81]), index=[0, 1, 2])
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_pandas_multi(self):
@@ -117,7 +117,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 16, 16, 81, 81]), index=[0, 0, 1, 1, 2, 2]
         )
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_pandas_keep_original(self):
@@ -127,7 +127,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 16, 16, 3, 81, 81]), index=[0, 0, 0, 1, 1, 1, 2, 2, 2]
         )
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_returns_none(self):
@@ -139,7 +139,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 3, 81, 81]), index=[0, 0, 0, 1, 2, 2, 2]
         )
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_pandas_modify_in_place(self):
@@ -150,5 +150,5 @@ class TestPandasTFApplier(unittest.TestCase):
         df_augmented = applier.apply(df)
         idx = [0, 0, 0, 1, 1, 1, 2, 2, 2]
         df_expected = pd.DataFrame(dict(d=DATA_IN_PLACE_EXPECTED), index=idx)
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.d.tolist(), get_data_dict())

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -1,0 +1,171 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sparse
+
+from snorkel.labeling.analysis import (
+    label_coverage,
+    label_overlap,
+    label_conflict,
+    lf_conflicts,
+    lf_coverages,
+    lf_empirical_accuracies,
+    lf_overlaps,
+    lf_polarities,
+    error_buckets,
+    lf_summary,
+    single_lf_summary,
+    confusion_matrix,
+)
+
+
+L = [
+    [0, 0, 1, 0, 0, 1],
+    [0, 0, 0, 3, 0, 0],
+    [3, 0, 0, 0, 0, 1],
+    [2, 0, 3, 0, 1, 1],
+    [0, 0, 0, 0, 0, 0],
+    [2, 0, 1, 3, 2, 1],
+]
+
+Y = [1, 2, 3, 1, 2, 3]
+
+
+class TestAnalysis(unittest.TestCase):
+    def setUp(self) -> None:
+        self.L = sparse.csr_matrix(np.array(L))
+        self.Y = np.array(Y)
+
+    def test_label_coverage(self) -> None:
+        self.assertEqual(label_coverage(self.L), 5 / 6)
+
+    def test_label_overlap(self) -> None:
+        self.assertEqual(label_overlap(self.L), 4 / 6)
+
+    def test_label_conflict(self) -> None:
+        self.assertEqual(label_conflict(self.L), 3 / 6)
+
+    def test_lf_polarities(self) -> None:
+        polarities = lf_polarities(self.L)
+        self.assertEqual(polarities, [[2, 3], [], [1, 3], 3, [1, 2], 1])
+
+    def test_lf_coverages(self) -> None:
+        coverages = lf_coverages(self.L)
+        coverages_expected = [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6]
+        np.testing.assert_array_almost_equal(coverages, np.array(coverages_expected))
+
+    def test_lf_overlaps(self) -> None:
+        overlaps = lf_overlaps(self.L, normalize_by_coverage=False)
+        overlaps_expected = [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6]
+        np.testing.assert_array_almost_equal(overlaps, np.array(overlaps_expected))
+
+        overlaps = lf_overlaps(self.L, normalize_by_coverage=True)
+        overlaps_expected = [1, 0, 1, 1 / 2, 1, 1]
+        np.testing.assert_array_almost_equal(overlaps, np.array(overlaps_expected))
+
+    def test_lf_conflicts(self) -> None:
+        conflicts = lf_conflicts(self.L, normalize_by_overlaps=False)
+        conflicts_expected = [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6]
+        np.testing.assert_array_almost_equal(conflicts, np.array(conflicts_expected))
+
+        conflicts = lf_conflicts(self.L, normalize_by_overlaps=True)
+        conflicts_expected = [1, 0, 2 / 3, 1, 1, 3 / 4]
+        np.testing.assert_array_almost_equal(conflicts, np.array(conflicts_expected))
+
+    def test_lf_empirical_accuracies(self) -> None:
+        accs = lf_empirical_accuracies(self.L, self.Y)
+        accs_expected = [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4]
+        np.testing.assert_array_almost_equal(accs, np.array(accs_expected))
+
+    def test_lf_summary(self) -> None:
+        df = lf_summary(self.L, self.Y, lf_names=None, est_accs=None)
+        df_expected = pd.DataFrame(
+            {
+                "Polarity": [[2, 3], [], [1, 3], 3, [1, 2], 1],
+                "Coverage": [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6],
+                "Overlaps": [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6],
+                "Conflicts": [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6],
+                "Correct": [1, 0, 1, 1, 1, 2],
+                "Incorrect": [2, 0, 2, 1, 1, 2],
+                "Emp. Acc.": [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4],
+            }
+        )
+        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+
+        df = lf_summary(self.L, Y=None, lf_names=None, est_accs=None)
+        df_expected = pd.DataFrame(
+            {
+                "Polarity": [[2, 3], [], [1, 3], 3, [1, 2], 1],
+                "Coverage": [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6],
+                "Overlaps": [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6],
+                "Conflicts": [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6],
+            }
+        )
+        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+
+        est_accs = [1, 0, 1, 1, 1, 0.5]
+        names = list("abcdef")
+        df = lf_summary(self.L, self.Y, lf_names=names, est_accs=est_accs)
+        df_expected = pd.DataFrame(
+            {
+                "j": [0, 1, 2, 3, 4, 5],
+                "Polarity": [[2, 3], [], [1, 3], 3, [1, 2], 1],
+                "Coverage": [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6],
+                "Overlaps": [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6],
+                "Conflicts": [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6],
+                "Correct": [1, 0, 1, 1, 1, 2],
+                "Incorrect": [2, 0, 2, 1, 1, 2],
+                "Emp. Acc.": [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4],
+                "Learned Acc.": [1, 0, 1, 1, 1, 0.5],
+            }
+        ).set_index(pd.Index(names))
+        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+
+    def test_single_lf_summary(self) -> None:
+        df = single_lf_summary(self.L[:, 0].toarray(), self.Y)
+        df_expected = pd.DataFrame(
+            {
+                "Polarity": [[2, 3]],
+                "Coverage": [3 / 6],
+                "Correct": [1],
+                "Incorrect": [2],
+                "Emp. Acc.": [1 / 3],
+            }
+        )
+        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+
+    def test_error_buckets(self) -> None:
+        pred = [2, 1, 3, 1, 1, 3]
+        buckets = error_buckets(self.Y, pred, X=None)
+        self.assertEqual(
+            buckets, {(2, 1): [0], (1, 2): [1, 4], (3, 3): [2, 5], (1, 1): [3]}
+        )
+
+    def test_confusion_matrix(self) -> None:
+        pred = [0, 2, 2, 3, 1, 0, 1, 3]
+        gold = [1, 2, 2, 0, 3, 0, 2, 3]
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=False, null_gold=False, normalize=False
+        )
+        mat_expected = np.array([[0, 1, 1], [0, 2, 0], [0, 0, 1]])
+        np.testing.assert_array_equal(mat, mat_expected)
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=False, null_gold=False, normalize=True
+        )
+        mat_expected = np.array([[0, 1 / 8, 1 / 8], [0, 2 / 8, 0], [0, 0, 1 / 8]])
+        np.testing.assert_array_equal(mat, mat_expected)
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=True, null_gold=False, normalize=False
+        )
+        mat_expected = np.array([[1, 0, 0], [0, 1, 1], [0, 2, 0], [0, 0, 1]])
+        np.testing.assert_array_equal(mat, mat_expected)
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=True, null_gold=True, normalize=False
+        )
+        mat_expected = np.array([[1, 1, 0, 0], [0, 0, 1, 1], [0, 0, 2, 0], [1, 0, 0, 1]])
+        np.testing.assert_array_equal(mat, mat_expected)

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -90,7 +90,7 @@ class TestAnalysis(unittest.TestCase):
                 "Emp. Acc.": [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4],
             }
         )
-        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
 
         df = lf_summary(self.L, Y=None, lf_names=None, est_accs=None)
         df_expected = pd.DataFrame(
@@ -101,7 +101,7 @@ class TestAnalysis(unittest.TestCase):
                 "Conflicts": [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6],
             }
         )
-        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
 
         est_accs = [1, 0, 1, 1, 1, 0.5]
         names = list("abcdef")
@@ -119,7 +119,7 @@ class TestAnalysis(unittest.TestCase):
                 "Learned Acc.": [1, 0, 1, 1, 1, 0.5],
             }
         ).set_index(pd.Index(names))
-        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
 
     def test_single_lf_summary(self) -> None:
         df = single_lf_summary(self.L[:, 0].toarray(), self.Y)
@@ -132,7 +132,7 @@ class TestAnalysis(unittest.TestCase):
                 "Emp. Acc.": [1 / 3],
             }
         )
-        self.assertTrue(df.round(6).equals(df_expected.round(6)))
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
 
     def test_error_buckets(self) -> None:
         pred = [2, 1, 3, 1, 1, 3]

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -5,20 +5,19 @@ import pandas as pd
 import scipy.sparse as sparse
 
 from snorkel.labeling.analysis import (
+    confusion_matrix,
+    error_buckets,
+    label_conflict,
     label_coverage,
     label_overlap,
-    label_conflict,
     lf_conflicts,
     lf_coverages,
     lf_empirical_accuracies,
     lf_overlaps,
     lf_polarities,
-    error_buckets,
     lf_summary,
     single_lf_summary,
-    confusion_matrix,
 )
-
 
 L = [
     [0, 0, 1, 0, 0, 1],
@@ -167,5 +166,7 @@ class TestAnalysis(unittest.TestCase):
         mat = confusion_matrix(
             gold, pred, null_pred=True, null_gold=True, normalize=False
         )
-        mat_expected = np.array([[1, 1, 0, 0], [0, 0, 1, 1], [0, 0, 2, 0], [1, 0, 0, 1]])
+        mat_expected = np.array(
+            [[1, 1, 0, 0], [0, 0, 1, 1], [0, 0, 2, 0], [1, 0, 0, 1]]
+        )
         np.testing.assert_array_equal(mat, mat_expected)

--- a/test/labeling/test_lf.py
+++ b/test/labeling/test_lf.py
@@ -27,7 +27,7 @@ def g(x: DataPoint, db: List[int]) -> int:
     return 1 if x.num in db else 0
 
 
-class TestLabelingFunctionCore(unittest.TestCase):
+class TestLabelingFunction(unittest.TestCase):
     def _run_lf(self, lf: LabelingFunction) -> None:
         x_43 = SimpleNamespace(num=43)
         x_19 = SimpleNamespace(num=19)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands = mypy -p snorkel
 description = run coverage checks
 basepython = python3
 usedevelop = True
-commands = pytest --cov=snorkel test/
+commands = python -m pytest --cov=snorkel test/
 
 [testenv:dev]
 description = install dev tools


### PR DESCRIPTION
See title. Primarily adding unit tests for analysis.py
Also:
* Handling of NaN outputs in `lf_empirical_accuracies`
* Trim poorly defined columns in `single_lf_summary`
* Replace `issparse` for type-ability
* Removed that goofball `global` since it's unused

**Test plan**
Added tests...obviously