### PR TITLE
Add Dask parallel LF applier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ dmypy.json
 
 # Editors
 .vscode/
+
+# Dask
+dask-worker-space/

--- a/snorkel/labeling/apply/__init__.py
+++ b/snorkel/labeling/apply/__init__.py
@@ -1,3 +1,3 @@
 from .lf_applier import LFApplier  # noqa: F401
-from .lf_applier_dask import DaskLFApplier  # noqa: F401
+from .lf_applier_dask import DaskLFApplier, PandasParallelLFApplier  # noqa: F401
 from .lf_applier_pandas import PandasLFApplier  # noqa: F401

--- a/snorkel/labeling/apply/__init__.py
+++ b/snorkel/labeling/apply/__init__.py
@@ -1,2 +1,3 @@
 from .lf_applier import LFApplier  # noqa: F401
+from .lf_applier_dask import DaskLFApplier  # noqa: F401
 from .lf_applier_pandas import PandasLFApplier  # noqa: F401

--- a/snorkel/labeling/apply/lf_applier_dask.py
+++ b/snorkel/labeling/apply/lf_applier_dask.py
@@ -1,0 +1,48 @@
+from functools import partial
+from typing import Union
+
+import scipy.sparse as sparse
+from dask import dataframe as DataFrame
+from dask.distributed import Client
+
+from snorkel.labeling.preprocess import PreprocessorMode
+
+from .lf_applier import BaseLFApplier
+from .lf_applier_pandas import apply_lfs_to_data_point, rows_to_triplets
+
+Scheduler = Union[str, Client]
+
+
+class DaskLFApplier(BaseLFApplier):
+    """LF applier for a Dask DataFrame.
+
+    Dask DataFrames consist of partitions, each being a Pandas DataFrame.
+    This allows for efficient parallel computation over DataFrame rows.
+    For more information, see https://docs.dask.org/en/stable/dataframe.html
+    """
+
+    def apply(
+        self, df: DataFrame, scheduler: Scheduler = "processes"
+    ) -> sparse.csr_matrix:  # type: ignore
+        """Label Dask DataFrame of data points with LFs.
+
+        Parameters
+        ----------
+        data_points
+            Dask DataFrame containing data points to be labeled by LFs
+        scheduler
+            A Dask scheduling configuration: either a string option or
+            a `Client`. For more information, see
+            https://docs.dask.org/en/stable/scheduling.html#
+
+        Returns
+        -------
+        sparse.csr_matrix
+            Sparse matrix of labels emitted by LFs
+        """
+        self._set_lf_preprocessor_mode(PreprocessorMode.DASK)
+        apply_fn = partial(apply_lfs_to_data_point, lfs=self._lfs)
+        map_fn = df.map_partitions(lambda p_df: p_df.apply(apply_fn, axis=1))
+        labels = map_fn.compute(scheduler=scheduler)
+        labels_with_index = rows_to_triplets(labels)
+        return self._matrix_from_row_data(labels_with_index)

--- a/snorkel/labeling/apply/lf_applier_pandas.py
+++ b/snorkel/labeling/apply/lf_applier_pandas.py
@@ -9,7 +9,7 @@ from snorkel.labeling.lf import LabelingFunction
 from snorkel.labeling.preprocess import PreprocessorMode
 from snorkel.types import DataPoint
 
-from .lf_applier import BaseLFApplier
+from .lf_applier import BaseLFApplier, RowData
 
 PandasRowData = List[Tuple[int, int]]
 
@@ -35,6 +35,14 @@ def apply_lfs_to_data_point(x: DataPoint, lfs: List[LabelingFunction]) -> Pandas
         if y != 0:
             labels.append((j, y))
     return labels
+
+
+def rows_to_triplets(labels: List[PandasRowData]) -> List[RowData]:
+    """Convert list of list sparse matrix representation to list of triplets."""
+    return [
+        [(index, j, y) for j, y in row_labels]
+        for index, row_labels in enumerate(labels)
+    ]
 
 
 class PandasLFApplier(BaseLFApplier):
@@ -63,8 +71,5 @@ class PandasLFApplier(BaseLFApplier):
         apply_fn = partial(apply_lfs_to_data_point, lfs=self._lfs)
         tqdm.pandas()
         labels = df.progress_apply(apply_fn, axis=1)
-        labels_with_index = [
-            [(index, j, y) for j, y in row_labels]
-            for index, row_labels in enumerate(labels)
-        ]
+        labels_with_index = rows_to_triplets(labels)
         return self._matrix_from_row_data(labels_with_index)

--- a/snorkel/labeling/apply/lf_applier_pandas.py
+++ b/snorkel/labeling/apply/lf_applier_pandas.py
@@ -59,7 +59,7 @@ class PandasLFApplier(BaseLFApplier):
 
         Parameters
         ----------
-        data_points
+        df
             Pandas DataFrame containing data points to be labeled by LFs
 
         Returns

--- a/snorkel/map/core.py
+++ b/snorkel/map/core.py
@@ -167,12 +167,10 @@ class Mapper(BaseMapper):
             }
         if self.mode == MapperMode.NONE:
             raise ValueError("No Mapper mode set. Use `Mapper.set_mode(...)`.")
-        if self.mode in (MapperMode.NAMESPACE, MapperMode.PANDAS):
+        if self.mode in (MapperMode.NAMESPACE, MapperMode.PANDAS, MapperMode.DASK):
             for k, v in mapped_fields.items():
                 setattr(x, k, v)
             return x
