### PR TITLE
Remove PyArrow-based test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ matplotlib==3.0.1
 networkx==2.2
 numpy==1.16.0
 pandas==0.24.0
-pyarrow==0.12.0
 scikit-learn==0.20.2
 scipy==1.2.0
 spacy==2.1.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,6 @@ known_first_party=
 known_third_party=
     numpy,
     pandas,
-    pyarrow,
     pyspark,
     scipy,
     setuptools,

--- a/snorkel/model/utils.py
+++ b/snorkel/model/utils.py
@@ -1,13 +1,14 @@
 import argparse
 import copy
 import random
-import warnings
 from collections import defaultdict
 
 import numpy as np
+import scipy.sparse as sparse
 import torch
-from scipy.sparse import issparse
 from torch.utils.data import Dataset
+
+from snorkel.types import ArrayLike
 
 
 class MetalDataset(Dataset):
@@ -66,7 +67,7 @@ def pred_to_prob(Y_h, k):
     return Y_s
 
 
-def arraylike_to_numpy(array_like):
+def arraylike_to_numpy(array_like: ArrayLike) -> np.ndarray:
     """Convert a 1d array-like (e.g,. list, tensor, etc.) to an np.ndarray"""
 
     orig_type = type(array_like)
@@ -76,7 +77,7 @@ def arraylike_to_numpy(array_like):
         pass
     elif isinstance(array_like, list):
         array_like = np.array(array_like)
-    elif issparse(array_like):
+    elif isinstance(array_like, sparse.spmatrix):
         array_like = array_like.toarray()
     elif isinstance(array_like, torch.Tensor):
         array_like = array_like.numpy()
@@ -452,25 +453,6 @@ def padded_tensor(items, pad_idx=0, left_padded=False, max_len=None):
     return output
 
 
