### PR TITLE
Add generator mode to TF applier

### DIFF
--- a/snorkel/augmentation/apply/tf_applier.py
+++ b/snorkel/augmentation/apply/tf_applier.py
@@ -151,7 +151,7 @@ class TFApplier(BaseTFApplier):
         List[DataPoint]
             List of data points in augmented data set for batches of inputs
         """
-        for i in range(0, len(data_points), step=batch_size):
+        for i in range(0, len(data_points), batch_size):
             batch_transformed: List[DataPoint] = []
             for x in data_points[i : i + batch_size]:
                 batch_transformed.extend(self._apply_policy_to_data_point(x))

--- a/snorkel/augmentation/apply/tf_applier.py
+++ b/snorkel/augmentation/apply/tf_applier.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, Iterator, List
 
 from tqdm import tqdm
 
@@ -7,7 +7,7 @@ from snorkel.augmentation.tf import (
     BaseTransformationFunction,
     TransformationFunctionMode,
 )
-from snorkel.types import DataPoint
+from snorkel.types import DataPoint, DataPoints
 
 
 class BaseTFApplier:
@@ -51,7 +51,7 @@ class BaseTFApplier:
         for tf in self._tfs:
             tf.set_mode(mode)
 
-    def _apply_policy_to_data_point(self, x: DataPoint) -> List[DataPoint]:
+    def _apply_policy_to_data_point(self, x: DataPoint) -> DataPoints:
         x_transformed = []
         if self._keep_original:
             x_transformed.append(x)
@@ -69,7 +69,7 @@ class BaseTFApplier:
         return x_transformed
 
     def apply(self, data_points: Any, *args: Any, **kwargs: Any) -> Any:
-        """Label collection of data points with LFs.
+        """Transform a collection of data points with TFs and policy.
 
         Parameters
         ----------
@@ -89,6 +89,37 @@ class BaseTFApplier:
         """
         raise NotImplementedError
 
+    def apply_generator(
+        self, data_points: Any, batch_size: int, *args: Any, **kwargs: Any
+    ) -> Any:
+        """Transform a collection of data points with TFs and policy in batches.
+
+        This method acts as a generator, yielding augmented data points for
+        a given input batch of data points. This can be useful in a training
+        loop when it is too memory-intensive to pregenerate all transformed
+        examples.
+
+        Parameters
+        ----------
+        data_points
+            Collection of data points to be transformed by TFs and policy. Subclasses
+            implement functionality for a specific format (e.g. `DataFrame`).
+        batch_size
+            Batch size for generator. Yields augmented data points
+            for the next `batch_size` input data points.
+
+        Yields
+        ------
+        Any
+            Collections of data points in augmented data set for batches of inputs
+
+        Raises
+        ------
+        NotImplementedError
+            This method must be implemented by subclasses
+        """
+        raise NotImplementedError
+
 
 class TFApplier(BaseTFApplier):
     """TF applier for a list of data points.
@@ -97,7 +128,36 @@ class TFApplier(BaseTFApplier):
     useful for testing.
     """
 
-    def apply(self, data_points: List[DataPoint]) -> List[DataPoint]:  # type: ignore
+    def apply_generator(  # type: ignore
+        self, data_points: DataPoints, batch_size: int
+    ) -> Iterator[List[DataPoint]]:
+        """Augment a list of data points using TFs and policy in batches.
+
+        This method acts as a generator, yielding augmented data points for
+        a given input batch of data points. This can be useful in a training
+        loop when it is too memory-intensive to pregenerate all transformed
+        examples.
+
+        Parameters
+        ----------
+        data_points
+            List containing data points to be transformed
+        batch_size
+            Batch size for generator. Yields augmented data points
+            for the next `batch_size` input data points.
+
+        Yields
+        ------
+        List[DataPoint]
+            List of data points in augmented data set for batches of inputs
+        """
+        for i in range(0, len(data_points), step=batch_size):
+            batch_transformed: List[DataPoint] = []
+            for x in data_points[i : i + batch_size]:
+                batch_transformed.extend(self._apply_policy_to_data_point(x))
+            yield batch_transformed
+
+    def apply(self, data_points: DataPoints) -> List[DataPoint]:  # type: ignore
         """Augment a list of data points using TFs and policy.
 
         Parameters
@@ -108,10 +168,10 @@ class TFApplier(BaseTFApplier):
         Returns
         -------
         List[DataPoint]
-            Augmented list of data points
+            List of data points in augmented data set
         """
         self._set_tf_mode(TransformationFunctionMode.NAMESPACE)
