### PR TITLE
Add Mapper memoization

### DIFF
--- a/snorkel/augmentation/apply/tf_applier.py
+++ b/snorkel/augmentation/apply/tf_applier.py
@@ -52,7 +52,7 @@ class BaseTFApplier:
 
     def _set_tf_mode(self, mode: TransformationFunctionMode) -> None:
         for tf in self._tfs:
-            tf.set_mode(mode)
+            tf.mode = mode
 
     def _apply_policy_to_data_point(self, x: DataPoint) -> DataPoints:
         x_transformed = []

--- a/snorkel/labeling/lf.py
+++ b/snorkel/labeling/lf.py
@@ -93,7 +93,7 @@ class LabelingFunction:
             Mode to set preprocessors to
         """
         for preprocessor in self._preprocessors:
-            preprocessor.set_mode(mode)
+            preprocessor.mode = mode
 
     def _preprocess_data_point(self, x: DataPoint) -> DataPoint:
         for preprocessor in self._preprocessors:

--- a/snorkel/map/core.py
+++ b/snorkel/map/core.py
@@ -53,6 +53,7 @@ def get_hashable(obj: Any) -> Hashable:
     This helper is used for caching mapper outputs of data points.
     For common data point formats (e.g. SimpleNamespace, pandas.Series),
     produces hashable representations of the values using a `frozenset`.
+    For objects like `pandas.Series`, the name/index indentifier is dropped.
 
     Parameters
     ----------
@@ -62,12 +63,12 @@ def get_hashable(obj: Any) -> Hashable:
     Returns
     -------
     Hashable
-        [description]
+        Hashable representation of object values
 
     Raises
     ------
     ValueError
-        [description]
+        No hashable proxy for object
     """
     # If hashable already, just return
     if is_hashable(obj):

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -10,13 +10,13 @@ from snorkel.augmentation.tf import transformation_function
 from snorkel.types import DataPoint
 
 
-@transformation_function
+@transformation_function()
 def square(x: DataPoint) -> DataPoint:
     x.num = x.num ** 2
     return x
 
 
-@transformation_function
+@transformation_function()
 def square_returns_none(x: DataPoint) -> DataPoint:
     if x.num == 2:
         return None
@@ -24,7 +24,7 @@ def square_returns_none(x: DataPoint) -> DataPoint:
     return x
 
 
-@transformation_function
+@transformation_function()
 def modify_in_place(x: DataPoint) -> DataPoint:
     x.d["my_key"] = 0
     return x

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -18,13 +18,19 @@ from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
 from snorkel.types import DataPoint
 
 
-@preprocessor
+@preprocessor()
 def square(x: DataPoint) -> DataPoint:
     x.num_squared = x.num ** 2
     return x
 
 
-spacy = SpacyPreprocessor(text_field="text", doc_field="doc")
+class SquareHitTracker:
+    def __init__(self):
+        self.n_hits = 0
+
+    def __call__(self, x: float) -> float:
+        self.n_hits += 1
+        return x ** 2
 
 
 @labeling_function()
@@ -42,22 +48,12 @@ def g(x: DataPoint, db: List[int]) -> int:
     return 1 if x.num in db else 0
 
 
-@labeling_function(preprocessors=[spacy])
-def first_is_name(x: DataPoint) -> int:
-    return 1 if x.doc[0].pos_ == "PROPN" else 0
+DATA = [3, 43, 12, 9, 3]
+L_EXPECTED = np.array([[0, 1], [1, 0], [0, 0], [0, 1], [0, 1]])
+L_PREPROCESS_EXPECTED = np.array([[0, 0], [1, 1], [0, 1], [0, 1], [0, 0]])
 
-
-@labeling_function(preprocessors=[spacy])
-def has_verb(x: DataPoint) -> int:
-    return 1 if sum(t.pos_ == "VERB" for t in x.doc) > 0 else 0
-
-
-DATA = [3, 43, 12, 9]
-L_EXPECTED = np.array([[0, 1], [1, 0], [0, 0], [0, 1]])
-L_PREPROCESS_EXPECTED = np.array([[0, 0], [1, 1], [0, 1], [0, 1]])
-
-TEXT_DATA = ["Jane", "Jane plays soccer."]
-L_TEXT_EXPECTED = np.array([[1, 0], [1, 1]])
+TEXT_DATA = ["Jane", "Jane plays soccer.", "Jane plays soccer."]
+L_TEXT_EXPECTED = np.array([[1, 0], [1, 1], [1, 1]])
 
 
 class TestLFApplier(unittest.TestCase):
