### PR TITLE
Update requirements structure

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,0 @@
-black
-flake8
-isort
-mypy
-pydocstyle
-pytest
-pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,58 @@
-dask[complete]==1.2.1
-dill==0.2.9
-jupyter==1.0.0
-jupyterlab==0.33.12
-matplotlib==3.0.1
-networkx==2.2
-numpy==1.16.0
-pandas==0.24.0
-scikit-learn==0.20.2
-scipy==1.2.0
-spacy==2.1.3
-tensorboardX==1.6
-torch==1.1.0
-torchtext==0.3.1
-tqdm==4.29.1
+# Library dependencies for Python code.  You need to install these with
+# `pip install -r requirements.txt` or
+# `conda install --file requirements.txt`
+# to ensure that you can use all Snorkel code.
+# NOTE: all essential packages must be placed under a section named
+# '#### ESSENTIAL ...' so that the script `./scripts/check_requirements.py`
+# can find them.
+
+#### ESSENTIAL LIBRARIES
+
+# General scientific computing
+numpy>=1.16.0
+scipy>=1.2.0
+
+# Data storage and function application
+pandas>=0.24.0
+tqdm>=4.29.0
+
+# Internal models
+scikit-learn>=0.20.2
+torch>=1.1.0
+
+# LF dependency learning
+networkx>=2.2
+
+
+#### EXTRA LIBRARIES
+
+# Notebook usage (may be ported to tutorials repo)
+jupyter>=1.0.0
+matplotlib>=3.0.1
+
+# NLP applications
+spacy>=2.1.3
+torchtext>=0.3.1
+
+# Model introspection tools
+tensorboardX>=1.6
+
+# Scale-up/out
+dask[complete]>=1.2.1
+
+# Note: you may want to remove PySpark from the 
+# required installs. Installing a new version may
+# overwrite your existing system install.
+pyspark>=2.4.3
+
+
+#### DEV TOOLS
+
+black
+flake8
+isort
+mypy
+pydocstyle
+pytest
+pytest-cov
+tox

--- a/scripts/check_requirements.py
+++ b/scripts/check_requirements.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+
+"""Check requirements.txt and setup.py install requirements.
+
+Adapted from https://github.com/allenai/allennlp/tree/master/scripts
+
+This script checks the requirements in requirements.txt against those in setup.py.
+In particular, it makes sure that there are no duplicates within either setup.py or
+requirements.txt and that each package that is listed in both setup.py
+and requirements.txt having matching versions. It also ensures that any requirement
+listed as "ESSENTIAL" in requirements.txt appears under the "install_requires"
+field in setup.py.
+"""
+
+import re
+import sys
+from typing import Dict, Optional, Set, Tuple
+
+PackagesType = Dict[str, Optional[str]]
+
+
+def parse_section_name(line: str) -> str:
+    return line.replace("####", "").strip()
+
+
+def parse_package(line: str) -> Tuple[str, Optional[str]]:
+    parts = re.split(r"(==|>=|<=|>|<)", line)
+    module = parts[0]
+    version = line.replace(module, "")
+    return (module, version)
+
+
+def parse_requirements() -> Tuple[PackagesType, PackagesType, Set[str]]:
+    """Parse all dependencies out of the requirements.txt file."""
+    essential_packages: PackagesType = {}
+    other_packages: PackagesType = {}
+    duplicates: Set[str] = set()
+    with open("requirements.txt", "r") as req_file:
+        section: str = ""
+        for line in req_file:
+            line = line.strip()
+
+            if line.startswith("####"):
+                # Line is a section name.
+                section = parse_section_name(line)
+                continue
+
+            if not line or line.startswith("#"):
+                # Line is empty or just regular comment.
+                continue
+
+            module, version = parse_package(line)
+            if module in essential_packages or module in other_packages:
+                duplicates.add(module)
+
+            if section.startswith("ESSENTIAL"):
+                essential_packages[module] = version
+            else:
+                other_packages[module] = version
+
+    return essential_packages, other_packages, duplicates
+
+
+def parse_setup() -> Tuple[PackagesType, PackagesType, Set[str], Set[str]]:
+    """Parse all dependencies out of the setup.py script."""
+    essential_packages: PackagesType = {}
+    test_packages: PackagesType = {}
+    essential_duplicates: Set[str] = set()
+    test_duplicates: Set[str] = set()
+
+    with open("setup.py") as setup_file:
+        contents = setup_file.read()
+
+    # Parse out essential packages.
+    match = re.search(
+        r"""install_requires=\[[\s\n]*['"](.*?)['"],?[\s\n]*\]""", contents, re.DOTALL
+    )
+    if match is not None:
+        package_string = match.groups()[0].strip()
+        for package in re.split(r"""['"],[\s\n]+['"]""", package_string):
+            module, version = parse_package(package)
+            if module in essential_packages:
+                essential_duplicates.add(module)
+            else:
+                essential_packages[module] = version
+
+    # Parse packages only needed for testing.
+    match = re.search(
+        r"""tests_require=\[[\s\n]*['"](.*?)['"],?[\s\n]*\]""", contents, re.DOTALL
+    )
+    if match is not None:
+        package_string = match.groups()[0].strip()
+        for package in re.split(r"""['"],[\s\n]+['"]""", package_string):
+            module, version = parse_package(package)
+            if module in test_packages:
+                test_duplicates.add(module)
+            else:
+                test_packages[module] = version
+
+    return essential_packages, test_packages, essential_duplicates, test_duplicates
+
+
+def main() -> int:
+    exit_code = 0
+
+    requirements_essential, requirements_other, requirements_duplicate = (
+        parse_requirements()
+    )
+    requirements_all = dict(requirements_essential, **requirements_other)
+    setup_essential, setup_test, essential_duplicates, test_duplicates = parse_setup()
+
+    if requirements_duplicate:
+        exit_code = 1
+        for module in requirements_duplicate:
+            print(f"  ✗ '{module}' appears more than once in requirements.txt")
+
+    if essential_duplicates:
+        exit_code = 1
+        for module in essential_duplicates:
+            print(
+                f"  ✗ '{module}' appears more than once in 'install_requires' "
+                f"section of setup.py"
+            )
+
+    if test_duplicates:
+        exit_code = 1
+        for module in test_duplicates:
+            print(
+                f"  ✗ '{module}' appears more than once in 'tests_require' "
+                f"section of setup.py"
+            )
+
+    # Find all packages listed as essential in requirements.txt that differ
+    # in or are absent from setup.py.
+    for module, version in requirements_essential.items():
+        if module not in setup_essential:
+            exit_code = 1
+            print(
+                f"  ✗ '{module}' listed as essential in requirements.txt "
+                f"but is missing from 'install_requires' field of setup.py"
+            )
+        elif setup_essential[module] != version:
+            exit_code = 1
+            print(
+                f"  ✗ '{module}' has version '{version}' in requirements.txt but "
+                f"'{setup_essential[module]}' in 'install_requires' field of setup.py"
+            )
+
+    # Find all packages listed under 'install_requires' in setup.py that are not
+    # listed as essential in requirements.txt.
+    for module, version in setup_essential.items():
+        if module in requirements_other:
+            exit_code = 1
+            print(
+                f"  ✗ '{module}' appears under 'install_requires' in setup.py but "
+                f"is listed as non-essential in requirements.txt"
+            )
+        elif module not in requirements_essential:
+            exit_code = 1
+            print(f"  ✗ '{module}' appears in setup.py but not in requirements.txt")
+
+    # Find all packages listed under 'tests_require' in setup.py that are missing
+    # from requirements.txt, or have a version discrepancy.
+    for module, version in setup_test.items():
+        if module not in requirements_all:
+            exit_code = 1
+            print(
+                f"  ✗ '{module}' appears under 'tests_require' in setup.py "
+                f"but is missing from requirements.txt"
+            )
+        elif requirements_all[module] != version:
+            exit_code = 1
+            print(
+                f"  ✗ '{module}' has version '{version}' in 'tests_require' field of "
+                f"setup.py but '{requirements_all[module]}' in requirements.txt"
+            )
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/setup.py
+++ b/setup.py
@@ -1,23 +1,25 @@
+from typing import Dict
+
 from setuptools import find_packages, setup
 
