### PR TITLE
Simplify end model scheduler/dataset signatures

### DIFF
--- a/snorkel/end_model/batch_schedulers/scheduler.py
+++ b/snorkel/end_model/batch_schedulers/scheduler.py
@@ -1,4 +1,7 @@
 from abc import ABC, abstractmethod
+from typing import Any, Dict, Sequence, Tuple
+
+from snorkel.end_model.data import MultitaskDataLoader
 
 
 class Scheduler(ABC):
@@ -9,10 +12,21 @@ class Scheduler(ABC):
         pass
 
     @abstractmethod
-    def get_batches(self, dataloaders):
-        """Return batches in a specified order.
+    def get_batches(
+        self, dataloaders: Sequence[MultitaskDataLoader]
+    ) -> Tuple[Tuple[Dict[str, Any], Dict[str, Any]], MultitaskDataLoader]:
+        """Return batches in shuffled order from dataloaders
 
-        :param dataloaders: a list of dataloaders
-        :type dataloaders: list
+        Parameters
+        ----------
+        dataloaders
+            A sequence of dataloaders to get batches from
+
+        Yields
+        -------
+        (batch, dataloader)
+            batch is a tuple of (X_dict, Y_dict) and dataloader is the dataloader
+            that that batch came from. That dataloader will not be accessed by the
+            model; it is passed primarily so that the model can pull the necessary
+            metadata to know what to do with the batch it has been given.
         """
-        pass

--- a/snorkel/end_model/batch_schedulers/sequential_scheduler.py
+++ b/snorkel/end_model/batch_schedulers/sequential_scheduler.py
@@ -10,22 +10,8 @@ class SequentialScheduler(Scheduler):
     def get_batches(self, dataloaders):
         """Return batches in sequential order.
 
-        :param dataloaders: a list of dataloaders
-        :type dataloaders: list
-        :return: A generator of all batches
-        :rtype: genertor
+        TBD
         """
-
-        task_to_label_dicts = [
-            dataloader.task_to_label_dict for dataloader in dataloaders
-        ]
-        data_names = [dataloader.data_name for dataloader in dataloaders]
-        batch_counts = [len(dataloader) for dataloader in dataloaders]
-        data_loaders = [iter(dataloader) for dataloader in dataloaders]
-        splits = [dataloader.split for dataloader in dataloaders]
-
-        for task_to_label_dict, data_name, batch_count, data_loader, split in zip(
-            task_to_label_dicts, data_names, batch_counts, data_loaders, splits
-        ):
-            for batch in range(batch_count):
-                yield next(data_loader), task_to_label_dict, data_name, split
+        for dataloader in dataloaders:
+            for batch in dataloader:
+                yield batch, dataloader

--- a/snorkel/end_model/batch_schedulers/sequential_scheduler.py
+++ b/snorkel/end_model/batch_schedulers/sequential_scheduler.py
@@ -1,3 +1,7 @@
+from typing import Any, Dict, Sequence, Tuple
+
+from snorkel.end_model.data import MultitaskDataLoader
+
 from .scheduler import Scheduler
 
 
@@ -7,10 +11,23 @@ class SequentialScheduler(Scheduler):
     def __init__(self):
         super().__init__()
 
-    def get_batches(self, dataloaders):
-        """Return batches in sequential order.
+    def get_batches(
+        self, dataloaders: Sequence[MultitaskDataLoader]
+    ) -> Tuple[Tuple[Dict[str, Any], Dict[str, Any]], MultitaskDataLoader]:
+        """Return batches from dataloaders sequentially in the order they were given.
 
-        TBD
+        Parameters
+        ----------
+        dataloaders
+            A sequence of dataloaders to get batches from
+
+        Yields
+        -------
+        (batch, dataloader)
+            batch is a tuple of (X_dict, Y_dict) and dataloader is the dataloader
+            that that batch came from. That dataloader will not be accessed by the
+            model; it is passed primarily so that the model can pull the necessary
+            metadata to know what to do with the batch it has been given.
         """
         for dataloader in dataloaders:
             for batch in dataloader:

--- a/snorkel/end_model/batch_schedulers/shuffled_scheduler.py
+++ b/snorkel/end_model/batch_schedulers/shuffled_scheduler.py
@@ -1,4 +1,7 @@
 import random
+from typing import Any, Dict, Sequence, Tuple
+
+from snorkel.end_model.data import MultitaskDataLoader
 
 from .scheduler import Scheduler
 
@@ -9,10 +12,23 @@ class ShuffledScheduler(Scheduler):
     def __init__(self):
         super().__init__()
 