@@ -73,6 +69,24 @@ class TestLFApplier(unittest.TestCase):
         L = applier.apply(data_points)
         np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
 
+    def test_lf_applier_preprocessor_memoized(self) -> None:
+        data_points = [SimpleNamespace(num=num) for num in DATA]
+        square_hit_tracker = SquareHitTracker()
+
+        @preprocessor(memoize=True)
+        def square_memoize(x: DataPoint) -> DataPoint:
+            x.num_squared = square_hit_tracker(x.num)
+            return x
+
+        @labeling_function(preprocessors=[square_memoize])
+        def fp_memoized(x: DataPoint) -> int:
+            return 1 if x.num_squared > 42 else 0
+
+        applier = LFApplier([f, fp_memoized])
+        L = applier.apply(data_points)
+        np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
+        self.assertEqual(square_hit_tracker.n_hits, 4)
+
 
 class TestPandasApplier(unittest.TestCase):
     def test_lf_applier_pandas(self) -> None:
@@ -87,11 +101,57 @@ class TestPandasApplier(unittest.TestCase):
         L = applier.apply(df)
         np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
 
+    def test_lf_applier_pandas_preprocessor_memoized(self) -> None:
+        df = pd.DataFrame(dict(num=DATA))
+        square_hit_tracker = SquareHitTracker()
+
+        @preprocessor(memoize=True)
+        def square_memoize(x: DataPoint) -> DataPoint:
+            x.num_squared = square_hit_tracker(x.num)
+            return x
+
+        @labeling_function(preprocessors=[square_memoize])
+        def fp_memoized(x: DataPoint) -> int:
+            return 1 if x.num_squared > 42 else 0
+
+        applier = PandasLFApplier([f, fp_memoized])
+        L = applier.apply(df)
+        np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
+        self.assertEqual(square_hit_tracker.n_hits, 4)
+
     def test_lf_applier_pandas_spacy_preprocessor(self) -> None:
+        spacy = SpacyPreprocessor(text_field="text", doc_field="doc")
+
+        @labeling_function(preprocessors=[spacy])
+        def first_is_name(x: DataPoint) -> int:
+            return 1 if x.doc[0].pos_ == "PROPN" else 0
+
+        @labeling_function(preprocessors=[spacy])
+        def has_verb(x: DataPoint) -> int:
+            return 1 if sum(t.pos_ == "VERB" for t in x.doc) > 0 else 0
+
         df = pd.DataFrame(dict(text=TEXT_DATA))
         applier = PandasLFApplier([first_is_name, has_verb])
         L = applier.apply(df)
         np.testing.assert_equal(L.toarray(), L_TEXT_EXPECTED)
+
+    def test_lf_applier_pandas_spacy_preprocessor_memoized(self) -> None:
+        spacy = SpacyPreprocessor(text_field="text", doc_field="doc")
+        spacy.memoize_outputs(True)
+
+        @labeling_function(preprocessors=[spacy])
+        def first_is_name(x: DataPoint) -> int:
+            return 1 if x.doc[0].pos_ == "PROPN" else 0
+
+        @labeling_function(preprocessors=[spacy])
+        def has_verb(x: DataPoint) -> int:
+            return 1 if sum(t.pos_ == "VERB" for t in x.doc) > 0 else 0
+
+        df = pd.DataFrame(dict(text=TEXT_DATA))
+        applier = PandasLFApplier([first_is_name, has_verb])
+        L = applier.apply(df)
+        np.testing.assert_equal(L.toarray(), L_TEXT_EXPECTED)
+        self.assertEqual(len(spacy._cache), 2)
 
 
 class TestDaskApplier(unittest.TestCase):
@@ -110,6 +170,16 @@ class TestDaskApplier(unittest.TestCase):
         np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
 
     def test_lf_applier_dask_spacy_preprocessor(self) -> None:
+        spacy = SpacyPreprocessor(text_field="text", doc_field="doc")
+
+        @labeling_function(preprocessors=[spacy])
+        def first_is_name(x: DataPoint) -> int:
+            return 1 if x.doc[0].pos_ == "PROPN" else 0
+
+        @labeling_function(preprocessors=[spacy])
+        def has_verb(x: DataPoint) -> int:
+            return 1 if sum(t.pos_ == "VERB" for t in x.doc) > 0 else 0
+
         df = pd.DataFrame(dict(text=TEXT_DATA))
         df = dd.from_pandas(df, npartitions=2)
         applier = DaskLFApplier([first_is_name, has_verb])

--- a/test/labeling/preprocess/test_nlp.py
+++ b/test/labeling/preprocess/test_nlp.py
@@ -9,7 +9,7 @@ class TestSpacyPreprocessor(unittest.TestCase):
     def test_spacy_preprocessor(self) -> None:
         x = SimpleNamespace(text="Jane plays soccer.")
         preprocessor = SpacyPreprocessor("text", "doc")
-        preprocessor.set_mode(PreprocessorMode.NAMESPACE)
+        preprocessor.mode = PreprocessorMode.NAMESPACE
         x_preprocessed = preprocessor(x)
         self.assertEqual(len(x_preprocessed.doc), 4)
         token = x_preprocessed.doc[0]

--- a/test/labeling/test_lf.py
+++ b/test/labeling/test_lf.py
@@ -8,13 +8,13 @@ from snorkel.labeling.preprocess import PreprocessorMode, preprocessor
 from snorkel.types import DataPoint
 
 
-@preprocessor
+@preprocessor()
 def square(x: DataPoint) -> DataPoint:
     x.num = x.num ** 2
     return x
 
 
-@preprocessor
+@preprocessor()
 def returns_none(x: DataPoint) -> DataPoint:
     return None
 

--- a/test/map/test_core.py
+++ b/test/map/test_core.py
@@ -280,3 +280,9 @@ class TestGetHashable(unittest.TestCase):
         x_hashable = get_hashable(x)
         x_expected = (8, frozenset((("a", v.data.tobytes()),)))
         self.assertEqual(x_hashable, x_expected)
+
+    def test_get_hashable_unhashable(self) -> None:
+        v = pd.DataFrame(dict(a=[4, 5], b=[1, 2]))
+        x = (8, dict(a=v))
+        with self.assertRaises(ValueError):
+            get_hashable(x)

--- a/test/map/test_core.py
+++ b/test/map/test_core.py
@@ -71,7 +71,6 @@ class TestMapperCore(unittest.TestCase):
         return SimpleNamespace(num=8, d=dict(my_key=1))
 
     def test_numeric_mapper(self) -> None:
-        square.set_mode(MapperMode.NAMESPACE)
         x_mapped = square(self._get_x())
         # NB: not using `self.assertIsNotNone` due to mypy
         # See https://github.com/python/mypy/issues/5088
@@ -82,7 +81,7 @@ class TestMapperCore(unittest.TestCase):
 
     def test_text_mapper(self) -> None:
         split_words = SplitWordsMapper("text", "text_lower", "text_words")
-        split_words.set_mode(MapperMode.NAMESPACE)
+        split_words.mode = MapperMode.NAMESPACE
         x_mapped = split_words(self._get_x())
         assert x_mapped is not None
         self.assertEqual(x_mapped.num, 8)
@@ -92,7 +91,7 @@ class TestMapperCore(unittest.TestCase):
 
     def test_mapper_same_field(self) -> None:
         split_words = SplitWordsMapper("text", "text", "text_words")
-        split_words.set_mode(MapperMode.NAMESPACE)
+        split_words.mode = MapperMode.NAMESPACE
         x = self._get_x()
         x_mapped = split_words(x)
         self.assertEqual(x.num, 8)
@@ -105,7 +104,7 @@ class TestMapperCore(unittest.TestCase):
 
     def test_mapper_default_args(self) -> None:
         split_words = SplitWordsMapperDefaultArgs()
-        split_words.set_mode(MapperMode.NAMESPACE)
+        split_words.mode = MapperMode.NAMESPACE
         x_mapped = split_words(self._get_x())
         assert x_mapped is not None
         self.assertEqual(x_mapped.num, 8)