-        x_transformed = []
+        x_transformed: List[DataPoint] = []
         for x in tqdm(data_points):
             x_transformed.extend(self._apply_policy_to_data_point(x))
         return x_transformed

--- a/snorkel/augmentation/apply/tf_applier.py
+++ b/snorkel/augmentation/apply/tf_applier.py
@@ -27,7 +27,10 @@ class BaseTFApplier:
     k
         Number of transformed data points per original
     keep_original
-        Keep untransformed data point in augmented data set?
+        Keep untransformed data point in augmented data set? Note that
+        even if in-place modifications are made to the original data
+        point by the TFs being applied, the original data point will
+        remain unchanged.
 
     Raises
     ------

--- a/snorkel/augmentation/apply/tf_applier_pandas.py
+++ b/snorkel/augmentation/apply/tf_applier_pandas.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import pandas as pd
 from tqdm import tqdm
 
@@ -15,6 +17,38 @@ class PandasTFApplier(BaseTFApplier):
     For large datasets, consider `DaskTFApplier` or `SparkTFApplier`.
     """
 
+    def apply_generator(  # type: ignore
+        self, df: pd.DataFrame, batch_size: int
+    ) -> pd.DataFrame:
+        """Augment a Pandas DataFrame of data points using TFs and policy in batches.
+
+        This method acts as a generator, yielding augmented data points for
+        a given input batch of data points. This can be useful in a training
+        loop when it is too memory-intensive to pregenerate all transformed
+        examples.
+
+        Parameters
+        ----------
+        df
+            Pandas DataFrame containing data points to be transformed
+        batch_size
+            Batch size for generator. Yields augmented data points
+            for the next `batch_size` input data points.
+
+        Returns
+        -------
+        pd.DataFrame
+            Pandas DataFrame of data points in augmented data set
+        """
+        self._set_tf_mode(TransformationFunctionMode.PANDAS)
+        batch_transformed: List[pd.Series] = []
+        for i, (_, x) in enumerate(df.iterrows()):
+            batch_transformed.extend(self._apply_policy_to_data_point(x))
+            if (i + 1) % batch_size == 0:
+                yield pd.concat(batch_transformed, axis=1).T
+                batch_transformed = []
+        yield pd.concat(batch_transformed, axis=1).T
+
     def apply(self, df: pd.DataFrame) -> pd.DataFrame:  # type: ignore
         """Augment a Pandas DataFrame of data points using TFs and policy.
 
@@ -26,10 +60,10 @@ class PandasTFApplier(BaseTFApplier):
         Returns
         -------
         pd.DataFrame
