### PR TITLE
[EASY] Refactor Multitask{DataLoader, Dataset} to Snorkel{...}

### DIFF
--- a/snorkel/end_model/data.py
+++ b/snorkel/end_model/data.py
@@ -8,7 +8,7 @@ from torch.utils.data import DataLoader, Dataset
 from .utils import list_to_tensor
 
 
-class MultitaskDataset(Dataset):
+class SnorkelDataset(Dataset):
     """An advanced dataset class to handle input data with multipled fields and output
     data with multiple label sets
 
@@ -68,7 +68,7 @@ def collate_dicts(batch):
     return dict(X_batch), dict(Y_batch)
 
 
-class MultitaskDataLoader(DataLoader):
+class SnorkelDataLoader(DataLoader):
     """An advanced dataloader class which contains mapping from task to label (which
     label(s) to use in dataset's Y_dict for this task), and split (which part this
     dataset belongs to) information.
@@ -89,7 +89,7 @@ class MultitaskDataLoader(DataLoader):
         self, dataset, collate_fn=collate_dicts, task_to_label_dict=None, **kwargs
     ):
 
-        assert isinstance(dataset, MultitaskDataset)
+        assert isinstance(dataset, SnorkelDataset)
         super().__init__(dataset, collate_fn=collate_fn, **kwargs)
 
         self.task_to_label_dict = task_to_label_dict or {}

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_matrix
 from torch import nn
 
 from snorkel.analysis.utils import convert_labels
-from snorkel.end_model.data import MultitaskDataLoader
+from snorkel.end_model.data import SnorkelDataLoader
 from snorkel.end_model.modules.utils import ce_loss, softmax
 from snorkel.end_model.scorer import Scorer
 from snorkel.end_model.task import Operation, Task