@@ -114,7 +113,6 @@ class TestMapperCore(unittest.TestCase):
         self.assertEqual(x_mapped.words, ["Henry", "has", "fun"])
 
     def test_mapper_in_place(self) -> None:
-        modify_in_place.set_mode(MapperMode.NAMESPACE)
         x = self._get_x_dict()
         x_mapped = modify_in_place(x)
         self.assertEqual(x.num, 8)
@@ -127,7 +125,7 @@ class TestMapperCore(unittest.TestCase):
 
     def test_mapper_returns_none(self) -> None:
         mapper = MapperReturnsNone()
-        mapper.set_mode(MapperMode.NAMESPACE)
+        mapper.mode = MapperMode.NAMESPACE
         x_mapped = mapper(self._get_x())
         self.assertIsNone(x_mapped)
 
@@ -139,7 +137,6 @@ class TestMapperCore(unittest.TestCase):
             x.num_squared = square_hit_tracker(x.num)
             return x
 
-        square.set_mode(MapperMode.NAMESPACE)
         x8 = self._get_x()
         x9 = self._get_x(9)
         x8_mapped = square(x8)
@@ -175,7 +172,6 @@ class TestMapperCore(unittest.TestCase):
                 return None
             return x
 
-        square.set_mode(MapperMode.NAMESPACE)
         x21 = self._get_x(21)
         x21_mapped = square(x21)
         self.assertIsNone(x21_mapped)
@@ -192,7 +188,6 @@ class TestMapperCore(unittest.TestCase):
             x.num_squared = square_hit_tracker(x.num)
             return x
 
-        square.set_mode(MapperMode.NAMESPACE)
         x8 = self._get_x()
         x9 = self._get_x(9)
         x8_mapped = square(x8)
@@ -223,15 +218,15 @@ class TestMapperCore(unittest.TestCase):
         x = self._get_x()
         split_words = SplitWordsMapper("text", "text_lower", "text_words")
 
-        split_words.set_mode(18)  # type: ignore
+        split_words.mode = 18  # type: ignore
         with self.assertRaises(ValueError):
             split_words(x)
 
-        split_words.set_mode(MapperMode.NONE)
+        split_words.mode = MapperMode.NONE
         with self.assertRaises(ValueError):
             split_words(x)
 
-        split_words.set_mode(MapperMode.SPARK)
+        split_words.mode = MapperMode.SPARK
         with self.assertRaises(NotImplementedError):
             split_words(x)
 

--- a/test/map/test_core.py
+++ b/test/map/test_core.py
@@ -2,7 +2,12 @@ import unittest
 from types import SimpleNamespace
 from typing import Any, Optional
 
+import numpy as np
+import pandas as pd
+import spacy
+
 from snorkel.map import Mapper, MapperMode, lambda_mapper
+from snorkel.map.core import get_hashable
 from snorkel.types import DataPoint, FieldMap
 
 
@@ -36,13 +41,22 @@ class MapperWithKwargs(Mapper):
         return None
 
 
-@lambda_mapper
+class SquareHitTracker:
+    def __init__(self):
+        self.n_hits = 0
+
+    def __call__(self, x: float) -> float:
+        self.n_hits += 1
+        return x ** 2
+
+
+@lambda_mapper()
 def square(x: DataPoint) -> DataPoint:
     x.num_squared = x.num ** 2
     return x
 
 
-@lambda_mapper
+@lambda_mapper()
 def modify_in_place(x: DataPoint) -> DataPoint:
     x.d["my_key"] = 0
     x.d_new = x.d
@@ -50,8 +64,8 @@ def modify_in_place(x: DataPoint) -> DataPoint:
 
 
 class TestMapperCore(unittest.TestCase):
-    def _get_x(self) -> SimpleNamespace:
-        return SimpleNamespace(num=8, text="Henry has fun")
+    def _get_x(self, num=8, text="Henry has fun") -> SimpleNamespace:
+        return SimpleNamespace(num=num, text=text)
 
     def _get_x_dict(self) -> SimpleNamespace:
         return SimpleNamespace(num=8, d=dict(my_key=1))
@@ -59,6 +73,9 @@ class TestMapperCore(unittest.TestCase):
     def test_numeric_mapper(self) -> None:
         square.set_mode(MapperMode.NAMESPACE)
         x_mapped = square(self._get_x())