-    def get_batches(self, dataloaders):
-        """Return batches in shuffled order.
+    def get_batches(
+        self, dataloaders: Sequence[MultitaskDataLoader]
+    ) -> Tuple[Tuple[Dict[str, Any], Dict[str, Any]], MultitaskDataLoader]:
+        """Return batches in shuffled order from dataloaders
 
-        TBD
+        Parameters
+        ----------
+        dataloaders
+            A sequence of dataloaders to get batches from
+
+        Yields
+        -------
+        (batch, dataloader)
+            batch is a tuple of (X_dict, Y_dict) and dataloader is the dataloader
+            that that batch came from. That dataloader will not be accessed by the
+            model; it is passed primarily so that the model can pull the necessary
+            metadata to know what to do with the batch it has been given.
         """
         batch_counts = [len(dl) for dl in dataloaders]
         dataloader_iters = [iter(dl) for dl in dataloaders]

--- a/snorkel/end_model/batch_schedulers/shuffled_scheduler.py
+++ b/snorkel/end_model/batch_schedulers/shuffled_scheduler.py
@@ -12,27 +12,16 @@ class ShuffledScheduler(Scheduler):
     def get_batches(self, dataloaders):
         """Return batches in shuffled order.
 
-        :param dataloaders: a list of dataloaders
-        :type dataloaders: list
-        :return: A generator of all batches
-        :rtype: genertor
+        TBD
         """
+        batch_counts = [len(dl) for dl in dataloaders]
+        dataloader_iters = [iter(dl) for dl in dataloaders]
 
-        task_to_label_dicts = [
-            dataloader.task_to_label_dict for dataloader in dataloaders
-        ]
-        data_names = [dataloader.data_name for dataloader in dataloaders]
-        batch_counts = [len(dataloader) for dataloader in dataloaders]
-        data_loaders = [iter(dataloader) for dataloader in dataloaders]
-        splits = [dataloader.split for dataloader in dataloaders]
-
-        dataloader_indexer = []
+        dataloader_indices = []
         for idx, count in enumerate(batch_counts):
-            dataloader_indexer.extend([idx] * count)
+            dataloader_indices.extend([idx] * count)
 
-        random.shuffle(dataloader_indexer)
+        random.shuffle(dataloader_indices)
 
-        for index in dataloader_indexer:
-            yield next(data_loaders[index]), task_to_label_dicts[index], data_names[
-                index
-            ], splits[index]
+        for index in dataloader_indices:
+            yield next(dataloader_iters[index]), dataloaders[index]

--- a/snorkel/end_model/data.py
+++ b/snorkel/end_model/data.py
@@ -86,22 +86,15 @@ class MultitaskDataLoader(DataLoader):
     """
 
     def __init__(
-        self,
-        task_to_label_dict,
-        dataset,
-        split="train",
-        collate_fn=collate_dicts,
-        **kwargs,
+        self, dataset, collate_fn=collate_dicts, task_to_label_dict=None, **kwargs
     ):
 
         assert isinstance(dataset, MultitaskDataset)
         super().__init__(dataset, collate_fn=collate_fn, **kwargs)
 
-        self.task_to_label_dict = task_to_label_dict
-        self.data_name = dataset.name
-        self.split = split
+        self.task_to_label_dict = task_to_label_dict or {}
 