-with open("README.md") as read_file:
-    long_description = read_file.read()
+# version.py defines the VERSION and VERSION_SHORT variables.
+# We use exec here so we don't import snorkel.
+VERSION: Dict[str, str] = {}
+with open("snorkel/version.py", "r") as version_file:
+    exec(version_file.read(), VERSION)
 
-with open("requirements.txt") as f:
-    requirements = f.read().splitlines()
+# Use README.md as the long_description for the package
+with open("README.md", "r") as readme_file:
+    long_description = readme_file.read()
 
 setup(
     name="snorkel",
-    version="0.9.0",
+    version=VERSION["VERSION"],
     url="https://github.com/HazyResearch/snorkel",
     description="A system for quickly generating training data with weak supervision",
     long_description_content_type="text/markdown",
     long_description=long_description,
     license="Apache License 2.0",
-    packages=find_packages(),
-    include_package_data=True,
-    install_requires=requirements,
-    keywords="machine-learning ai information-extraction weak-supervision",
     classifiers=[
         "Intended Audience :: Science/Research",
         "Topic :: Scientific/Engineering :: Information Analysis",
@@ -30,4 +32,17 @@ setup(
         "Bug Reports": "https://github.com/HazyResearch/snorkel/issues",
         "Citation": "https://doi.org/10.14778/3157794.3157797",
     },
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        "numpy>=1.16.0",
+        "scipy>=1.2.0",
+        "pandas>=0.24.0",
+        "tqdm>=4.29.0",
+        "scikit-learn>=0.20.2",
+        "torch>=1.1.0",
+        "networkx>=2.2",
+    ],
+    python_requires=">=3.6",
+    keywords="machine-learning ai weak-supervision",
 )

--- a/snorkel/__init__.py
+++ b/snorkel/__init__.py
@@ -1,0 +1,1 @@
+from .version import VERSION as __version__  # noqa: F401

--- a/snorkel/version.py
+++ b/snorkel/version.py
@@ -1,0 +1,6 @@
+_MAJOR = "0"
+_MINOR = "9"
+_REVISION = "0-prerelease"
+
+VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
+VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ isolated_build = true
 
 [testenv]
 description = run the test driver with {basepython}
-deps = -rrequirements-dev.txt
+deps = -rrequirements.txt
 commands_pre = python -m spacy download en_core_web_sm
 commands = python -m pytest {posargs:test/}
 
@@ -20,6 +20,7 @@ commands =
     isort -rc -c .
     black --check .
     flake8 .
+    {toxinidir}/scripts/check_requirements.py
 
 [testenv:type]
 description = run static type checking


### PR DESCRIPTION
Restructuring of our lib dependencies. Largely inspired by https://github.com/allenai/allennlp.

* Merge requirements.txt, and block into essential, extra, and dev
* Hard-code core dependencies in setup.py
* Pull check_requirements.py from AllenNLP to check setup.py against requirements.txt
* Copy AllenNLP's versioning approach

**Test plan:**
* Running tox now replicates a `pip install snorkel` then `pip install -r requirements.txt`, which is exactly what we want to test
* Added check_requirements.py to `tox -e check`