+        # NB: not using `self.assertIsNotNone` due to mypy
+        # See https://github.com/python/mypy/issues/5088
+        assert x_mapped is not None
         self.assertEqual(x_mapped.num, 8)
         self.assertEqual(x_mapped.text, "Henry has fun")
         self.assertEqual(x_mapped.num_squared, 64)
@@ -67,6 +84,7 @@ class TestMapperCore(unittest.TestCase):
         split_words = SplitWordsMapper("text", "text_lower", "text_words")
         split_words.set_mode(MapperMode.NAMESPACE)
         x_mapped = split_words(self._get_x())
+        assert x_mapped is not None
         self.assertEqual(x_mapped.num, 8)
         self.assertEqual(x_mapped.text, "Henry has fun")
         self.assertEqual(x_mapped.text_lower, "henry has fun")
@@ -80,6 +98,7 @@ class TestMapperCore(unittest.TestCase):
         self.assertEqual(x.num, 8)
         self.assertEqual(x.text, "Henry has fun")
         self.assertFalse(hasattr(x, "text_words"))
+        assert x_mapped is not None
         self.assertEqual(x_mapped.num, 8)
         self.assertEqual(x_mapped.text, "henry has fun")
         self.assertEqual(x_mapped.text_words, ["Henry", "has", "fun"])
@@ -88,6 +107,7 @@ class TestMapperCore(unittest.TestCase):
         split_words = SplitWordsMapperDefaultArgs()
         split_words.set_mode(MapperMode.NAMESPACE)
         x_mapped = split_words(self._get_x())
+        assert x_mapped is not None
         self.assertEqual(x_mapped.num, 8)
         self.assertEqual(x_mapped.text, "Henry has fun")
         self.assertEqual(x_mapped.lower, "henry has fun")
@@ -100,6 +120,7 @@ class TestMapperCore(unittest.TestCase):
         self.assertEqual(x.num, 8)
         self.assertEqual(x.d, dict(my_key=1))
         self.assertFalse(hasattr(x, "d_new"))
+        assert x_mapped is not None
         self.assertEqual(x_mapped.num, 8)
         self.assertEqual(x_mapped.d, dict(my_key=0))
         self.assertEqual(x_mapped.d_new, dict(my_key=0))
@@ -109,6 +130,87 @@ class TestMapperCore(unittest.TestCase):
         mapper.set_mode(MapperMode.NAMESPACE)
         x_mapped = mapper(self._get_x())
         self.assertIsNone(x_mapped)
+
+    def test_decorator_mapper_memoized(self) -> None:
+        square_hit_tracker = SquareHitTracker()
+
+        @lambda_mapper(memoize=True)
+        def square(x: DataPoint) -> DataPoint:
+            x.num_squared = square_hit_tracker(x.num)
+            return x
+
+        square.set_mode(MapperMode.NAMESPACE)
+        x8 = self._get_x()
+        x9 = self._get_x(9)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x19_mapped = square(x9)
+        assert x19_mapped is not None
+        self.assertEqual(x19_mapped.num_squared, 81)
+        self.assertEqual(square_hit_tracker.n_hits, 2)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 2)
+
+        square.reset_cache()
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 3)
+
+    def test_decorator_mapper_memoized_none(self) -> None:
+        square_hit_tracker = SquareHitTracker()
+
+        @lambda_mapper(memoize=True)
+        def square(x: DataPoint) -> DataPoint:
+            x.num_squared = square_hit_tracker(x.num)
+            if x.num == 21:
+                return None
+            return x
+
+        square.set_mode(MapperMode.NAMESPACE)
+        x21 = self._get_x(21)
+        x21_mapped = square(x21)
+        self.assertIsNone(x21_mapped)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x21_mapped = square(x21)
+        self.assertIsNone(x21_mapped)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+
+    def test_decorator_mapper_not_memoized(self) -> None:
+        square_hit_tracker = SquareHitTracker()
+
+        @lambda_mapper(memoize=False)
+        def square(x: DataPoint) -> DataPoint:
+            x.num_squared = square_hit_tracker(x.num)
+            return x
+
+        square.set_mode(MapperMode.NAMESPACE)
+        x8 = self._get_x()
+        x9 = self._get_x(9)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 2)
+        x19_mapped = square(x9)
+        assert x19_mapped is not None
+        self.assertEqual(x19_mapped.num_squared, 81)
+        self.assertEqual(square_hit_tracker.n_hits, 3)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 4)
 
     def test_mapper_with_args_kwargs(self) -> None:
         with self.assertRaises(ValueError):
