### PR TITLE
Standardize naming of preds/probs

### DIFF
--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -9,13 +9,13 @@ from .utils import arraylike_to_numpy
 
 
 def error_buckets(
-    gold: ArrayLike, pred: ArrayLike, X: Optional[Sequence[Any]] = None
+    golds: ArrayLike, preds: ArrayLike, X: Optional[Sequence[Any]] = None
 ) -> Mapping[Tuple[int, int], Any]:
     """Group items by error buckets
 
     Args:
-        gold: an array-like of gold labels (ints)
-        pred: an array-like of predictions (ints)
+        golds: an array-like of golds labels (ints)
+        preds: an array-like of predictions (ints)
         X: an iterable of items
     Returns:
         buckets: A dict of items where buckets[i,j] is a list of items with
@@ -29,34 +29,34 @@ def error_buckets(
         buckets[2,2] = true negatives
     """
     buckets: Mapping[Tuple[int, int], List[Any]] = defaultdict(list)
-    gold = arraylike_to_numpy(gold)
-    pred = arraylike_to_numpy(pred)
-    for i, (y, l) in enumerate(zip(pred, gold)):
+    golds = arraylike_to_numpy(golds)
+    preds = arraylike_to_numpy(preds)
+    for i, (y, l) in enumerate(zip(preds, golds)):
         buckets[y, l].append(X[i] if X is not None else i)
     return dict(buckets)
 
 
 def confusion_matrix(
-    gold, pred, null_pred=False, null_gold=False, normalize=False, pretty_print=True
+    golds, preds, null_pred=False, null_gold=False, normalize=False, pretty_print=True
 ):
     """A shortcut method for building a confusion matrix all at once.
 
     Args:
-        gold: an array-like of gold labels (ints)
-        pred: an array-like of predictions (ints)
+        golds: an array-like of golds labels (ints)
+        preds: an array-like of predictions (ints)
         null_pred: If True, include the row corresponding to null predictions
-        null_gold: If True, include the col corresponding to null gold labels
+        null_gold: If True, include the col corresponding to null golds labels
         normalize: if True, divide counts by the total number of items
         pretty_print: if True, pretty-print the matrix before returning
     """
     conf = ConfusionMatrix(null_pred=null_pred, null_gold=null_gold)
-    gold = arraylike_to_numpy(gold)
-    pred = arraylike_to_numpy(pred)
-    conf.add(gold, pred)
+    golds = arraylike_to_numpy(golds)
+    preds = arraylike_to_numpy(preds)
+    conf.add(golds, preds)
     mat = conf.compile()
 
     if normalize:
-        mat = mat / len(gold)
+        mat = mat / len(golds)
 
     if pretty_print:
         conf.display(normalize=normalize)
@@ -76,7 +76,7 @@ class ConfusionMatrix(object):
         Args:
             null_pred: If True, include the row corresponding to null
                 predictions
-            null_gold: If True, include the col corresponding to null gold
+            null_gold: If True, include the col corresponding to null golds
                 labels
 
         """
@@ -90,13 +90,13 @@ class ConfusionMatrix(object):
             self.compile()
         return str(self.mat)
 
-    def add(self, gold, pred):
+    def add(self, golds, preds):
         """
         Args:
-            gold: a np.ndarray of gold labels (ints)
-            pred: a np.ndarray of predictions (ints)
+            golds: a np.ndarray of golds labels (ints)
+            preds: a np.ndarray of predictions (ints)
         """
-        self.counter.update(zip(gold, pred))
+        self.counter.update(zip(golds, preds))
 
     def compile(self, trim=True):
         k = max([max(tup) for tup in self.counter.keys()]) + 1  # include 0
@@ -134,7 +134,7 @@ class ConfusionMatrix(object):
                 continue
             s = margin + f" l={i} " + tab
             for j in range(n):
-                # Skip null gold if necessary
+                # Skip null golds if necessary
                 if j == 0 and not self.null_gold:
                     continue
                 else:

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -18,7 +18,9 @@ def accuracy_score(golds, preds, probs=None, ignore_in_gold=[], ignore_in_pred=[
     Returns:
         A float, the (micro) accuracy score
     """
-    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(
+        golds, preds, probs, ignore_in_gold, ignore_in_pred
+    )
 
     if len(golds) and len(preds):
         acc = np.sum(golds == preds) / len(golds)