-            Augmented DataFrame of data points
+            Pandas DataFrame of data points in augmented data set
         """
         self._set_tf_mode(TransformationFunctionMode.PANDAS)
-        x_transformed = []
+        x_transformed: List[pd.Series] = []
         for _, x in tqdm(df.iterrows(), total=len(df)):
             x_transformed.extend(self._apply_policy_to_data_point(x))
         return pd.concat(x_transformed, axis=1).T

--- a/snorkel/types/data.py
+++ b/snorkel/types/data.py
@@ -1,11 +1,11 @@
-from typing import Any, Collection, Mapping, Union
+from typing import Any, Mapping, Sequence, Union
 
 import numpy as np
 import scipy.sparse as sparse
 from torch import Tensor
 
 DataPoint = Any
-DataPoints = Collection[DataPoint]
+DataPoints = Sequence[DataPoint]
 
 Field = Any
 FieldMap = Mapping[str, Field]

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -40,6 +40,10 @@ DATA_IN_PLACE_EXPECTED = [
 ]
 
 
+def make_df(values: list, index: list, key: str = "num") -> pd.DataFrame:
+    return pd.DataFrame({key: values}, index=index)
+
+
 # NB: reconstruct each time to avoid inplace updates
 def get_data_dict():
     return [dict(my_key=num) for num in DATA]
@@ -96,7 +100,51 @@ class TestTFApplier(unittest.TestCase):
         self.assertTrue(all(x.d == y for x, y in zip(data, get_data_dict())))
 
     def test_tf_applier_generator(self) -> None:
-        pass
+        data = self._get_x_namespace()
+        applier = TFApplier([square], policy, k=1, keep_original=False)
+        batches_expected = [[1, 16], [81]]
+        gen = applier.apply_generator(data, batch_size=2)
+        for batch, batch_expected in zip(gen, batches_expected):
+            self.assertEqual([x.num for x in batch], batch_expected)
+        self.assertEqual([x.num for x in data], DATA)
+
+    def test_tf_applier_multi_generator(self) -> None:
+        data = self._get_x_namespace()
+        applier = TFApplier([square], policy, k=2, keep_original=False)
+        batches_expected = [[1, 1, 16, 16], [81, 81]]
+        gen = applier.apply_generator(data, batch_size=2)
+        for batch, batch_expected in zip(gen, batches_expected):
+            self.assertEqual([x.num for x in batch], batch_expected)
+        self.assertEqual([x.num for x in data], DATA)
+
+    def test_tf_applier_keep_original_generator(self) -> None:
+        data = self._get_x_namespace()
+        applier = TFApplier([square], policy, k=2, keep_original=True)
+        batches_expected = [[1, 1, 1, 2, 16, 16], [3, 81, 81]]
+        gen = applier.apply_generator(data, batch_size=2)
+        for batch, batch_expected in zip(gen, batches_expected):
+            self.assertEqual([x.num for x in batch], batch_expected)
+        self.assertEqual([x.num for x in data], DATA)
+
+    def test_tf_applier_returns_none_generator(self) -> None:
+        data = self._get_x_namespace()
+        applier = TFApplier([square_returns_none], policy, k=2, keep_original=True)
+        batches_expected = [[1, 1, 1, 2], [3, 81, 81]]
+        gen = applier.apply_generator(data, batch_size=2)
+        for batch, batch_expected in zip(gen, batches_expected):
+            self.assertEqual([x.num for x in batch], batch_expected)
+        self.assertEqual([x.num for x in data], DATA)
+
+    def test_tf_applier_keep_original_modify_in_place_generator(self) -> None:
+        data = self._get_x_namespace_dict()
+        applier = TFApplier(
+            [modify_in_place], policy_modify_in_place, k=2, keep_original=True
+        )
+        batches_expected = [DATA_IN_PLACE_EXPECTED[:6], DATA_IN_PLACE_EXPECTED[6:]]
+        gen = applier.apply_generator(data, batch_size=2)
+        for batch, batch_expected in zip(gen, batches_expected):
+            self.assertTrue(all(x.d == d for x, d in zip(batch, batch_expected)))
+        self.assertTrue(all(x.d == y for x, y in zip(data, get_data_dict())))
 
 
 class TestPandasTFApplier(unittest.TestCase):
@@ -155,4 +203,63 @@ class TestPandasTFApplier(unittest.TestCase):
         idx = [0, 0, 0, 1, 1, 1, 2, 2, 2]
         df_expected = pd.DataFrame(dict(d=DATA_IN_PLACE_EXPECTED), index=idx)
         pd.testing.assert_frame_equal(df_augmented, df_expected)
+        self.assertEqual(df.d.tolist(), get_data_dict())
+
+    def test_tf_applier_pandas_generator(self):
+        df = self._get_x_df()
+        applier = PandasTFApplier([square], policy, k=1, keep_original=False)
+        gen = applier.apply_generator(df, batch_size=2)
+        df_expected = [make_df([1, 16], [0, 1]), make_df([81], [2])]
+        for df_batch, df_batch_expected in zip(gen, df_expected):
+            pd.testing.assert_frame_equal(df_batch, df_batch_expected)
+        self.assertEqual(df.num.tolist(), DATA)
+
+    def test_tf_applier_pandas_multi_generator(self):
+        df = self._get_x_df()
+        applier = PandasTFApplier([square], policy, k=2, keep_original=False)
+        gen = applier.apply_generator(df, batch_size=2)
+        df_expected = [make_df([1, 1, 16, 16], [0, 0, 1, 1]), make_df([81, 81], [2, 2])]
+        for df_batch, df_batch_expected in zip(gen, df_expected):
+            pd.testing.assert_frame_equal(df_batch, df_batch_expected)
+        self.assertEqual(df.num.tolist(), DATA)
+
+    def test_tf_applier_pandas_keep_original_generator(self):
+        df = self._get_x_df()
+        applier = PandasTFApplier([square], policy, k=2, keep_original=True)
+        gen = applier.apply_generator(df, batch_size=2)
+        df_expected = [
+            make_df([1, 1, 1, 2, 16, 16], [0, 0, 0, 1, 1, 1]),
+            make_df([3, 81, 81], [2, 2, 2]),
+        ]
+        for df_batch, df_batch_expected in zip(gen, df_expected):
+            pd.testing.assert_frame_equal(df_batch, df_batch_expected)
+        self.assertEqual(df.num.tolist(), DATA)
+
+    def test_tf_applier_returns_none_generator(self):
+        df = self._get_x_df()
+        applier = PandasTFApplier(
+            [square_returns_none], policy, k=2, keep_original=True
+        )
+        gen = applier.apply_generator(df, batch_size=2)
+        df_expected = [
+            make_df([1, 1, 1, 2], [0, 0, 0, 1]),
+            make_df([3, 81, 81], [2, 2, 2]),
+        ]
+        for df_batch, df_batch_expected in zip(gen, df_expected):
+            pd.testing.assert_frame_equal(df_batch, df_batch_expected)
+        self.assertEqual(df.num.tolist(), DATA)
+
+    def test_tf_applier_pandas_modify_in_place_generator(self):
+        df = self._get_x_df_dict()
+        applier = PandasTFApplier(
+            [modify_in_place], policy_modify_in_place, k=2, keep_original=True
+        )
+        gen = applier.apply_generator(df, batch_size=2)
+        idx = [0, 0, 0, 1, 1, 1, 2, 2, 2]
+        df_expected = [
+            make_df(DATA_IN_PLACE_EXPECTED[:6], idx[:6], key="d"),
+            make_df(DATA_IN_PLACE_EXPECTED[6:], idx[6:], key="d"),
+        ]
+        for df_batch, df_batch_expected in zip(gen, df_expected):
+            pd.testing.assert_frame_equal(df_batch, df_batch_expected)
         self.assertEqual(df.d.tolist(), get_data_dict())

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -1,5 +1,6 @@
 import unittest
 from types import SimpleNamespace
+from typing import List
 
 import pandas as pd
 
@@ -45,13 +46,13 @@ def get_data_dict():
 
 
 class TestTFApplier(unittest.TestCase):
-    def _get_x_namespace(self):
+    def _get_x_namespace(self) -> List[SimpleNamespace]:
         return [SimpleNamespace(num=num) for num in DATA]
 
-    def _get_x_namespace_dict(self):
+    def _get_x_namespace_dict(self) -> List[SimpleNamespace]:
         return [SimpleNamespace(d=d) for d in get_data_dict()]
 
-    def test_tf_applier(self):
+    def test_tf_applier(self) -> None:
         data = self._get_x_namespace()
         applier = TFApplier([square], policy, k=1, keep_original=False)
         data_augmented = applier.apply(data)
@@ -59,7 +60,7 @@ class TestTFApplier(unittest.TestCase):
         self.assertEqual(vals, [1, 16, 81])
         self.assertEqual([x.num for x in data], DATA)
 
-    def test_tf_applier_multi(self):
+    def test_tf_applier_multi(self) -> None:
         data = self._get_x_namespace()
         applier = TFApplier([square], policy, k=2, keep_original=False)
         data_augmented = applier.apply(data)
@@ -67,7 +68,7 @@ class TestTFApplier(unittest.TestCase):
         self.assertEqual(vals, [1, 1, 16, 16, 81, 81])
         self.assertEqual([x.num for x in data], DATA)
 
-    def test_tf_applier_keep_original(self):
+    def test_tf_applier_keep_original(self) -> None:
         data = self._get_x_namespace()
         applier = TFApplier([square], policy, k=2, keep_original=True)
         data_augmented = applier.apply(data)
@@ -75,7 +76,7 @@ class TestTFApplier(unittest.TestCase):
         self.assertEqual(vals, [1, 1, 1, 2, 16, 16, 3, 81, 81])
         self.assertEqual([x.num for x in data], DATA)
 
-    def test_tf_applier_returns_none(self):
+    def test_tf_applier_returns_none(self) -> None:
         data = self._get_x_namespace()
         applier = TFApplier([square_returns_none], policy, k=2, keep_original=True)
         data_augmented = applier.apply(data)
@@ -83,7 +84,7 @@ class TestTFApplier(unittest.TestCase):
         self.assertEqual(vals, [1, 1, 1, 2, 3, 81, 81])
         self.assertEqual([x.num for x in data], DATA)
 
-    def test_tf_applier_keep_original_modify_in_place(self):
+    def test_tf_applier_keep_original_modify_in_place(self) -> None:
         data = self._get_x_namespace_dict()
         applier = TFApplier(
             [modify_in_place], policy_modify_in_place, k=2, keep_original=True
@@ -93,6 +94,9 @@ class TestTFApplier(unittest.TestCase):
             all(x.d == d for x, d in zip(data_augmented, DATA_IN_PLACE_EXPECTED))
         )
         self.assertTrue(all(x.d == y for x, y in zip(data, get_data_dict())))
+
+    def test_tf_applier_generator(self) -> None:
+        pass
 
 
 class TestPandasTFApplier(unittest.TestCase):


### PR DESCRIPTION
Add a method to TFApplier that takes a batch size and yields lists/DataFrames of transformed examples for batches. Implemented as separate `apply` method for stronger typing and for alignment with e.g. https://keras.io/preprocessing/image/.

**Test plan**
Added unit tests