@@ -132,3 +234,49 @@ class TestMapperCore(unittest.TestCase):
         split_words.set_mode(MapperMode.SPARK)
         with self.assertRaises(NotImplementedError):
             split_words(x)
+
+
+class TestGetHashable(unittest.TestCase):
+    def test_get_hashable_hashable(self) -> None:
+        x = (8, "abc")
+        x_hashable = get_hashable(x)
+        self.assertEqual(x, x_hashable)
+
+    def test_get_hashable_dict(self) -> None:
+        d = dict(a=8, b=dict(c=9, d="foo"))
+        d_hashable = get_hashable(d)
+        d_sub_expected = frozenset((("c", 9), ("d", "foo")))
+        d_expected = frozenset((("a", 8), ("b", d_sub_expected)))
+        self.assertEqual(d_hashable, d_expected)
+        self.assertEqual(hash(d_hashable), hash(d_expected))
+
+    def test_get_hashable_list(self) -> None:
+        c = [8, dict(c=9, d="foo")]
+        c_hashable = get_hashable(c)
+        c_expected = (8, frozenset((("c", 9), ("d", "foo"))))
+        self.assertEqual(c_hashable, c_expected)
+        self.assertEqual(hash(c_hashable), hash(c_expected))
+
+    def test_get_hashable_series(self) -> None:
+        s = pd.Series(dict(a=8, b=dict(c=9, d="foo")), name="bar")
+        s_hashable = get_hashable(s)
+        s_sub_expected = frozenset((("c", 9), ("d", "foo")))
+        s_expected = frozenset((("a", 8), ("b", s_sub_expected)))
+        self.assertEqual(s_hashable, s_expected)
+        self.assertEqual(hash(s_hashable), hash(s_expected))
+
+    def test_get_hashable_series_with_doc(self) -> None:
+        nlp = spacy.load("en_core_web_sm")
+        doc = nlp("Foo went to the bar.")
+        s = pd.Series(dict(a=8, b=doc), name="baz")
+        s_hashable = get_hashable(s)
+        s_expected = frozenset((("a", 8), ("b", doc)))
+        self.assertEqual(s_hashable, s_expected)
+        self.assertEqual(hash(s_hashable), hash(s_expected))
+
+    def test_get_hashable_ndarray(self) -> None:
+        v = np.array([[3, 6, 9], [0.4, 0.8, 0.12]])
+        x = (8, dict(a=v))
+        x_hashable = get_hashable(x)
+        x_expected = (8, frozenset((("a", v.data.tobytes()),)))
+        self.assertEqual(x_hashable, x_expected)


### PR DESCRIPTION
Adds memoization to `BaseMapper` classes (preprocessor, TF, etc.).

* BaseMapper objects just maintain a simple dictionary cache which is populated/read from if memoization is turned on
* Only complexity is in `get_hashable`, which recursively generates a hashable value type for common unhashable data types we encounter (SimpleNamespace, pd.Series, np.ndarray, list, dict). It's a bit tricky, so it's extensively tested in both `test/labeling/apply/test_lf_applier.py` and `test/map/test_core.py`
* Considered using `functools.lru_cache`, but it doesn't handle unhashable types
* `lambda_mapper` is now a class so it has parens (@bhancock8 @vincentschen)

There are times we could manually reset the preprocessor caches (e.g. LFApplier.__call__), but not sure we always want to. Opinions welcome. In a follow-up diff, will introduce nested mappers. These two diffs together mean we avoid re-execution of preprocessors when they're used by multiple LFs.

**Test plan**
* Lots of added unit tests for `get_hashable` and BaseMapper caching
* Speed-up test results below. Ran on 2000k English movie review sentences with 4 LFs that use SpaCy. Speed-up is close to 4x (corresponding to reduction in SpaCy calls).

<img width="701" alt="Screen Shot 2019-06-28 at 7 23 19 PM" src="https://user-images.githubusercontent.com/7783678/60378652-59cc6b00-99da-11e9-9499-1648eaf5ba61.png">
