### PR TITLE
Allow retries for codecov in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
   - tox
 
 after_success:
-  - codecov
+  - travis_retry codecov


### PR DESCRIPTION
See https://travis-ci.org/HazyResearch/snorkel/jobs/551538180#L682 as an example. The `codecov` command uploads the `.coverage` file, so can fail with a bad connection. It doesn't retry by default.

**Test plan**
¯\_(ツ)_/¯