@@ -16,7 +16,7 @@ from .modules.slice_combiner import SliceCombinerModule
 
 
 def add_slice_labels(
-    dataloader: MultitaskDataLoader,
+    dataloader: SnorkelDataLoader,
     base_task: Task,
     slice_labels: csr_matrix,
     slice_names: List[str],

--- a/test/end_model/batch_schedulers/test_schedulers.py
+++ b/test/end_model/batch_schedulers/test_schedulers.py
@@ -4,17 +4,17 @@ import torch
 
 from snorkel.analysis.utils import set_seed
 from snorkel.end_model.batch_schedulers import SequentialScheduler, ShuffledScheduler
-from snorkel.end_model.data import MultitaskDataLoader, MultitaskDataset
+from snorkel.end_model.data import SnorkelDataLoader, SnorkelDataset
 
-dataset1 = MultitaskDataset(
+dataset1 = SnorkelDataset(
     "d1", "train", {"data": ["a", "b", "c"]}, {"labels": torch.LongTensor([1, 2, 3])}
 )
-dataset2 = MultitaskDataset(
+dataset2 = SnorkelDataset(
     "d2", "train", {"data": ["d", "e", "f"]}, {"labels": torch.LongTensor([4, 5, 6])}
 )
 
-dataloader1 = MultitaskDataLoader(dataset1, batch_size=2)
-dataloader2 = MultitaskDataLoader(dataset2, batch_size=2)
+dataloader1 = SnorkelDataLoader(dataset1, batch_size=2)
+dataloader2 = SnorkelDataLoader(dataset2, batch_size=2)
 dataloaders = [dataloader1, dataloader2]
 
 

--- a/test/end_model/test_data.py
+++ b/test/end_model/test_data.py
@@ -2,12 +2,12 @@ import unittest
 
 import torch
 
-from snorkel.end_model.data import MultitaskDataLoader, MultitaskDataset
+from snorkel.end_model.data import SnorkelDataLoader, SnorkelDataset
 
 
 class DatasetTest(unittest.TestCase):
     def test_mtl_dataset(self):
-        """Unit test of MultitaskDataset"""
+        """Unit test of SnorkelDataset"""
 
         x1 = [
             torch.Tensor([1]),
@@ -19,7 +19,7 @@ class DatasetTest(unittest.TestCase):
 
         y1 = torch.Tensor([0, 0, 0, 0, 0])
 
-        dataset = MultitaskDataset(
+        dataset = SnorkelDataset(
             X_dict={"data1": x1}, Y_dict={"label1": y1}, name="new_data", split="train"
         )
 
@@ -28,7 +28,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(torch.equal(dataset[0][1]["label1"], y1[0]))
 
     def test_mtl_dataloader(self):
-        """Unit test of MultitaskDataloader"""
+        """Unit test of SnorkelDataLoader"""
 
         x1 = [
             torch.Tensor([1]),
@@ -50,14 +50,14 @@ class DatasetTest(unittest.TestCase):
 
         y2 = torch.Tensor([1, 1, 1, 1, 1])
 
-        dataset = MultitaskDataset(
+        dataset = SnorkelDataset(
             name="new_data",
             split="train",
             X_dict={"data1": x1, "data2": x2},
             Y_dict={"label1": y1, "label2": y2},
         )
 
-        dataloader1 = MultitaskDataLoader(
+        dataloader1 = SnorkelDataLoader(
             task_to_label_dict={"task1": "label1"}, dataset=dataset, batch_size=2
         )
 
@@ -75,10 +75,8 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(torch.equal(y_batch["label1"], torch.Tensor([0, 0])))
         self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([1, 1])))
 
-        dataloader2 = MultitaskDataLoader(
-            task_to_label_dict={"task2": "label2"},
-            dataset=dataset,
-            batch_size=3,
+        dataloader2 = SnorkelDataLoader(
+            task_to_label_dict={"task2": "label2"}, dataset=dataset, batch_size=3
         )
 
         x_batch, y_batch = next(iter(dataloader2))

--- a/test/end_model/test_trainer.py
+++ b/test/end_model/test_trainer.py
@@ -5,7 +5,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from snorkel.end_model.data import MultitaskDataLoader, MultitaskDataset
+from snorkel.end_model.data import SnorkelDataLoader, SnorkelDataset
 from snorkel.end_model.model import MultitaskModel
 from snorkel.end_model.modules.utils import ce_loss, softmax
 from snorkel.end_model.scorer import Scorer
@@ -62,11 +62,11 @@ def create_dataloaders(num_tasks=1):
             Y_dict["task2_labels"] = Y_split[:, 1]
             task_to_label_dict["task2"] = "task2_labels"
 
-        dataset = MultitaskDataset(
+        dataset = SnorkelDataset(
             name="dataset", split=split, X_dict={"coordinates": X_split}, Y_dict=Y_dict
         )
 
-        dataloader = MultitaskDataLoader(
+        dataloader = SnorkelDataLoader(
             task_to_label_dict=task_to_label_dict,
             dataset=dataset,
             batch_size=4,

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -6,7 +6,7 @@ import pandas as pd
 import torch
 import torch.nn as nn
 
-from snorkel.end_model.data import MultitaskDataLoader, MultitaskDataset
+from snorkel.end_model.data import SnorkelDataLoader, SnorkelDataset
 from snorkel.end_model.model import MultitaskModel
 from snorkel.end_model.modules.utils import ce_loss, softmax
 from snorkel.end_model.scorer import Scorer
@@ -109,7 +109,7 @@ def create_dataloader(df, split):
     Y_dict[f"task2_labels"] = torch.LongTensor(df["y2"])
     task_to_label_dict["task2"] = "task2_labels"
 
-    dataset = MultitaskDataset(
+    dataset = SnorkelDataset(
         name="TestData",
         split=split,
         X_dict={
@@ -120,7 +120,7 @@ def create_dataloader(df, split):
         Y_dict=Y_dict,
     )
 
-    dataloader = MultitaskDataLoader(
+    dataloader = SnorkelDataLoader(
         task_to_label_dict=task_to_label_dict,
         dataset=dataset,
         batch_size=4,

--- a/tutorials/mtl/Multitask_Tutorial.ipynb
+++ b/tutorials/mtl/Multitask_Tutorial.ipynb
@@ -190,9 +190,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With our data now loaded/created, we can now package it up into `MultitaskDataLoader`s for training. \n",
+    "With our data now loaded/created, we can now package it up into `SnorkelDataLoader`s for training. \n",
     "\n",
-    "In the `MultitaskDataLoader`, we specify a mapping from each `Task` to its corresponding labels.  We'll define these `Task` objects in the following section as we define our model."
+    "In the `SnorkelDataLoader`, we specify a mapping from each `Task` to its corresponding labels.  We'll define these `Task` objects in the following section as we define our model."
    ]
   },
   {
@@ -201,17 +201,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from snorkel.mtl.data import MultitaskDataset, MultitaskDataLoader\n",
+    "from snorkel.mtl.data import SnorkelDataset, SnorkelDataLoader\n",
     "\n",
     "dataloaders = []\n",
     "for split in [0,1,2]:\n",
     "    X_dict = {\"circle_data\": circle_data_splits[split]}\n",
     "    Y_dict = {\"circle_labels\": circle_label_splits[split]}\n",
-    "    dataset = MultitaskDataset(\"Circle\", X_dict, Y_dict)\n",
+    "    dataset = SnorkelDataset(\"Circle\", X_dict, Y_dict)\n",
     "\n",
     "    task_to_label_dict = {\"circle_task\": \"circle_labels\"}\n",
     "\n",
-    "    dataloader = MultitaskDataLoader(\n",
+    "    dataloader = SnorkelDataLoader(\n",
     "        task_to_label_dict,\n",
     "        dataset,\n",
     "        split=[\"train\", \"valid\", \"test\"][split],\n",
@@ -222,11 +222,11 @@
     "for split in [0,1,2]:\n",
     "    X_dict = {\"square_data\": square_data_splits[split]}\n",
     "    Y_dict = {\"square_labels\": square_label_splits[split]}\n",
-    "    dataset = MultitaskDataset(\"Square\", X_dict, Y_dict)\n",
+    "    dataset = SnorkelDataset(\"Square\", X_dict, Y_dict)\n",
     "\n",
     "    task_to_label_dict = {\"square_task\": \"square_labels\"}\n",
     "\n",
-    "    dataloader = MultitaskDataLoader(\n",
+    "    dataloader = SnorkelDataLoader(\n",
     "        task_to_label_dict,\n",
     "        dataset,\n",
     "        split=[\"train\", \"valid\", \"test\"][split],\n",

--- a/tutorials/workshop/utils.py
+++ b/tutorials/workshop/utils.py
@@ -10,7 +10,7 @@ from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 from torchtext.vocab import Vocab
 
-from snorkel.end_model.data import MultitaskDataLoader, MultitaskDataset
+from snorkel.end_model.data import SnorkelDataLoader, SnorkelDataset
 
 
 def upgrade_dataloaders(dataloaders: List[DataLoader]):
@@ -18,12 +18,12 @@ def upgrade_dataloaders(dataloaders: List[DataLoader]):
     for dataloader in dataloaders:
         dataset = dataloader.dataset
 
-        new_dataset = MultitaskDataset(
+        new_dataset = SnorkelDataset(
             name=f"data_{dataloader.split}",
             X_dict={"data": dataset.X},  # This op is specific to TensorDataset
             Y_dict={"labels": dataset.Y},  # Maybe
         )
-        new_dataloader = MultitaskDataLoader(
+        new_dataloader = SnorkelDataLoader(
             task_to_label_dict={"task": "labels"},
             dataset=new_dataset,
             split=dataloader.split,


### PR DESCRIPTION
As simple as it looks: just change MultitaskDataLoader to SnorkelDataLoader and MultitaskDataset to SnorkelDataset. 

With recent refactorings, all end model tooling can be used by both single-task and multi-task end models except the models themselves, so the dataset/dataloader classes are getting more general names.