### PR TITLE
Add basic deterministic policies

### DIFF
--- a/snorkel/augmentation/apply/tf_applier.py
+++ b/snorkel/augmentation/apply/tf_applier.py
@@ -2,7 +2,7 @@ from typing import Any, List
 
 from tqdm import tqdm
 
-from snorkel.augmentation.policy import AugmentationPolicy
+from snorkel.augmentation.policy import Policy
 from snorkel.augmentation.tf import (
     BaseTransformationFunction,
     TransformationFunctionMode,
@@ -38,7 +38,7 @@ class BaseTFApplier:
     def __init__(
         self,
         tfs: List[BaseTransformationFunction],
-        policy: AugmentationPolicy,
+        policy: Policy,
         k: int = 1,
         keep_original: bool = True,
     ) -> None:

--- a/snorkel/augmentation/policy/__init__.py
+++ b/snorkel/augmentation/policy/__init__.py
@@ -1,6 +1,6 @@
 from .core import (  # noqa: F401
-    AugmentationPolicy,
     ApplyAllAugmentationPolicy,
     ApplyOneAugmentationPolicy,
+    AugmentationPolicy,
     RandomAugmentationPolicy,
 )

--- a/snorkel/augmentation/policy/__init__.py
+++ b/snorkel/augmentation/policy/__init__.py
@@ -1,6 +1,2 @@
-from .core import (  # noqa: F401
-    ApplyAllAugmentationPolicy,
-    ApplyOneAugmentationPolicy,
-    AugmentationPolicy,
-    RandomAugmentationPolicy,
-)
+from .core import ApplyAllPolicy, ApplyOnePolicy, Policy  # noqa: F401
+from .sampling import MeanFieldPolicy, RandomPolicy  # noqa: F401

--- a/snorkel/augmentation/policy/__init__.py
+++ b/snorkel/augmentation/policy/__init__.py
@@ -1,1 +1,6 @@
-from .core import AugmentationPolicy, RandomAugmentationPolicy  # noqa: F401
+from .core import (  # noqa: F401
+    AugmentationPolicy,
+    ApplyAllAugmentationPolicy,
+    ApplyOneAugmentationPolicy,
+    RandomAugmentationPolicy,
+)

--- a/snorkel/augmentation/policy/core.py
+++ b/snorkel/augmentation/policy/core.py
@@ -39,6 +39,32 @@ class AugmentationPolicy:
         raise NotImplementedError
 
 
+class ApplyAllAugmentationPolicy(AugmentationPolicy):
+    """Apply all TFs in order to each data point.
+
+    Parameters
+    ----------
+    n_tfs
+        Total number of TFs
+    """
+
+    def generate(self) -> List[int]:
+        """Generate indices of all TFs in order.
+
+        Returns
+        -------
+        List[int]
+            Indices of all TFs in order.
+        """
+        return list(range(self._n))
+
+
+class ApplyOneAugmentationPolicy(ApplyAllAugmentationPolicy):
+    """Apply a single TF to each data point."""
+    def __init__(self):
+        super().__init__(n_tfs=1)
+
+
 class RandomAugmentationPolicy(AugmentationPolicy):
     """Naive random augmentation policy.
 

--- a/snorkel/augmentation/policy/core.py
+++ b/snorkel/augmentation/policy/core.py
@@ -1,9 +1,7 @@
-from typing import List, Optional, Sequence
-
-import numpy as np
+from typing import List
 
 
-class AugmentationPolicy:
+class Policy:
     """Base class for augmentation policies.
 
     Augmentation policies generate sequences of indices, corresponding
@@ -39,11 +37,11 @@ class AugmentationPolicy:
         raise NotImplementedError
 
 
-class ApplyAllAugmentationPolicy(AugmentationPolicy):
+class ApplyAllPolicy(Policy):
     """Apply all TFs in order to each data point.
 
     While this can be used as a baseline policy, using a
-    random policy is more standard. See `RandomAugmentationPolicy`.
+    random policy is more standard. See `RandomPolicy`.
 
     Parameters
     ----------
@@ -62,47 +60,8 @@ class ApplyAllAugmentationPolicy(AugmentationPolicy):
         return list(range(self._n))
 
 
-class ApplyOneAugmentationPolicy(ApplyAllAugmentationPolicy):
+class ApplyOnePolicy(ApplyAllPolicy):
     """Apply a single TF to each data point."""
 
     def __init__(self):
         super().__init__(n_tfs=1)
-
-
-class RandomAugmentationPolicy(AugmentationPolicy):
-    """Naive random augmentation policy.
-
-    Samples sequences of TF indices a specified length at random
-    from the total number of TFs. Sampling uniformly at random is
-    a common baseline approach to data augmentation. A distribution
-    over TFs can also be specified. This can be learned by a TANDA
-    mean-field model, for example.
-    See https://hazyresearch.github.io/snorkel/blog/tanda.html
-
-    Parameters
-    ----------
-    n_tfs
-        Total number of TFs
-    sequence_length
-        Number of TFs to run on each data point
-    p
-        Probability distribution from which to sample TF indices.
-        Must have length `n_tfs` and be a valid distribution.
-    """
-
-    def __init__(
-        self, n_tfs: int, sequence_length: int = 1, p: Optional[Sequence[float]] = None
-    ) -> None:
-        self._k = sequence_length
-        self._p = p
-        super().__init__(n_tfs)
-
-    def generate(self) -> List[int]:
-        """Generate a sequence of TF indices by sampling at random.
-
-        Returns
-        -------
-        List[int]
-            Indices of TFs to run on data point in order.
-        """
-        return np.random.choice(self._n, size=self._k, p=self._p).tolist()

--- a/snorkel/augmentation/policy/sampling.py
+++ b/snorkel/augmentation/policy/sampling.py
@@ -1,0 +1,61 @@
+from typing import List, Optional, Sequence
+
+import numpy as np
+
+from .core import Policy
+
+
+class MeanFieldPolicy(Policy):
+    """Sample sequences of TFs according to a distribution.
+
+    Samples sequences of indices of a specified length from a
+    user-provided distribution. A distribution over TFs can be
+    learned by a TANDA mean-field model, for example.
+    See https://hazyresearch.github.io/snorkel/blog/tanda.html
+
+    Parameters
+    ----------
+    n_tfs
+        Total number of TFs
+    sequence_length
+        Number of TFs to run on each data point
+    p
+        Probability distribution from which to sample TF indices.
+        Must have length `n_tfs` and be a valid distribution.
+    """
+
+    def __init__(
+        self, n_tfs: int, sequence_length: int = 1, p: Optional[Sequence[float]] = None
+    ) -> None:
+        self._k = sequence_length
+        self._p = p
+        super().__init__(n_tfs)
+
+    def generate(self) -> List[int]:
+        """Generate a sequence of TF indices by sampling from distribution.
+
+        Returns
+        -------
+        List[int]
+            Indices of TFs to run on data point in order.
+        """
+        return np.random.choice(self._n, size=self._k, p=self._p).tolist()
+
+
+class RandomPolicy(MeanFieldPolicy):
+    """Naive random augmentation policy.
+
+    Samples sequences of TF indices a specified length at random
+    from the total number of TFs. Sampling uniformly at random is
+    a common baseline approach to data augmentation.
+
+    Parameters
+    ----------
+    n_tfs
+        Total number of TFs
+    sequence_length
+        Number of TFs to run on each data point
+    """
+
+    def __init__(self, n_tfs: int, sequence_length: int = 1) -> None:
+        super().__init__(n_tfs, sequence_length=sequence_length, p=None)

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 import pandas as pd
 
 from snorkel.augmentation.apply import PandasTFApplier, TFApplier
-from snorkel.augmentation.policy import RandomAugmentationPolicy
+from snorkel.augmentation.policy import (
+    ApplyOneAugmentationPolicy,
+    RandomAugmentationPolicy,
+)
 from snorkel.augmentation.tf import transformation_function
 from snorkel.types import DataPoint
 
@@ -30,7 +33,7 @@ def modify_in_place(x: DataPoint) -> DataPoint:
 
 
 policy = RandomAugmentationPolicy(1, sequence_length=2)
-policy_modify_in_place = RandomAugmentationPolicy(1, sequence_length=1)
+policy_modify_in_place = ApplyOneAugmentationPolicy()
 
 
 DATA = [1, 2, 3]

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -4,10 +4,7 @@ from types import SimpleNamespace
 import pandas as pd
 
 from snorkel.augmentation.apply import PandasTFApplier, TFApplier
-from snorkel.augmentation.policy import (
-    ApplyOneAugmentationPolicy,
-    RandomAugmentationPolicy,
-)
+from snorkel.augmentation.policy import ApplyOnePolicy, RandomPolicy
 from snorkel.augmentation.tf import transformation_function
 from snorkel.types import DataPoint
 
@@ -32,8 +29,8 @@ def modify_in_place(x: DataPoint) -> DataPoint:
     return x
 
 
-policy = RandomAugmentationPolicy(1, sequence_length=2)
-policy_modify_in_place = ApplyOneAugmentationPolicy()
+policy = RandomPolicy(1, sequence_length=2)
+policy_modify_in_place = ApplyOnePolicy()
 
 
 DATA = [1, 2, 3]

--- a/test/augmentation/policy/test_core.py
+++ b/test/augmentation/policy/test_core.py
@@ -6,14 +6,14 @@ from snorkel.augmentation.policy import RandomAugmentationPolicy
 class TestAugmentationPolicy(unittest.TestCase):
     def test_random_augmentation_policy(self):
         policy = RandomAugmentationPolicy(2, sequence_length=2)
-        n_transformed = 100
-        x_transformed = [policy.generate() for _ in range(n_transformed)]
-        a_ct = x_transformed.count([0, 0])
-        b_ct = x_transformed.count([0, 1])
-        c_ct = x_transformed.count([1, 0])
-        d_ct = x_transformed.count([1, 1])
+        n_samples = 100
+        samples = [policy.generate() for _ in range(n_samples)]
+        a_ct = samples.count([0, 0])
+        b_ct = samples.count([0, 1])
+        c_ct = samples.count([1, 0])
+        d_ct = samples.count([1, 1])
         self.assertGreater(a_ct, 0)
         self.assertGreater(b_ct, 0)
         self.assertGreater(c_ct, 0)
         self.assertGreater(d_ct, 0)
-        self.assertEqual(a_ct + b_ct + c_ct + d_ct, n_transformed)
+        self.assertEqual(a_ct + b_ct + c_ct + d_ct, n_samples)

--- a/test/augmentation/policy/test_core.py
+++ b/test/augmentation/policy/test_core.py
@@ -17,3 +17,9 @@ class TestAugmentationPolicy(unittest.TestCase):
         self.assertGreater(c_ct, 0)
         self.assertGreater(d_ct, 0)
         self.assertEqual(a_ct + b_ct + c_ct + d_ct, n_samples)
+
+    def test_random_augmentation_policy_distribution(self):
+        policy = RandomAugmentationPolicy(2, sequence_length=2, p=[1, 0])
+        n_samples = 100
+        samples = [policy.generate() for _ in range(n_samples)]
+        self.assertEqual(samples.count([0, 0]), n_samples)

--- a/test/augmentation/policy/test_core.py
+++ b/test/augmentation/policy/test_core.py
@@ -1,11 +1,11 @@
 import unittest
 
-from snorkel.augmentation.policy import RandomAugmentationPolicy
+from snorkel.augmentation.policy import MeanFieldPolicy, RandomPolicy
 
 
 class TestAugmentationPolicy(unittest.TestCase):
     def test_random_augmentation_policy(self):
-        policy = RandomAugmentationPolicy(2, sequence_length=2)
+        policy = RandomPolicy(2, sequence_length=2)
         n_samples = 100
         samples = [policy.generate() for _ in range(n_samples)]
         a_ct = samples.count([0, 0])
@@ -18,8 +18,8 @@ class TestAugmentationPolicy(unittest.TestCase):
         self.assertGreater(d_ct, 0)
         self.assertEqual(a_ct + b_ct + c_ct + d_ct, n_samples)
 
-    def test_random_augmentation_policy_distribution(self):
-        policy = RandomAugmentationPolicy(2, sequence_length=2, p=[1, 0])
+    def test_mean_field_augmentation_policy(self):
+        policy = MeanFieldPolicy(2, sequence_length=2, p=[1, 0])
         n_samples = 100
         samples = [policy.generate() for _ in range(n_samples)]
         self.assertEqual(samples.count([0, 0]), n_samples)

--- a/test/synthetic/test_synthetic_data.py
+++ b/test/synthetic/test_synthetic_data.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from snorkel.augmentation.apply import PandasTFApplier
-from snorkel.augmentation.policy import RandomAugmentationPolicy
+from snorkel.augmentation.policy import ApplyOnePolicy
 from snorkel.labeling.apply import PandasLFApplier
 from snorkel.synthetic.synthetic_data import (
     generate_mog_dataset,
@@ -86,7 +86,7 @@ class TestGenerateResamplingTFs(unittest.TestCase):
         data = generate_mog_dataset(10, 4)
         tf_dim = 0
         tfs = generate_resampling_tfs(dims=[tf_dim])
-        policy = RandomAugmentationPolicy(len(tfs), sequence_length=1)
+        policy = ApplyOnePolicy()
         applier = PandasTFApplier(tfs, policy, keep_original=False)
         data_augmented = applier.apply(data)
         X = np.array(data.x.tolist())


### PR DESCRIPTION
* Adds distribution option for random policy (e.g. sticking in a distribution learned by a TANDA mean-field model)
* Adds a policy that just generates [0, 1, ..., k]
* Adds a policy that just generates [0]

**Test plan**
* Added unit test for distribution
* Other two don't really need testing, but assured basic functionality by using ApplyOne in a test