-        for label in task_to_label_dict.values():
+        for label in self.task_to_label_dict.values():
             if label not in dataset.Y_dict:
                 raise ValueError(
                     f"Label {label} specified in task_to_label_dict could not be found in Y_dict"

--- a/snorkel/end_model/data.py
+++ b/snorkel/end_model/data.py
@@ -1,4 +1,3 @@
-import logging
 import random
 from collections import defaultdict
 
@@ -23,8 +22,9 @@ class MultitaskDataset(Dataset):
     :type Y_dict: dict
     """
 
-    def __init__(self, name, X_dict, Y_dict):
+    def __init__(self, name, split, X_dict, Y_dict):
         self.name = name
+        self.split = split
         self.X_dict = X_dict
         self.Y_dict = Y_dict
 
@@ -41,57 +41,9 @@ class MultitaskDataset(Dataset):
 
     def __len__(self):
         try:
-            return len(next(iter(self.X_dict.values())))
+            return len(next(iter(self.Y_dict.values())))
         except StopIteration:
             return 0
-
-    def _update_dict(self, old_dict, new_dict):
-        for key, value in new_dict.items():
-            old_dict[key] = value
-
-    def _remove_key(self, old_dict, key):
-        if key in old_dict:
-            del old_dict[key]
-
-    def add_features(self, X_dict):
-        """Add new features into X_dict
-
-        :param X_dict: the new feature dict to add into the existing feature dict
-        :type X_dict: dict
-        """
-
-        self._update_dict(self.X_dict, X_dict)
-
-    def add_labels(self, Y_dict):
-        """Add new labels into Y_dict
-
-        :param Y_dict: the new label dict to add into the existing label dict
-        :type Y_dict: dict
-        """
-
-        for name, label in Y_dict.items():
-            if not isinstance(label, torch.Tensor):
-                raise ValueError(f"Label {name} should be torch.Tensor.")
-
-        self._update_dict(self.Y_dict, Y_dict)
-
-    def remove_feature(self, feature_name):
-        """Remove one feature from feature dict
-
-        :param feature_name: the feature that removes from feature dict
-        :type feature_name: str
-        """
-
-        self._remove_key(self.X_dict, feature_name)
-
-    def remove_label(self, label_name):
-        """Remove one label from label dict
-
-        :param label_name: the label that removes from label dict
-        :type label_name: str
-        """
-
-        self._remove_key(self.Y_dict, label_name)
 
 
 def collate_dicts(batch):
@@ -149,17 +101,11 @@ class MultitaskDataLoader(DataLoader):
         self.data_name = dataset.name
         self.split = split
 
-        for task_name, label_names in task_to_label_dict.items():
-            if not isinstance(label_names, list):
-                label_names = [label_names]
-            unrecognized_labels = set(label_names) - set(dataset.Y_dict.keys())
-            if len(unrecognized_labels) > 0:
-                msg = (
-                    f"Unrecognized Label {unrecognized_labels} of Task {task_name} in "
-                    f"dataset {dataset.name}"
+        for label in task_to_label_dict.values():
+            if label not in dataset.Y_dict:
+                raise ValueError(
+                    f"Label {label} specified in task_to_label_dict could not be found in Y_dict"
                 )
-                logging.warn(msg)
-                raise ValueError(msg)
 
 
 def split_data(

--- a/snorkel/end_model/trainer.py
+++ b/snorkel/end_model/trainer.py
@@ -45,7 +45,7 @@ class Trainer(object):
             train_split = [train_split]
 
         train_dataloaders = [
-            dataloader for dataloader in dataloaders if dataloader.split in train_split
+            dl for dl in dataloaders if dl.dataset.split in train_split
         ]
 
         if not train_dataloaders:
@@ -156,7 +156,7 @@ class Trainer(object):
             test_split = [test_split]
 
         all_splits = train_split + valid_split + test_split
-        if not all([dl.split in all_splits for dl in dataloaders]):
+        if not all([dl.dataset.split in all_splits for dl in dataloaders]):
             raise ValueError(f"Dataloader splits must be one of {all_splits}")
 
     def _set_checkpointer(self):
@@ -339,7 +339,7 @@ class Trainer(object):
             valid_split = split
 
         valid_dataloaders = [
-            dataloader for dataloader in dataloaders if dataloader.split in valid_split
+            dl for dl in dataloaders if dl.dataset.split in valid_split
         ]
         return model.score(valid_dataloaders)
 

--- a/test/end_model/batch_schedulers/test_schedulers.py
+++ b/test/end_model/batch_schedulers/test_schedulers.py
@@ -1,0 +1,41 @@
+import unittest
+
+import torch
+
+from snorkel.analysis.utils import set_seed
+from snorkel.end_model.batch_schedulers import SequentialScheduler, ShuffledScheduler
+from snorkel.end_model.data import MultitaskDataLoader, MultitaskDataset
+
+dataset1 = MultitaskDataset(
+    "d1", "train", {"data": ["a", "b", "c"]}, {"labels": torch.LongTensor([1, 2, 3])}
+)
+dataset2 = MultitaskDataset(
+    "d2", "train", {"data": ["d", "e", "f"]}, {"labels": torch.LongTensor([4, 5, 6])}
+)
+
+dataloader1 = MultitaskDataLoader(dataset1, batch_size=2)
+dataloader2 = MultitaskDataLoader(dataset2, batch_size=2)
+dataloaders = [dataloader1, dataloader2]
+
+
+class SequentialTest(unittest.TestCase):
+    def test_sequential(self):
+        scheduler = SequentialScheduler()
+        data = []
+        for (batch, dl) in scheduler.get_batches(dataloaders):
+            X_dict, Y_dict = batch
+            data.extend(X_dict["data"])
+        self.assertEqual(data, ["a", "b", "c", "d", "e", "f"])
+
+    def test_shuffled(self):
+        set_seed(123)
+        scheduler = ShuffledScheduler()
+        data = []
+        for (batch, dl) in scheduler.get_batches(dataloaders):
+            X_dict, Y_dict = batch
+            data.extend(X_dict["data"])
+        self.assertNotEqual(data, ["a", "b", "c", "d", "e", "f"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/end_model/batch_schedulers/test_schedulers.py
+++ b/test/end_model/batch_schedulers/test_schedulers.py
@@ -7,10 +7,16 @@ from snorkel.end_model.batch_schedulers import SequentialScheduler, ShuffledSche
 from snorkel.end_model.data import MultitaskDataLoader, MultitaskDataset
 
 dataset1 = MultitaskDataset(
-    "d1", "train", {"data": ["a", "b", "c"]}, {"labels": torch.LongTensor([1, 2, 3])}
+    "d1",
+    "train",
+    X_dict={"data": [0, 1, 2, 3, 4]},
+    Y_dict={"labels": torch.LongTensor([1, 1, 1, 1, 1])},
 )
 dataset2 = MultitaskDataset(
-    "d2", "train", {"data": ["d", "e", "f"]}, {"labels": torch.LongTensor([4, 5, 6])}
+    "d2",
+    "train",
+    X_dict={"data": [5, 6, 7, 8, 9]},
+    Y_dict={"labels": torch.LongTensor([2, 2, 2, 2, 2])},
 )
 
 dataloader1 = MultitaskDataLoader(dataset1, batch_size=2)
@@ -25,7 +31,7 @@ class SequentialTest(unittest.TestCase):
         for (batch, dl) in scheduler.get_batches(dataloaders):
             X_dict, Y_dict = batch
             data.extend(X_dict["data"])
-        self.assertEqual(data, ["a", "b", "c", "d", "e", "f"])
+        self.assertEqual(data, sorted(data))
 
     def test_shuffled(self):
         set_seed(123)
@@ -34,7 +40,7 @@ class SequentialTest(unittest.TestCase):
         for (batch, dl) in scheduler.get_batches(dataloaders):
             X_dict, Y_dict = batch
             data.extend(X_dict["data"])
-        self.assertNotEqual(data, ["a", "b", "c", "d", "e", "f"])
+        self.assertNotEqual(data, sorted(data))
 
 
 if __name__ == "__main__":

--- a/test/end_model/test_data.py
+++ b/test/end_model/test_data.py
@@ -20,37 +20,12 @@ class DatasetTest(unittest.TestCase):
         y1 = torch.Tensor([0, 0, 0, 0, 0])
 
         dataset = MultitaskDataset(
-            X_dict={"data1": x1}, Y_dict={"label1": y1}, name="new_data"
+            X_dict={"data1": x1}, Y_dict={"label1": y1}, name="new_data", split="train"
         )
 
         # Check if the dataset is correctly constructed
         self.assertTrue(torch.equal(dataset[0][0]["data1"], x1[0]))
         self.assertTrue(torch.equal(dataset[0][1]["label1"], y1[0]))
-
-        x2 = [
-            torch.Tensor([1, 2, 3, 4, 5]),
-            torch.Tensor([1, 2, 3, 4]),
-            torch.Tensor([1, 2, 3]),
-            torch.Tensor([1, 2]),
-            torch.Tensor([1]),
-        ]
-
-        dataset.add_features(X_dict={"data2": x2})
-
-        # Check add one more feature to dataset
-        self.assertTrue(torch.equal(dataset[0][0]["data2"], x2[0]))
-
-        y2 = torch.Tensor([1, 1, 1, 1, 1])
-
-        dataset.add_labels(Y_dict={"label2": y2})
-
-        # Check add one more label to dataset
-        self.assertTrue(torch.equal(dataset[0][1]["label2"], y2[0]))
-
-        dataset.remove_label(label_name="label1")
-
-        # Check remove one more label to dataset
-        self.assertTrue("label1" not in dataset.Y_dict)
 
     def test_mtl_dataloader(self):
         """Unit test of MultitaskDataloader"""
@@ -76,16 +51,14 @@ class DatasetTest(unittest.TestCase):
         y2 = torch.Tensor([1, 1, 1, 1, 1])
 
         dataset = MultitaskDataset(
+            name="new_data",
+            split="train",
             X_dict={"data1": x1, "data2": x2},
             Y_dict={"label1": y1, "label2": y2},
-            name="new_data",
         )
 
         dataloader1 = MultitaskDataLoader(
-            task_to_label_dict={"task1": "label1"},
-            dataset=dataset,
-            split="train",
-            batch_size=2,
+            task_to_label_dict={"task1": "label1"}, dataset=dataset, batch_size=2
         )
 
         x_batch, y_batch = next(iter(dataloader1))
@@ -155,3 +128,7 @@ class DatasetTest(unittest.TestCase):
             )
         )
         self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([[2], [2], [2]])))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/end_model/test_data.py
+++ b/test/end_model/test_data.py
@@ -76,9 +76,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([1, 1])))
 
         dataloader2 = MultitaskDataLoader(
-            task_to_label_dict={"task2": "label2"},
-            dataset=dataset,
-            batch_size=3,
+            task_to_label_dict={"task2": "label2"}, dataset=dataset, batch_size=3
         )
 
         x_batch, y_batch = next(iter(dataloader2))

--- a/test/end_model/test_data.py
+++ b/test/end_model/test_data.py
@@ -65,7 +65,7 @@ class DatasetTest(unittest.TestCase):
 
         # Check if the dataloader is correctly constructed
         self.assertEqual(dataloader1.task_to_label_dict, {"task1": "label1"})
-        self.assertEqual(dataloader1.split, "train")
+        self.assertEqual(dataloader1.dataset.split, "train")
         self.assertTrue(torch.equal(x_batch["data1"], torch.Tensor([[1, 0], [1, 2]])))
         self.assertTrue(
             torch.equal(
@@ -78,7 +78,6 @@ class DatasetTest(unittest.TestCase):
         dataloader2 = MultitaskDataLoader(
             task_to_label_dict={"task2": "label2"},
             dataset=dataset,
-            split="test",
             batch_size=3,
         )
 
@@ -86,7 +85,7 @@ class DatasetTest(unittest.TestCase):
 
         # Check if the dataloader with differet batch size is correctly constructed
         self.assertEqual(dataloader2.task_to_label_dict, {"task2": "label2"})
-        self.assertEqual(dataloader2.split, "test")
+        self.assertEqual(dataloader2.dataset.split, "train")
         self.assertTrue(
             torch.equal(
                 x_batch["data1"], torch.Tensor([[1, 0, 0], [1, 2, 0], [1, 2, 3]])

--- a/test/end_model/test_trainer.py
+++ b/test/end_model/test_trainer.py
@@ -12,20 +12,16 @@ from snorkel.end_model.scorer import Scorer
 from snorkel.end_model.task import Operation, Task
 from snorkel.end_model.trainer import Trainer
 
-SEED = 123
+trainer_config = {"n_epochs": 2, "progress_bar": False}
 
 
 class TrainerTest(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.trainer_config = {"n_epochs": 2, "progress_bar": False}
-
     def test_trainer_onetask(self):
         """Train a single-task model"""
         task1 = create_task("task1", module_suffixes=["A", "A"])
         model = MultitaskModel(tasks=[task1])
         dataloaders = create_dataloaders(num_tasks=1)
-        trainer = Trainer(**self.trainer_config)
+        trainer = Trainer(**trainer_config)
         trainer.train_model(model, dataloaders)
 
     def test_trainer_twotask(self):
@@ -34,7 +30,7 @@ class TrainerTest(unittest.TestCase):
         task2 = create_task("task2", module_suffixes=["A", "B"])
         model = MultitaskModel(tasks=[task1, task2])
         dataloaders = create_dataloaders(num_tasks=2)
-        trainer = Trainer(**self.trainer_config)
+        trainer = Trainer(**trainer_config)
         trainer.train_model(model, dataloaders)
 
 

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -111,6 +111,7 @@ def create_dataloader(df, split):
 
     dataset = MultitaskDataset(
         name="TestData",
+        split=split,
         X_dict={
             "coordinates": torch.stack(
                 (torch.Tensor(df["x1"]), torch.Tensor(df["x2"])), dim=1
@@ -122,9 +123,8 @@ def create_dataloader(df, split):
     dataloader = MultitaskDataLoader(
         task_to_label_dict=task_to_label_dict,
         dataset=dataset,
-        split=split,
         batch_size=4,
-        shuffle=(split == "train"),
+        shuffle=(dataset.split == "train"),
     )
     return dataloader
 
@@ -155,3 +155,7 @@ def create_task(task_name, module_suffixes):
     )
 
     return task
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Another stepping stone on the path to fixing up the end model:
- Remove unused add_X/remove_X methods from MultitaskDataset
- Significantly simplify batch schedulers by letting them pass back the dataloader object from which metadata can be pulled; this will also make the trainer more single-task/multi-task agnostic
- Make split and dataset name attributes of the dataset, not the dataloader
- Remove potentially stochastic tests in `test_trainer.py` that checked for quality after training.

**Test plan:**
- Added unit tests for schedulers
- Additional typing coming in #1204