-        if self.mode == MapperMode.DASK:
-            raise NotImplementedError("Dask Mapper mode not implemented")
         if self.mode == MapperMode.SPARK:
             raise NotImplementedError("Spark Mapper mode not implemented")
         else:

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -4,8 +4,9 @@ from typing import List
 
 import numpy as np
 import pandas as pd
+from dask import dataframe as dd
 
-from snorkel.labeling.apply import LFApplier, PandasLFApplier
+from snorkel.labeling.apply import DaskLFApplier, LFApplier, PandasLFApplier
 from snorkel.labeling.lf import labeling_function
 from snorkel.labeling.preprocess import preprocessor
 from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
@@ -67,6 +68,8 @@ class TestLFApplier(unittest.TestCase):
         L = applier.apply(data_points)
         np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
 
+
+class TestPandasApplier(unittest.TestCase):
     def test_lf_applier_pandas(self) -> None:
         df = pd.DataFrame(dict(num=DATA))
         applier = PandasLFApplier([f, g])
@@ -82,5 +85,28 @@ class TestLFApplier(unittest.TestCase):
     def test_lf_applier_pandas_spacy_preprocessor(self) -> None:
         df = pd.DataFrame(dict(text=TEXT_DATA))
         applier = PandasLFApplier([first_is_name, has_verb])
+        L = applier.apply(df)
+        np.testing.assert_equal(L.toarray(), L_TEXT_EXPECTED)
+
+
+class TestDaskApplier(unittest.TestCase):
+    def test_lf_applier_dask(self) -> None:
+        df = pd.DataFrame(dict(num=DATA))
+        df = dd.from_pandas(df, npartitions=2)
+        applier = DaskLFApplier([f, g])
+        L = applier.apply(df)
+        np.testing.assert_equal(L.toarray(), L_EXPECTED)
+
+    def test_lf_applier_dask_preprocessor(self) -> None:
+        df = pd.DataFrame(dict(num=DATA))
+        df = dd.from_pandas(df, npartitions=2)
+        applier = DaskLFApplier([f, fp])
+        L = applier.apply(df)
+        np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
+
+    def test_lf_applier_dask_spacy_preprocessor(self) -> None:
+        df = pd.DataFrame(dict(text=TEXT_DATA))
+        df = dd.from_pandas(df, npartitions=2)
+        applier = DaskLFApplier([first_is_name, has_verb])
         L = applier.apply(df)
         np.testing.assert_equal(L.toarray(), L_TEXT_EXPECTED)

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -6,7 +6,12 @@ import numpy as np
 import pandas as pd
 from dask import dataframe as dd
 
-from snorkel.labeling.apply import DaskLFApplier, LFApplier, PandasLFApplier
+from snorkel.labeling.apply import (
+    DaskLFApplier,
+    LFApplier,
+    PandasLFApplier,
+    PandasParallelLFApplier,
+)
 from snorkel.labeling.lf import labeling_function
 from snorkel.labeling.preprocess import preprocessor
 from snorkel.labeling.preprocess.nlp import SpacyPreprocessor
@@ -110,3 +115,15 @@ class TestDaskApplier(unittest.TestCase):
         applier = DaskLFApplier([first_is_name, has_verb])
         L = applier.apply(df)
         np.testing.assert_equal(L.toarray(), L_TEXT_EXPECTED)
+
+    def test_lf_applier_pandas_parallel(self) -> None:
+        df = pd.DataFrame(dict(num=DATA))
+        applier = PandasParallelLFApplier([f, g])
+        L = applier.apply(df, n_parallel=2)
+        np.testing.assert_equal(L.toarray(), L_EXPECTED)
+
+    def test_lf_applier_pandas_parallel_raises(self) -> None:
+        df = pd.DataFrame(dict(num=DATA))
+        applier = PandasParallelLFApplier([f, g])
+        with self.assertRaises(ValueError):
+            applier.apply(df, n_parallel=1)

--- a/test/map/test_core.py
+++ b/test/map/test_core.py
@@ -129,10 +129,6 @@ class TestMapperCore(unittest.TestCase):
         with self.assertRaises(ValueError):
             split_words(x)
 
-        split_words.set_mode(MapperMode.DASK)
-        with self.assertRaises(NotImplementedError):
-            split_words(x)
-
         split_words.set_mode(MapperMode.SPARK)
         with self.assertRaises(NotImplementedError):
             split_words(x)


### PR DESCRIPTION
Adds an LF applier for Dask (similar to Pandas and Spark) for single machine parallel computation. Simple usage of `map_partition`. Some info here: https://towardsdatascience.com/how-i-learned-to-love-parallelized-applies-with-python-pandas-dask-and-numba-f06b0b367138

Also plays nicely with Mapper memoization. Because rows are partitioned across processes, no two process-copy mapper objevct will cache results for the same row (i.e. no wasted memory). Will run a Dask + memo speed test once both diffs are landed.

**Test plan**
* Added unit tests. The SpaCy one takes a second because the model needs to get copied between processes.
* Speed test vs. single process Pandas

<img width="636" alt="Screen Shot 2019-06-30 at 9 54 59 PM" src="https://user-images.githubusercontent.com/7783678/60411571-36442480-9b82-11e9-8549-a8dd9455547e.png">
