### PR TITLE
Add PySpark unit testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,4 +12,4 @@ ignore_errors = True
 omit =
     test/*
     tutorials/*
-    snorkel/labeling/apply/lf_applier_spark.py
+    *spark.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 # Only run CI on master, release branches, tags, and PRs
 if: tag IS present OR type = pull_request OR ((branch = master OR branch =~ release-*) AND type = push)
 
+# Main dist is Python
 language: python
 
 # Cache package wheels
@@ -10,7 +11,7 @@ cache: pip
 dist: xenial
 
 env:
-  TOXENV=py,check,coverage
+  TOXENV=py,spark,check,coverage JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 jobs:
   include:
@@ -18,6 +19,13 @@ jobs:
       python: 3.6
     - name: "Tests: python3.7"
       python: 3.7
+
+# Install JDK8 for PySpark tests
+before_install:
+  - sudo add-apt-repository -y ppa:openjdk-r/ppa
+  - sudo apt-get -qq update
+  - sudo apt-get install -y openjdk-8-jdk --no-install-recommends
+  - sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
 
 install:
   - pip install -U pip setuptools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,6 +85,17 @@ Note that we use PEP 484 type hints, so parameter types should be removed from t
 }
 ```
 
+### PySpark tests
+PySpark tests are invoked separately from the rest since they require
+installing Java and the large PySpark package.
+They are executed on Travis, but not by default for a local `tox` command.
+If you're making changes to Spark-based operators, make sure you have
+Java 8 installed locally and then run `tox -e spark`.
+If you add a test that imports PySpark mark it with the 
+`@pytest.mark.spark` decorator.
+Add the `@pytest.mark.complex` decorator as well if it runs a Spark
+action (e.g. `.collect()`).
+
 
 ## PRs
 

--- a/requirements-pyspark.txt
+++ b/requirements-pyspark.txt
@@ -1,0 +1,3 @@
+# Note: we don't include PySpark in the normal required installs.
+# Installing a new version may overwrite your existing system install.
+pyspark==2.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ networkx>=2.2
 
 # Notebook usage (may be ported to tutorials repo)
 jupyter>=1.0.0
-matplotlib>=3.0.1
+matplotlib==3.0.1
 
 # NLP applications
 spacy>=2.1.3
@@ -39,11 +39,6 @@ tensorboardX>=1.6
 
 # Scale-up/out
 dask[complete]>=1.2.1
-
-# Note: you may want to remove PySpark from the 
-# required installs. Installing a new version may
-# overwrite your existing system install.
-pyspark>=2.4.3
 
 
 #### DEV TOOLS

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
+[tool:pytest]
+markers =
+    spark
+
 [flake8]
 ignore = 
     E203,

--- a/test/labeling/apply/test_lf_applier_spark.py
+++ b/test/labeling/apply/test_lf_applier_spark.py
@@ -1,0 +1,85 @@
+import unittest
+from typing import List
+
+import numpy as np
+import pandas as pd
+import pytest
+from pyspark import SparkContext
+from pyspark.sql import Row, SQLContext
+
+from snorkel.labeling.apply.lf_applier_spark import SparkLFApplier
+from snorkel.labeling.lf import labeling_function
+from snorkel.labeling.preprocess import preprocessor
+from snorkel.types import DataPoint
+
+
+@preprocessor()
+def square(x: Row) -> Row:
+    return Row(num=x.num, num_squared=x.num ** 2)
+
+
+@labeling_function()
+def f(x: DataPoint) -> int:
+    return 1 if x.num > 42 else 0
+
+
+@labeling_function(preprocessors=[square])
+def fp(x: DataPoint) -> int:
+    return 1 if x.num_squared > 42 else 0
+
+
+@labeling_function(resources=dict(db=[3, 6, 9]))
+def g(x: DataPoint, db: List[int]) -> int:
+    return 1 if x.num in db else 0
+
+
+DATA = [3, 43, 12, 9, 3]
+L_EXPECTED = np.array([[0, 1], [1, 0], [0, 0], [0, 1], [0, 1]])
+L_PREPROCESS_EXPECTED = np.array([[0, 0], [1, 1], [0, 1], [0, 1], [0, 0]])
+
+TEXT_DATA = ["Jane", "Jane plays soccer.", "Jane plays soccer."]
+L_TEXT_EXPECTED = np.array([[1, 0], [1, 1], [1, 1]])
+
+
+class TestSparkApplier(unittest.TestCase):
+    @pytest.mark.complex
+    @pytest.mark.spark
+    def test_lf_applier_spark(self) -> None:
+        sc = SparkContext.getOrCreate()
+        sql = SQLContext(sc)
+        df = pd.DataFrame(dict(num=DATA))
+        rdd = sql.createDataFrame(df).rdd
+        applier = SparkLFApplier([f, g])
+        L = applier.apply(rdd)
+        np.testing.assert_equal(L.toarray(), L_EXPECTED)
+
+    @pytest.mark.complex
+    @pytest.mark.spark
+    def test_lf_applier_spark_preprocessor(self) -> None:
+        sc = SparkContext.getOrCreate()
+        sql = SQLContext(sc)
+        df = pd.DataFrame(dict(num=DATA))
+        rdd = sql.createDataFrame(df).rdd
+        applier = SparkLFApplier([f, fp])
+        L = applier.apply(rdd)
+        np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)
+
+    @pytest.mark.complex
+    @pytest.mark.spark
+    def test_lf_applier_pandas_preprocessor_memoized(self) -> None:
+        sc = SparkContext.getOrCreate()
+        sql = SQLContext(sc)
+
+        @preprocessor(memoize=True)
+        def square_memoize(x: DataPoint) -> DataPoint:
+            return Row(num=x.num, num_squared=x.num ** 2)
+
+        @labeling_function(preprocessors=[square_memoize])
+        def fp_memoized(x: DataPoint) -> int:
+            return 1 if x.num_squared > 42 else 0
+
+        df = pd.DataFrame(dict(num=DATA))
+        rdd = sql.createDataFrame(df).rdd
+        applier = SparkLFApplier([f, fp_memoized])
+        L = applier.apply(rdd)
+        np.testing.assert_equal(L.toarray(), L_PREPROCESS_EXPECTED)

--- a/test/map/test_spark.py
+++ b/test/map/test_spark.py
@@ -1,0 +1,222 @@
+import unittest
+from typing import Any, Optional
+
+import pytest
+from pyspark.sql import Row
+
+from snorkel.map import lambda_mapper
+from snorkel.map.spark import SparkMapper
+from snorkel.types import DataPoint, FieldMap
+
+
+class SplitWordsMapper(SparkMapper):
+    def __init__(self, text_field: str, lower_field: str, words_field: str) -> None:
+        super().__init__(
+            dict(text=text_field), dict(lower=lower_field, words=words_field)
+        )
+
+    def run(self, text: str) -> FieldMap:  # type: ignore
+        return dict(lower=text.lower(), words=text.split())
+
+
+class SplitWordsMapperDefaultArgs(SparkMapper):
+    def run(self, text: str) -> FieldMap:  # type: ignore
+        return dict(lower=text.lower(), words=text.split())
+
+
+class MapperReturnsNone(SparkMapper):
+    def run(self, text: str) -> Optional[FieldMap]:  # type: ignore
+        return None
+
+
+class MapperWithArgs(SparkMapper):
+    def run(self, text: str, *args: Any) -> Optional[FieldMap]:  # type: ignore
+        return None
+
+
+class MapperWithKwargs(SparkMapper):
+    def run(self, text: str, **kwargs: Any) -> Optional[FieldMap]:  # type: ignore
+        return None
+
+
+class SquareHitTracker:
+    def __init__(self):
+        self.n_hits = 0
+
+    def __call__(self, x: float) -> float:
+        self.n_hits += 1
+        return x ** 2
+
+
+@lambda_mapper()
+def square(x: DataPoint) -> DataPoint:
+    fields = x.asDict()
+    fields["num_squared"] = x.num ** 2
+    return Row(**fields)
+
+
+@lambda_mapper()
+def modify_in_place(x: DataPoint) -> DataPoint:
+    x.d["my_key"] = 0
+    return Row(num=x.num, d=x.d, d_new=x.d)
+
+
+class TestMapperCore(unittest.TestCase):
+    def _get_x(self, num=8, text="Henry has fun") -> Row:
+        return Row(num=num, text=text)
+
+    def _get_x_dict(self) -> Row:
+        return Row(num=8, d=dict(my_key=1))
+
+    @pytest.mark.spark
+    def test_numeric_mapper(self) -> None:
+        x_mapped = square(self._get_x())
+        # NB: not using `self.assertIsNotNone` due to mypy
+        # See https://github.com/python/mypy/issues/5088
+        assert x_mapped is not None
+        self.assertEqual(x_mapped.num, 8)
+        self.assertEqual(x_mapped.text, "Henry has fun")
+        self.assertEqual(x_mapped.num_squared, 64)
+
+    @pytest.mark.spark
+    def test_text_mapper(self) -> None:
+        split_words = SplitWordsMapper("text", "text_lower", "text_words")
+        x_mapped = split_words(self._get_x())
+        assert x_mapped is not None
+        self.assertEqual(x_mapped.num, 8)
+        self.assertEqual(x_mapped.text, "Henry has fun")
+        self.assertEqual(x_mapped.text_lower, "henry has fun")
+        self.assertEqual(x_mapped.text_words, ["Henry", "has", "fun"])
+
+    @pytest.mark.spark
+    def test_mapper_same_field(self) -> None:
+        split_words = SplitWordsMapper("text", "text", "text_words")
+        x = self._get_x()
+        x_mapped = split_words(x)
+        self.assertEqual(x.num, 8)
+        self.assertEqual(x.text, "Henry has fun")
+        self.assertFalse(hasattr(x, "text_words"))
+        assert x_mapped is not None
+        self.assertEqual(x_mapped.num, 8)
+        self.assertEqual(x_mapped.text, "henry has fun")
+        self.assertEqual(x_mapped.text_words, ["Henry", "has", "fun"])
+
+    @pytest.mark.spark
+    def test_mapper_default_args(self) -> None:
+        split_words = SplitWordsMapperDefaultArgs()
+        x_mapped = split_words(self._get_x())
+        assert x_mapped is not None
+        self.assertEqual(x_mapped.num, 8)
+        self.assertEqual(x_mapped.text, "Henry has fun")
+        self.assertEqual(x_mapped.lower, "henry has fun")
+        self.assertEqual(x_mapped.words, ["Henry", "has", "fun"])
+
+    @pytest.mark.spark
+    def test_mapper_in_place(self) -> None:
+        x = self._get_x_dict()
+        x_mapped = modify_in_place(x)
+        self.assertEqual(x.num, 8)
+        self.assertEqual(x.d, dict(my_key=1))
+        self.assertFalse(hasattr(x, "d_new"))
+        assert x_mapped is not None
+        self.assertEqual(x_mapped.num, 8)
+        self.assertEqual(x_mapped.d, dict(my_key=0))
+        self.assertEqual(x_mapped.d_new, dict(my_key=0))
+
+    @pytest.mark.spark
+    def test_mapper_returns_none(self) -> None:
+        mapper = MapperReturnsNone()
+        x_mapped = mapper(self._get_x())
+        self.assertIsNone(x_mapped)
+
+    @pytest.mark.spark
+    def test_decorator_mapper_memoized(self) -> None:
+        square_hit_tracker = SquareHitTracker()
+
+        @lambda_mapper(memoize=True)
+        def square(x: DataPoint) -> DataPoint:
+            fields = x.asDict()
+            fields["num_squared"] = square_hit_tracker(x.num)
+            return Row(**fields)
+
+        x8 = self._get_x()
+        x9 = self._get_x(9)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x19_mapped = square(x9)
+        assert x19_mapped is not None
+        self.assertEqual(x19_mapped.num_squared, 81)
+        self.assertEqual(square_hit_tracker.n_hits, 2)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 2)
+
+        square.reset_cache()
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 3)
+
+    @pytest.mark.spark
+    def test_decorator_mapper_memoized_none(self) -> None:
+        square_hit_tracker = SquareHitTracker()
+
+        @lambda_mapper(memoize=True)
+        def square(x: DataPoint) -> DataPoint:
+            fields = x.asDict()
+            fields["num_squared"] = square_hit_tracker(x.num)
+            if x.num == 21:
+                return None
+            return Row(**fields)
+
+        x21 = self._get_x(21)
+        x21_mapped = square(x21)
+        self.assertIsNone(x21_mapped)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x21_mapped = square(x21)
+        self.assertIsNone(x21_mapped)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+
+    @pytest.mark.spark
+    def test_decorator_mapper_not_memoized(self) -> None:
+        square_hit_tracker = SquareHitTracker()
+
+        @lambda_mapper(memoize=False)
+        def square(x: DataPoint) -> DataPoint:
+            fields = x.asDict()
+            fields["num_squared"] = square_hit_tracker(x.num)
+            return Row(**fields)
+
+        x8 = self._get_x()
+        x9 = self._get_x(9)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 1)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 2)
+        x19_mapped = square(x9)
+        assert x19_mapped is not None
+        self.assertEqual(x19_mapped.num_squared, 81)
+        self.assertEqual(square_hit_tracker.n_hits, 3)
+        x8_mapped = square(x8)
+        assert x8_mapped is not None
+        self.assertEqual(x8_mapped.num_squared, 64)
+        self.assertEqual(square_hit_tracker.n_hits, 4)
+
+    @pytest.mark.spark
+    def test_mapper_with_args_kwargs(self) -> None:
+        with self.assertRaises(ValueError):
+            MapperWithArgs()
+
+        with self.assertRaises(ValueError):
+            MapperWithKwargs()

--- a/tox.ini
+++ b/tox.ini
@@ -8,13 +8,22 @@ isolated_build = true
 
 [testenv]
 description = run the test driver with {basepython}
-deps = -rrequirements.txt
+deps =
+    -rrequirements.txt
+    -rrequirements-pyspark.txt
 commands_pre = python -m spacy download en_core_web_sm
-commands = python -m pytest {posargs:test/}
+commands = python -m pytest -m 'not spark and not complex' {posargs:test/}
+
+[testenv:spark]
+description = run the test driver with {basepython}
+passenv = JAVA_HOME
+commands_pre = python -m spacy download en_core_web_sm
+commands = python -m pytest -m spark {posargs:test/}
 
 [testenv:check]
 description = check the code style
 basepython = python3
+deps = -rrequirements.txt
 commands_pre =
 commands =
     isort -rc -c .
@@ -25,12 +34,14 @@ commands =
 [testenv:type]
 description = run static type checking
 basepython = python3
+deps = -rrequirements.txt
 commands_pre =
 commands = mypy -p snorkel
 
 [testenv:docstyle]
 description = check doc style
 basepython = python3
+deps = -rrequirements.txt
 commands_pre =
 commands =
     pydocstyle snorkel
@@ -39,7 +50,7 @@ commands =
 description = run coverage checks
 basepython = python3
 usedevelop = True
-commands = python -m pytest --cov=snorkel test/
+commands = python -m pytest -m 'not spark and not complex' --cov=snorkel test/
 
 [testenv:dev]
 description = install dev tools
@@ -52,6 +63,7 @@ commands =
 [testenv:fix]
 description = run code stylers
 basepython = python3
+deps = -rrequirements.txt
 usedevelop = True
 commands_pre =
 commands =


### PR DESCRIPTION
On the way to adding integration/complex testing, I found a good way to add PySpark tests. We don't want to run them with everything else all the time because we need Java and the PySpark install is huge. We do however want to run them in Travis.

You can also see that I'm marking things with `pytest.mark.complex`. In a future diff, we'll add integration/complex system testing support by just running `pytest.mark.complex` on master.

It's important to note that single node Spark tests won't catch everything. But it's the best we can do with current CI setup.

* Add PySpark unit tests, decorated with `pytest.mark.spark`
* Separate Spark tests from other tests in pytest invocation in tox.ini
* Update Travis to install JDK8 so that we can run Spark tests
* Add documentation on PySpark testing