@@ -43,7 +45,9 @@ def coverage_score(golds, preds, probs=None, ignore_in_gold=[], ignore_in_pred=[
     Returns:
         A float, the (global) coverage score
     """
-    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(
+        golds, preds, probs, ignore_in_gold, ignore_in_pred
+    )
 
     return np.sum(preds != 0) / len(preds)
 
@@ -66,7 +70,9 @@ def precision_score(
     Returns:
         pre: The (float) precision score
     """
-    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(
+        golds, preds, probs, ignore_in_gold, ignore_in_pred
+    )
 
     positives = np.where(preds == pos_label, 1, 0).astype(bool)
     trues = np.where(golds == pos_label, 1, 0).astype(bool)
@@ -99,7 +105,9 @@ def recall_score(
     Returns:
         rec: The (float) recall score
     """
-    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(
+        golds, preds, probs, ignore_in_gold, ignore_in_pred
+    )
 
     positives = np.where(preds == pos_label, 1, 0).astype(bool)
     trues = np.where(golds == pos_label, 1, 0).astype(bool)
@@ -115,7 +123,13 @@ def recall_score(
 
 
 def fbeta_score(
-    golds, preds, probs=None, pos_label=1, beta=1.0, ignore_in_gold=[], ignore_in_pred=[]
+    golds,
+    preds,
+    probs=None,
+    pos_label=1,
+    beta=1.0,
+    ignore_in_gold=[],
+    ignore_in_pred=[],
 ):
     """
     Calculate recall for a single class.
@@ -133,7 +147,9 @@ def fbeta_score(
     Returns:
         fbeta: The (float) f-beta score
     """
-    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(
+        golds, preds, probs, ignore_in_gold, ignore_in_pred
+    )
     pre = precision_score(golds, preds, pos_label=pos_label)
     rec = recall_score(golds, preds, pos_label=pos_label)
 
@@ -181,7 +197,7 @@ METRICS = {
 }
 
 
-def metric_score(golds, preds, probs, metric, probs=None, **kwargs):
+def metric_score(golds, preds, metric, probs=None, **kwargs):
     if metric not in METRICS:
         msg = f"The metric you provided ({metric}) is not supported."
         raise ValueError(msg)

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -3,73 +3,73 @@ import numpy as np
 from .utils import arraylike_to_numpy
 
 
-def accuracy_score(gold, pred, prob=None, ignore_in_gold=[], ignore_in_pred=[]):
+def accuracy_score(golds, preds, probs=None, ignore_in_gold=[], ignore_in_pred=[]):
     """
     Calculate (micro) accuracy.
     Args:
-        gold: A 1d array-like of gold labels
-        pred: A 1d array-like of predicted labels (assuming abstain = 0)
-        prob: Unused (kept for compatibility with expected metric func signature)
-        ignore_in_gold: A list of labels for which elements having that gold
+        golds: A 1d array-like of golds labels
+        preds: A 1d array-like of predicted labels (assuming abstain = 0)
+        probs: Unused (kept for compatibility with expected metric func signature)
+        ignore_in_gold: A list of labels for which elements having that golds
             label will be ignored.
-        ignore_in_pred: A list of labels for which elements having that pred
+        ignore_in_pred: A list of labels for which elements having that preds
             label will be ignored.
 
     Returns:
         A float, the (micro) accuracy score
     """
-    gold, pred, prob = _preprocess(gold, pred, prob, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
 
-    if len(gold) and len(pred):
-        acc = np.sum(gold == pred) / len(gold)
+    if len(golds) and len(preds):
+        acc = np.sum(golds == preds) / len(golds)
     else:
         acc = 0
 
     return acc
 
 
-def coverage_score(gold, pred, prob=None, ignore_in_gold=[], ignore_in_pred=[]):
+def coverage_score(golds, preds, probs=None, ignore_in_gold=[], ignore_in_pred=[]):
     """
     Calculate (global) coverage.
     Args:
-        gold: A 1d array-like of gold labels
-        pred: A 1d array-like of predicted labels (assuming abstain = 0)
-        prob: Unused (kept for compatibility with expected metric func signature)
-        ignore_in_gold: A list of labels for which elements having that gold
+        golds: A 1d array-like of golds labels
+        preds: A 1d array-like of predicted labels (assuming abstain = 0)
+        probs: Unused (kept for compatibility with expected metric func signature)
+        ignore_in_gold: A list of labels for which elements having that golds
             label will be ignored.
-        ignore_in_pred: A list of labels for which elements having that pred
+        ignore_in_pred: A list of labels for which elements having that preds
             label will be ignored.
 
     Returns:
         A float, the (global) coverage score
     """
-    gold, pred, prob = _preprocess(gold, pred, prob, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
 
-    return np.sum(pred != 0) / len(pred)
+    return np.sum(preds != 0) / len(preds)
 
 
 def precision_score(
-    gold, pred, prob=None, pos_label=1, ignore_in_gold=[], ignore_in_pred=[]
+    golds, preds, probs=None, pos_label=1, ignore_in_gold=[], ignore_in_pred=[]
 ):
     """
     Calculate precision for a single class.
     Args:
-        gold: A 1d array-like of gold labels
-        pred: A 1d array-like of predicted labels (assuming abstain = 0)
-        prob: Unused (kept for compatibility with expected metric func signature)
-        ignore_in_gold: A list of labels for which elements having that gold
+        golds: A 1d array-like of golds labels
+        preds: A 1d array-like of predicted labels (assuming abstain = 0)
+        probs: Unused (kept for compatibility with expected metric func signature)
+        ignore_in_gold: A list of labels for which elements having that golds
             label will be ignored.
-        ignore_in_pred: A list of labels for which elements having that pred
+        ignore_in_pred: A list of labels for which elements having that preds
             label will be ignored.
         pos_label: The class label to treat as positive for precision
 
     Returns:
         pre: The (float) precision score
     """
-    gold, pred, prob = _preprocess(gold, pred, prob, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
 
-    positives = np.where(pred == pos_label, 1, 0).astype(bool)
-    trues = np.where(gold == pos_label, 1, 0).astype(bool)
+    positives = np.where(preds == pos_label, 1, 0).astype(bool)
+    trues = np.where(golds == pos_label, 1, 0).astype(bool)
     TP = np.sum(positives * trues)
     FP = np.sum(positives * np.logical_not(trues))
 
@@ -82,27 +82,27 @@ def precision_score(
 
 
 def recall_score(
-    gold, pred, prob=None, pos_label=1, ignore_in_gold=[], ignore_in_pred=[]
+    golds, preds, probs=None, pos_label=1, ignore_in_gold=[], ignore_in_pred=[]
 ):
     """
     Calculate recall for a single class.
     Args:
-        gold: A 1d array-like of gold labels
-        pred: A 1d array-like of predicted labels (assuming abstain = 0)
-        prob: Unused (kept for compatibility with expected metric func signature)
-        ignore_in_gold: A list of labels for which elements having that gold
+        golds: A 1d array-like of golds labels
+        preds: A 1d array-like of predicted labels (assuming abstain = 0)
+        probs: Unused (kept for compatibility with expected metric func signature)
+        ignore_in_gold: A list of labels for which elements having that golds
             label will be ignored.
-        ignore_in_pred: A list of labels for which elements having that pred
+        ignore_in_pred: A list of labels for which elements having that preds
             label will be ignored.
         pos_label: The class label to treat as positive for recall
 
     Returns:
         rec: The (float) recall score
     """
-    gold, pred, prob = _preprocess(gold, pred, prob, ignore_in_gold, ignore_in_pred)
+    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
 
-    positives = np.where(pred == pos_label, 1, 0).astype(bool)
-    trues = np.where(gold == pos_label, 1, 0).astype(bool)
+    positives = np.where(preds == pos_label, 1, 0).astype(bool)
+    trues = np.where(golds == pos_label, 1, 0).astype(bool)
     TP = np.sum(positives * trues)
     FN = np.sum(np.logical_not(positives) * trues)
 
@@ -115,17 +115,17 @@ def recall_score(
 
 
 def fbeta_score(
-    gold, pred, prob=None, pos_label=1, beta=1.0, ignore_in_gold=[], ignore_in_pred=[]
+    golds, preds, probs=None, pos_label=1, beta=1.0, ignore_in_gold=[], ignore_in_pred=[]
 ):
     """
     Calculate recall for a single class.
     Args:
-        gold: A 1d array-like of gold labels
-        pred: A 1d array-like of predicted labels (assuming abstain = 0)
-        prob: Unused (kept for compatibility with expected metric func signature)
-        ignore_in_gold: A list of labels for which elements having that gold
+        golds: A 1d array-like of golds labels
+        preds: A 1d array-like of predicted labels (assuming abstain = 0)
+        probs: Unused (kept for compatibility with expected metric func signature)
+        ignore_in_gold: A list of labels for which elements having that golds
             label will be ignored.
-        ignore_in_pred: A list of labels for which elements having that pred
+        ignore_in_pred: A list of labels for which elements having that preds
             label will be ignored.
         pos_label: The class label to treat as positive for f-beta
         beta: The beta to use in the f-beta score calculation
@@ -133,9 +133,9 @@ def fbeta_score(
     Returns:
         fbeta: The (float) f-beta score
     """
-    gold, pred, prob = _preprocess(gold, pred, prob, ignore_in_gold, ignore_in_pred)
-    pre = precision_score(gold, pred, pos_label=pos_label)
-    rec = recall_score(gold, pred, pos_label=pos_label)
+    golds, preds, probs = _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred)
+    pre = precision_score(golds, preds, pos_label=pos_label)
+    rec = recall_score(golds, preds, pos_label=pos_label)
 
     if pre or rec:
         fbeta = (1 + beta ** 2) * (pre * rec) / ((beta ** 2 * pre) + rec)
@@ -145,30 +145,30 @@ def fbeta_score(
     return fbeta
 
 
-def f1_score(gold, pred, prob=None, **kwargs):
-    return fbeta_score(gold, pred, prob, beta=1.0, **kwargs)
+def f1_score(golds, preds, probs=None, **kwargs):
+    return fbeta_score(golds, preds, probs, beta=1.0, **kwargs)
 
 
-def _get_mask(gold, pred, ignore_in_gold, ignore_in_pred):
-    """Remove from gold, pred all items with labels designated to ignore."""
-    mask = np.ones_like(gold).astype(bool)
+def _get_mask(golds, preds, ignore_in_gold, ignore_in_pred):
+    """Remove from golds, preds all items with labels designated to ignore."""
+    mask = np.ones_like(golds).astype(bool)
     for x in ignore_in_gold:
-        mask *= np.where(gold != x, 1, 0).astype(bool)
+        mask *= np.where(golds != x, 1, 0).astype(bool)
     for x in ignore_in_pred:
-        mask *= np.where(pred != x, 1, 0).astype(bool)
+        mask *= np.where(preds != x, 1, 0).astype(bool)
 
     return mask
 
 
-def _preprocess(gold, pred, prob, ignore_in_gold, ignore_in_pred):
-    gold = arraylike_to_numpy(gold) if gold is not None else None
-    pred = arraylike_to_numpy(pred) if pred is not None else None
+def _preprocess(golds, preds, probs, ignore_in_gold, ignore_in_pred):
+    golds = arraylike_to_numpy(golds) if golds is not None else None
+    preds = arraylike_to_numpy(preds) if preds is not None else None
     if ignore_in_gold or ignore_in_pred:
-        mask = _get_mask(gold, pred, ignore_in_gold, ignore_in_pred)
-        gold = gold[mask] if gold is not None else None
-        pred = pred[mask] if pred is not None else None
-        prob = prob[mask] if prob is not None else None
-    return gold, pred, prob
+        mask = _get_mask(golds, preds, ignore_in_gold, ignore_in_pred)
+        golds = golds[mask] if golds is not None else None
+        preds = preds[mask] if preds is not None else None
+        probs = probs[mask] if probs is not None else None
+    return golds, preds, probs
 
 
 METRICS = {
@@ -181,9 +181,9 @@ METRICS = {
 }
 
 
-def metric_score(gold, pred, prob, metric, probs=None, **kwargs):
+def metric_score(golds, preds, probs, metric, probs=None, **kwargs):
     if metric not in METRICS:
         msg = f"The metric you provided ({metric}) is not supported."
         raise ValueError(msg)
     else:
-        return METRICS[metric](gold, pred, prob, **kwargs)
+        return METRICS[metric](golds, preds, probs, **kwargs)

--- a/snorkel/analysis/utils.py
+++ b/snorkel/analysis/utils.py
@@ -5,12 +5,12 @@ import torch
 from snorkel.types import ArrayLike
 
 
-def prob_to_pred(prob: np.ndarray) -> np.ndarray:
+def prob_to_pred(probs: np.ndarray) -> np.ndarray:
     """Convert an array of probabilistic labels into an array of predictions
 
     Parameters
     ----------
-    prob
+    probs
         A [num_datapoints, num_classes] array of probabilistic labels such that each
         row sums to 1.
 
@@ -19,24 +19,24 @@ def prob_to_pred(prob: np.ndarray) -> np.ndarray:
     np.ndarray
         A [num_datapoints, 1] array of predictions (integers in [1, ..., num_classes])
     """
-    assert prob.ndim == 2
-    assert (prob <= 1).all()
+    assert probs.ndim == 2
+    assert (probs <= 1).all()
 
-    pred = np.argmax(prob, axis=1) + 1
+    preds = np.argmax(probs, axis=1) + 1
 
-    n, k = prob.shape
-    assert (pred >= 1).all()
-    assert (pred <= k).all()
+    n, k = probs.shape
+    assert (preds >= 1).all()
+    assert (preds <= k).all()
 
-    return pred
+    return preds
 
 
-def pred_to_prob(pred: np.ndarray, num_classes: int) -> np.ndarray:
+def pred_to_prob(preds: np.ndarray, num_classes: int) -> np.ndarray:
     """Convert an array of probabilistic labels into an array of predictions
 
     Parameters
     ----------
-    pred
+    preds
         A [num_datapoints] or [num_datapoints], 1] array of predictions
 
     Returns
@@ -45,15 +45,15 @@ def pred_to_prob(pred: np.ndarray, num_classes: int) -> np.ndarray:
         A [num_datapoints, num_classes] array of probabilistic labels with probability
         of 1.0 in the column corresponding to the prediction
     """
-    pred = pred.reshape(-1, 1)
-    n = pred.shape[0]
+    preds = preds.reshape(-1, 1)
+    n = preds.shape[0]
 
-    prob = np.zeros((n, num_classes))
+    probs = np.zeros((n, num_classes))
 
-    for idx, class_idx in enumerate(pred):
-        prob[idx, class_idx - 1] = 1.0
+    for idx, class_idx in enumerate(preds):
+        probs[idx, class_idx - 1] = 1.0
 
-    return prob
+    return probs
 
 
 def arraylike_to_numpy(array_like: ArrayLike) -> np.ndarray:

--- a/snorkel/end_model/model.py
+++ b/snorkel/end_model/model.py
@@ -251,8 +251,8 @@ class MultitaskModel(nn.Module):
 
         if return_preds:
             pred_dict = defaultdict(list)
-            for task_name, prob in prob_dict.items():
-                pred_dict[task_name] = prob_to_pred(prob)
+            for task_name, probs in prob_dict.items():
+                pred_dict[task_name] = prob_to_pred(probs)
 
         results = {"golds": gold_dict, "probs": prob_dict}
 

--- a/snorkel/end_model/scorer.py
+++ b/snorkel/end_model/scorer.py
@@ -11,7 +11,7 @@ class Scorer(object):
     :param metrics: a list of metric names which provides in emmental (e.g., accuracy)
     :type metrics: list
     :param custom_metric_funcs: a dict of custom metrics where key is the metric
-    name and value is the metric function which takes gold, pred, prob as input
+    name and value is the metric function which takes golds, preds, probs as input
     :type custom_metric_funcs: dict
     """
 
@@ -24,16 +24,16 @@ class Scorer(object):
 
         self.metrics.update(custom_metric_funcs)
 
-    def score(self, gold, pred, prob):
+    def score(self, golds, preds, probs):
         metric_dict = dict()
 
         for metric_name, metric in self.metrics.items():
             # Handle no examples
-            if len(gold) == 0:
+            if len(golds) == 0:
                 metric_dict[metric_name] = float("nan")
                 continue
 
-            score = metric(gold, pred, prob)
+            score = metric(golds, preds, probs)
 
             if isinstance(score, dict):
                 metric_dict.update(score)

--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -125,7 +125,7 @@ def lf_empirical_accuracies(L: Matrix, Y: ArrayLike) -> np.ndarray:
     Args:
         L: an n x m scipy.sparse matrix where L_{i,j} is the label given by the
             jth LF to the ith candidate
-        Y: an [n] or [n, 1] np.ndarray of gold labels
+        Y: an [n] or [n, 1] np.ndarray of golds labels
     """
     # Assume labeled set is small, work with dense matrices
     Y = arraylike_to_numpy(Y)
@@ -145,7 +145,7 @@ def lf_summary(
     Args:
         L: an n x m scipy.sparse matrix where L_{i,j} is the label given by the
             jth LF to the ith candidate
-        Y: an [n] or [n, 1] np.ndarray of gold labels.
+        Y: an [n] or [n, 1] np.ndarray of golds labels.
             If provided, the empirical accuracy for each LF will be calculated
     """
     n, m = L.shape

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -242,7 +242,7 @@ class LabelModel(Classifier):
             c_probs[i * (self.k + 1) + 1 : (i + 1) * (self.k + 1), :] = mu_i
 
             # The 0th row (corresponding to abstains) is the difference between
-            # the sums of the other rows and one, by law of total prob
+            # the sums of the other rows and one, by law of total probs
             c_probs[i * (self.k + 1), :] = 1 - mu_i.sum(axis=0)
         c_probs = np.clip(c_probs, 0.01, 0.99)
 

--- a/snorkel/model/classifier.py
+++ b/snorkel/model/classifier.py
@@ -141,7 +141,7 @@ class Classifier(nn.Module):
         scores = []
         for metric in metric_list:
             score = metric_score(
-                gold=Y, pred=Y_p, prob=Y_s, metric=metric, ignore_in_gold=[0]
+                golds=Y, preds=Y_p, probs=Y_s, metric=metric, ignore_in_gold=[0]
             )
             scores.append(score)
             if verbose:

--- a/snorkel/model/logging/logger.py
+++ b/snorkel/model/logging/logger.py
@@ -135,7 +135,7 @@ class Logger(object):
                 )
                 for metric in target_standard_metrics:
                     score = metric_score(
-                        gold=Y, pred=Y_preds, prob=Y_probs, metric=metric
+                        golds=Y, preds=Y_preds, probs=Y_probs, metric=metric
                     )
                     metrics_dict[self.add_split_prefix(metric, split)] = score
         return metrics_dict

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -141,7 +141,7 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
         )
         pred_task_flow = body_flow + [pred_transform_op, pred_head_op]
 
-        # Create pred task
+        # Create preds task
         pred_task = Task(
             name=pred_task_name,
             module_pool=pred_module_pool,

--- a/test/analysis/test_error_analysis.py
+++ b/test/analysis/test_error_analysis.py
@@ -7,37 +7,37 @@ from snorkel.analysis.error_analysis import confusion_matrix, error_buckets
 
 class ErrorAnalysisTest(unittest.TestCase):
     def test_error_buckets(self) -> None:
-        gold = np.array([1, 2, 3, 1, 2, 3])
-        pred = np.array([2, 1, 3, 1, 1, 3])
-        buckets = error_buckets(gold, pred, X=None)
+        golds = np.array([1, 2, 3, 1, 2, 3])
+        preds = np.array([2, 1, 3, 1, 1, 3])
+        buckets = error_buckets(golds, preds, X=None)
         self.assertEqual(
             buckets, {(2, 1): [0], (1, 2): [1, 4], (3, 3): [2, 5], (1, 1): [3]}
         )
 
     def test_confusion_matrix(self) -> None:
-        pred = [0, 2, 2, 3, 1, 0, 1, 3]
-        gold = [1, 2, 2, 0, 3, 0, 2, 3]
+        preds = [0, 2, 2, 3, 1, 0, 1, 3]
+        golds = [1, 2, 2, 0, 3, 0, 2, 3]
 
         mat = confusion_matrix(
-            gold, pred, null_pred=False, null_gold=False, normalize=False
+            golds, preds, null_pred=False, null_gold=False, normalize=False
         )
         mat_expected = np.array([[0, 1, 1], [0, 2, 0], [0, 0, 1]])
         np.testing.assert_array_equal(mat, mat_expected)
 
         mat = confusion_matrix(
-            gold, pred, null_pred=False, null_gold=False, normalize=True
+            golds, preds, null_pred=False, null_gold=False, normalize=True
         )
         mat_expected = np.array([[0, 1 / 8, 1 / 8], [0, 2 / 8, 0], [0, 0, 1 / 8]])
         np.testing.assert_array_equal(mat, mat_expected)
 
         mat = confusion_matrix(
-            gold, pred, null_pred=True, null_gold=False, normalize=False
+            golds, preds, null_pred=True, null_gold=False, normalize=False
         )
         mat_expected = np.array([[1, 0, 0], [0, 1, 1], [0, 2, 0], [0, 0, 1]])
         np.testing.assert_array_equal(mat, mat_expected)
 
         mat = confusion_matrix(
-            gold, pred, null_pred=True, null_gold=True, normalize=False
+            golds, preds, null_pred=True, null_gold=True, normalize=False
         )
         mat_expected = np.array(
             [[1, 1, 0, 0], [0, 0, 1, 1], [0, 0, 2, 0], [1, 0, 0, 1]]

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -16,84 +16,84 @@ from snorkel.analysis.metrics import (
 
 class MetricsTest(unittest.TestCase):
     def test_accuracy_basic(self):
-        gold = [1, 1, 1, 2, 2]
-        pred = [1, 1, 1, 2, 1]
-        score = accuracy_score(gold, pred)
+        golds = [1, 1, 1, 2, 2]
+        preds = [1, 1, 1, 2, 1]
+        score = accuracy_score(golds, preds)
         self.assertAlmostEqual(score, 0.8)
 
     def test_metric_score(self):
-        gold = [1, 1, 1, 2, 2]
-        pred = [1, 1, 1, 2, 1]
-        acc = accuracy_score(gold, pred)
-        met = metric_score(gold, pred, prob=None, metric="accuracy")
+        golds = [1, 1, 1, 2, 2]
+        preds = [1, 1, 1, 2, 1]
+        acc = accuracy_score(golds, preds)
+        met = metric_score(golds, preds, probs=None, metric="accuracy")
         self.assertAlmostEqual(acc, met)
 
     def test_bad_inputs(self):
-        gold = [1, 1, 1, 2, 2]
+        golds = [1, 1, 1, 2, 2]
         pred1 = [1, 1, 1, 2, 0.5]
         pred2 = "1 1 1 2 2"
         pred3 = np.array([[1, 1, 1, 1, 1], [2, 2, 2, 2, 2]])
-        self.assertRaises(ValueError, accuracy_score, gold, pred1)
-        self.assertRaises(ValueError, accuracy_score, gold, pred2)
-        self.assertRaises(ValueError, accuracy_score, gold, pred3)
+        self.assertRaises(ValueError, accuracy_score, golds, pred1)
+        self.assertRaises(ValueError, accuracy_score, golds, pred2)
+        self.assertRaises(ValueError, accuracy_score, golds, pred3)
 
     def test_array_conversion(self):
-        gold = torch.Tensor([1, 1, 1, 2, 2])
-        pred = np.array([1.0, 1.0, 1.0, 2.0, 1.0])
-        score = accuracy_score(gold, pred)
+        golds = torch.Tensor([1, 1, 1, 2, 2])
+        preds = np.array([1.0, 1.0, 1.0, 2.0, 1.0])
+        score = accuracy_score(golds, preds)
         self.assertAlmostEqual(score, 0.8)
 
     def test_ignores(self):
-        gold = [1, 1, 1, 2, 2]
-        pred = [1, 0, 1, 2, 1]
-        score = accuracy_score(gold, pred)
+        golds = [1, 1, 1, 2, 2]
+        preds = [1, 0, 1, 2, 1]
+        score = accuracy_score(golds, preds)
         self.assertAlmostEqual(score, 0.6)
-        score = accuracy_score(gold, pred, ignore_in_pred=[0])
+        score = accuracy_score(golds, preds, ignore_in_pred=[0])
         self.assertAlmostEqual(score, 0.75)
-        score = accuracy_score(gold, pred, ignore_in_gold=[1])
+        score = accuracy_score(golds, preds, ignore_in_gold=[1])
         self.assertAlmostEqual(score, 0.5)
-        score = accuracy_score(gold, pred, ignore_in_gold=[2], ignore_in_pred=[0])
+        score = accuracy_score(golds, preds, ignore_in_gold=[2], ignore_in_pred=[0])
         self.assertAlmostEqual(score, 1.0)
 
     def test_coverage(self):
-        gold = [1, 1, 1, 1, 2]
-        pred = [0, 0, 1, 1, 1]
-        score = coverage_score(gold, pred)
+        golds = [1, 1, 1, 1, 2]
+        preds = [0, 0, 1, 1, 1]
+        score = coverage_score(golds, preds)
         self.assertAlmostEqual(score, 0.6)
-        score = coverage_score(gold, pred, ignore_in_gold=[2])
+        score = coverage_score(golds, preds, ignore_in_gold=[2])
         self.assertAlmostEqual(score, 0.5)
 
     def test_precision(self):
-        gold = [1, 1, 1, 2, 2]
-        pred = [0, 0, 1, 1, 2]
-        score = precision_score(gold, pred)
+        golds = [1, 1, 1, 2, 2]
+        preds = [0, 0, 1, 1, 2]
+        score = precision_score(golds, preds)
         self.assertAlmostEqual(score, 0.5)
-        score = precision_score(gold, pred, pos_label=2)
+        score = precision_score(golds, preds, pos_label=2)
         self.assertAlmostEqual(score, 1.0)
 
     def test_recall(self):
-        gold = [1, 1, 1, 1, 2]
-        pred = [0, 2, 1, 1, 2]
-        score = recall_score(gold, pred)
+        golds = [1, 1, 1, 1, 2]
+        preds = [0, 2, 1, 1, 2]
+        score = recall_score(golds, preds)
         self.assertAlmostEqual(score, 0.5)
-        score = recall_score(gold, pred, pos_label=2)
+        score = recall_score(golds, preds, pos_label=2)
         self.assertAlmostEqual(score, 1.0)
 
     def test_f1(self):
-        gold = [1, 1, 1, 1, 2]
-        pred = [0, 2, 1, 1, 2]
-        score = f1_score(gold, pred)
+        golds = [1, 1, 1, 1, 2]
+        preds = [0, 2, 1, 1, 2]
+        score = f1_score(golds, preds)
         self.assertAlmostEqual(score, 0.666, places=2)
-        score = f1_score(gold, pred, pos_label=2)
+        score = f1_score(golds, preds, pos_label=2)
         self.assertAlmostEqual(score, 0.666, places=2)
 
     def test_fbeta(self):
-        gold = [1, 1, 1, 1, 2]
-        pred = [0, 2, 1, 1, 2]
-        pre = precision_score(gold, pred)
-        rec = recall_score(gold, pred)
-        self.assertEqual(pre, fbeta_score(gold, pred, beta=0))
-        self.assertAlmostEqual(rec, fbeta_score(gold, pred, beta=1000), places=4)
+        golds = [1, 1, 1, 1, 2]
+        preds = [0, 2, 1, 1, 2]
+        pre = precision_score(golds, preds)
+        rec = recall_score(golds, preds)
+        self.assertEqual(pre, fbeta_score(golds, preds, beta=0))
+        self.assertAlmostEqual(rec, fbeta_score(golds, preds, beta=1000), places=4)
 
 
 if __name__ == "__main__":

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -4,17 +4,17 @@ import numpy as np
 
 from snorkel.analysis.utils import pred_to_prob, prob_to_pred
 
-PROB = np.array([[0.1, 0.9], [0.7, 0.3]])
-PRED = np.array([2, 1])
-PRED_SOFT = np.array([[0, 1], [1, 0]])
+PROBS = np.array([[0.1, 0.9], [0.7, 0.3]])
+PREDS = np.array([2, 1])
+PREDS_SOFT = np.array([[0, 1], [1, 0]])
 
 
 class MetricsTest(unittest.TestCase):
     def test_pred_to_prob(self):
-        np.testing.assert_array_equal(pred_to_prob(PRED, 2), PRED_SOFT)
+        np.testing.assert_array_equal(pred_to_prob(PREDS, 2), PREDS_SOFT)
 
     def test_prob_to_pred(self):
-        np.testing.assert_array_equal(prob_to_pred(PROB), PRED)
+        np.testing.assert_array_equal(prob_to_pred(PROBS), PREDS)
 
 
 if __name__ == "__main__":

--- a/test/end_model/test_scorer.py
+++ b/test/end_model/test_scorer.py
@@ -11,7 +11,7 @@ class ScorerTest(unittest.TestCase):
         preds = np.array([1, 0, 1, 1, 0])
         probs = np.array([0.8, 0.6, 0.9, 0.7, 0.4])
 
-        def sum(gold, pred, prob):
+        def sum(golds, preds, probs):
             return np.sum(preds)
 
         scorer = Scorer(metrics=["accuracy", "f1"], custom_metric_funcs={"sum": sum})


### PR DESCRIPTION
- Standardize names of label types: golds, preds, and probs (instead of gold, pred, prob).
- Remove an extra kwarg in metric_score (had both prob and probs, which collided after the refactor)

Test plan:
All tests still pass after refactor