-global warnings_given
-warnings_given = set([])
-
-
-def warn_once(self, msg, msg_name=None):
-    """Prints a warning statement just once
-
-    Args:
-        msg: The warning message
-        msg_name: [optional] The name of the warning. If None, the msg_name
-            will be the msg itself.
-    """
-    assert isinstance(msg, str)
-    msg_name = msg_name if msg_name else msg
-    if msg_name not in warnings_given:
-        warnings.warn(msg)
-    warnings_given.add(msg_name)
-
-
 # DEPRECATION: This is replaced by move_to_device
 def place_on_gpu(data):
     """Utility to place data on GPU, where data could be a torch.Tensor, a tuple
@@ -514,5 +496,6 @@ def set_seed(seed: int):
     np.random.seed(seed)
     torch.manual_seed(seed)
     if torch.cuda.is_available():
-        torch.backends.cudnn.enabled = True  # Is this necessary?
-        torch.cuda.manual_seed(seed)
+        # Is this necessary?
+        torch.backends.cudnn.enabled = True  # type: ignore
+        torch.cuda.manual_seed(seed)  # type: ignore

--- a/snorkel/types/__init__.py
+++ b/snorkel/types/__init__.py
@@ -1,2 +1,2 @@
-from .data import DataPoint, DataPoints, Field, FieldMap  # noqa: F401
+from .data import ArrayLike, DataPoint, DataPoints, Field, FieldMap  # noqa: F401
 from .logger import Config  # noqa: F401

--- a/snorkel/types/data.py
+++ b/snorkel/types/data.py
@@ -1,7 +1,13 @@
-from typing import Any, Collection, Mapping
+from typing import Any, Collection, Mapping, Union
+
+import numpy as np
+import scipy.sparse as sparse
+from torch import Tensor
 
 DataPoint = Any
 DataPoints = Collection[DataPoint]
 
 Field = Any
 FieldMap = Mapping[str, Field]
+
+ArrayLike = Union[np.ndarray, list, sparse.spmatrix, Tensor]

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -107,7 +107,7 @@ class TestPandasTFApplier(unittest.TestCase):
         applier = PandasTFApplier([square], policy, k=1, keep_original=False)
         df_augmented = applier.apply(df)
         df_expected = pd.DataFrame(dict(num=[1, 16, 81]), index=[0, 1, 2])
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_pandas_multi(self):
@@ -117,7 +117,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 16, 16, 81, 81]), index=[0, 0, 1, 1, 2, 2]
         )
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_pandas_keep_original(self):
@@ -127,7 +127,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 16, 16, 3, 81, 81]), index=[0, 0, 0, 1, 1, 1, 2, 2, 2]
         )
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_returns_none(self):
@@ -139,7 +139,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 3, 81, 81]), index=[0, 0, 0, 1, 2, 2, 2]
         )
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.num.tolist(), DATA)
 
     def test_tf_applier_pandas_modify_in_place(self):
@@ -150,5 +150,5 @@ class TestPandasTFApplier(unittest.TestCase):
         df_augmented = applier.apply(df)
         idx = [0, 0, 0, 1, 1, 1, 2, 2, 2]
         df_expected = pd.DataFrame(dict(d=DATA_IN_PLACE_EXPECTED), index=idx)
-        self.assertTrue(df_augmented.equals(df_expected))
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
         self.assertEqual(df.d.tolist(), get_data_dict())

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -4,8 +4,6 @@ from typing import List
 
 import numpy as np
 import pandas as pd
-import pyarrow as pa
-import pyarrow.parquet as pq
 
 from snorkel.labeling.apply import LFApplier, PandasLFApplier
 from snorkel.labeling.lf import labeling_function
@@ -86,14 +84,3 @@ class TestLFApplier(unittest.TestCase):
         applier = PandasLFApplier([first_is_name, has_verb])
         L = applier.apply(df)
         np.testing.assert_equal(L.toarray(), L_TEXT_EXPECTED)
-
-    def test_lf_applier_pandas_parquet(self) -> None:
-        table_write = pa.Table.from_pandas(pd.DataFrame(dict(num=DATA)))
-        stream = pa.BufferOutputStream()
-        pq.write_table(table_write, stream)
-        buffer = stream.getvalue()
-        reader = pa.BufferReader(buffer)
-        table = pq.read_table(reader)
-        applier = PandasLFApplier([f, g])
-        L = applier.apply(table.to_pandas())
-        np.testing.assert_equal(L.toarray(), L_EXPECTED)

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -1,0 +1,172 @@
+import unittest
+
+import numpy as np
+import pandas as pd
+import scipy.sparse as sparse
+
+from snorkel.labeling.analysis import (
+    confusion_matrix,
+    error_buckets,
+    label_conflict,
+    label_coverage,
+    label_overlap,
+    lf_conflicts,
+    lf_coverages,
+    lf_empirical_accuracies,
+    lf_overlaps,
+    lf_polarities,
+    lf_summary,
+    single_lf_summary,
+)
+
+L = [
+    [0, 0, 1, 0, 0, 1],
+    [0, 0, 0, 3, 0, 0],
+    [3, 0, 0, 0, 0, 1],
+    [2, 0, 3, 0, 1, 1],
+    [0, 0, 0, 0, 0, 0],
+    [2, 0, 1, 3, 2, 1],
+]
+
+Y = [1, 2, 3, 1, 2, 3]
+
+
+class TestAnalysis(unittest.TestCase):
+    def setUp(self) -> None:
+        self.L = sparse.csr_matrix(np.array(L))
+        self.Y = np.array(Y)
+
+    def test_label_coverage(self) -> None:
+        self.assertEqual(label_coverage(self.L), 5 / 6)
+
+    def test_label_overlap(self) -> None:
+        self.assertEqual(label_overlap(self.L), 4 / 6)
+
+    def test_label_conflict(self) -> None:
+        self.assertEqual(label_conflict(self.L), 3 / 6)
+
+    def test_lf_polarities(self) -> None:
+        polarities = lf_polarities(self.L)
+        self.assertEqual(polarities, [[2, 3], [], [1, 3], 3, [1, 2], 1])
+
+    def test_lf_coverages(self) -> None:
+        coverages = lf_coverages(self.L)
+        coverages_expected = [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6]
+        np.testing.assert_array_almost_equal(coverages, np.array(coverages_expected))
+
+    def test_lf_overlaps(self) -> None:
+        overlaps = lf_overlaps(self.L, normalize_by_coverage=False)
+        overlaps_expected = [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6]
+        np.testing.assert_array_almost_equal(overlaps, np.array(overlaps_expected))
+
+        overlaps = lf_overlaps(self.L, normalize_by_coverage=True)
+        overlaps_expected = [1, 0, 1, 1 / 2, 1, 1]
+        np.testing.assert_array_almost_equal(overlaps, np.array(overlaps_expected))
+
+    def test_lf_conflicts(self) -> None:
+        conflicts = lf_conflicts(self.L, normalize_by_overlaps=False)
+        conflicts_expected = [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6]
+        np.testing.assert_array_almost_equal(conflicts, np.array(conflicts_expected))
+
+        conflicts = lf_conflicts(self.L, normalize_by_overlaps=True)
+        conflicts_expected = [1, 0, 2 / 3, 1, 1, 3 / 4]
+        np.testing.assert_array_almost_equal(conflicts, np.array(conflicts_expected))
+
+    def test_lf_empirical_accuracies(self) -> None:
+        accs = lf_empirical_accuracies(self.L, self.Y)
+        accs_expected = [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4]
+        np.testing.assert_array_almost_equal(accs, np.array(accs_expected))
+
+    def test_lf_summary(self) -> None:
+        df = lf_summary(self.L, self.Y, lf_names=None, est_accs=None)
+        df_expected = pd.DataFrame(
+            {
+                "Polarity": [[2, 3], [], [1, 3], 3, [1, 2], 1],
+                "Coverage": [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6],
+                "Overlaps": [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6],
+                "Conflicts": [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6],
+                "Correct": [1, 0, 1, 1, 1, 2],
+                "Incorrect": [2, 0, 2, 1, 1, 2],
+                "Emp. Acc.": [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4],
+            }
+        )
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
+
+        df = lf_summary(self.L, Y=None, lf_names=None, est_accs=None)
+        df_expected = pd.DataFrame(
+            {
+                "Polarity": [[2, 3], [], [1, 3], 3, [1, 2], 1],
+                "Coverage": [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6],
+                "Overlaps": [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6],
+                "Conflicts": [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6],
+            }
+        )
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
+
+        est_accs = [1, 0, 1, 1, 1, 0.5]
+        names = list("abcdef")
+        df = lf_summary(self.L, self.Y, lf_names=names, est_accs=est_accs)
+        df_expected = pd.DataFrame(
+            {
+                "j": [0, 1, 2, 3, 4, 5],
+                "Polarity": [[2, 3], [], [1, 3], 3, [1, 2], 1],
+                "Coverage": [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6],
+                "Overlaps": [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6],
+                "Conflicts": [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6],
+                "Correct": [1, 0, 1, 1, 1, 2],
+                "Incorrect": [2, 0, 2, 1, 1, 2],
+                "Emp. Acc.": [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4],
+                "Learned Acc.": [1, 0, 1, 1, 1, 0.5],
+            }
+        ).set_index(pd.Index(names))
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
+
+    def test_single_lf_summary(self) -> None:
+        df = single_lf_summary(self.L[:, 0].toarray(), self.Y)
+        df_expected = pd.DataFrame(
+            {
+                "Polarity": [[2, 3]],
+                "Coverage": [3 / 6],
+                "Correct": [1],
+                "Incorrect": [2],
+                "Emp. Acc.": [1 / 3],
+            }
+        )
+        pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
+
+    def test_error_buckets(self) -> None:
+        pred = [2, 1, 3, 1, 1, 3]
+        buckets = error_buckets(self.Y, pred, X=None)
+        self.assertEqual(
+            buckets, {(2, 1): [0], (1, 2): [1, 4], (3, 3): [2, 5], (1, 1): [3]}
+        )
+
+    def test_confusion_matrix(self) -> None:
+        pred = [0, 2, 2, 3, 1, 0, 1, 3]
+        gold = [1, 2, 2, 0, 3, 0, 2, 3]
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=False, null_gold=False, normalize=False
+        )
+        mat_expected = np.array([[0, 1, 1], [0, 2, 0], [0, 0, 1]])
+        np.testing.assert_array_equal(mat, mat_expected)
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=False, null_gold=False, normalize=True
+        )
+        mat_expected = np.array([[0, 1 / 8, 1 / 8], [0, 2 / 8, 0], [0, 0, 1 / 8]])
+        np.testing.assert_array_equal(mat, mat_expected)
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=True, null_gold=False, normalize=False
+        )
+        mat_expected = np.array([[1, 0, 0], [0, 1, 1], [0, 2, 0], [0, 0, 1]])
+        np.testing.assert_array_equal(mat, mat_expected)
+
+        mat = confusion_matrix(
+            gold, pred, null_pred=True, null_gold=True, normalize=False
+        )
+        mat_expected = np.array(
+            [[1, 1, 0, 0], [0, 0, 1, 1], [0, 0, 2, 0], [1, 0, 0, 1]]
+        )
+        np.testing.assert_array_equal(mat, mat_expected)

--- a/test/labeling/test_lf.py
+++ b/test/labeling/test_lf.py
@@ -27,7 +27,7 @@ def g(x: DataPoint, db: List[int]) -> int:
     return 1 if x.num in db else 0
 
 
-class TestLabelingFunctionCore(unittest.TestCase):
+class TestLabelingFunction(unittest.TestCase):
     def _run_lf(self, lf: LabelingFunction) -> None:
         x_43 = SimpleNamespace(num=43)
         x_19 = SimpleNamespace(num=19)

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ commands = mypy -p snorkel
 description = run coverage checks
 basepython = python3
 usedevelop = True
-commands = pytest --cov=snorkel test/
+commands = python -m pytest --cov=snorkel test/
 
 [testenv:dev]
 description = install dev tools


### PR DESCRIPTION
Grrrr https://issues.apache.org/jira/browse/ARROW-3346

tl;dr importing PyTorch before PyArrow (depending on build) results in a segfault

Currently only using PyArrow in one completely unnecessary test, so we'll remove it for now, then figure out how to deal with Parquet once we have core tooling.