### PR TITLE
Reuse tox dependency installs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache: pip
 dist: xenial
 
 env:
-  TOXENV=py,spark,check,coverage JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+  TOXENV=coverage,spark,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 jobs:
   include:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [tool:pytest]
-markers =
-    spark
+testpaths = test
+markers = spark
+norecursedirs = .tox
 
 [flake8]
 ignore = 

--- a/tox.ini
+++ b/tox.ini
@@ -21,13 +21,13 @@ deps =
     -rrequirements.txt
     -rrequirements-pyspark.txt
 commands_pre = python -m spacy download en_core_web_sm
-commands = python -m pytest -m 'not spark and not complex' {posargs:test/}
+commands = python -m pytest -m 'not spark and not complex' {posargs}
 
 [testenv:spark]
 description = run the test driver with {basepython}
 passenv = JAVA_HOME
 commands_pre = python -m spacy download en_core_web_sm
-commands = python -m pytest -m spark {posargs:test/}
+commands = python -m pytest -m spark {posargs}
 
 [testenv:check]
 description = check the code style
@@ -49,16 +49,14 @@ commands = mypy -p snorkel
 description = check doc style
 basepython = python3
 commands_pre =
-commands =
-    pydocstyle snorkel
+commands = pydocstyle snorkel
 
 [testenv:coverage]
 description = run coverage checks
 basepython = python3
-usedevelop = True
 # Note: make sure this matches testenv since this is used
 # on CI as the default unit test runner
-commands = python -m pytest -m 'not spark and not complex' --cov=snorkel test/
+commands = python -m pytest -m 'not spark and not complex' --cov=snorkel
 
 [testenv:dev]
 description = install dev tools

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,15 @@ isolated_build = true
 
 [testenv]
 description = run the test driver with {basepython}
+# Note: in order to allow dependency library install reuse
+# on CI, we allow overriding the default envdir
+# (specified as `{toxworkdir}/{envname}`) by setting the
+# environment variable `TOX_INSTALL_DIR`. We avoid
+# collision with the already-used `TOX_ENV_DIR`.
+envdir = {env:TOX_INSTALL_DIR:{toxworkdir}/{envname}}
+# Note: we try to keep the deps the same for all tests
+# running on CI so that we skip reinstalling dependency
+# libraries for all testenvs
 deps =
     -rrequirements.txt
     -rrequirements-pyspark.txt
@@ -23,7 +32,6 @@ commands = python -m pytest -m spark {posargs:test/}
 [testenv:check]
 description = check the code style
 basepython = python3
-deps = -rrequirements.txt
 commands_pre =
 commands =
     isort -rc -c .
@@ -34,14 +42,12 @@ commands =
 [testenv:type]
 description = run static type checking
 basepython = python3
-deps = -rrequirements.txt
 commands_pre =
 commands = mypy -p snorkel
 
 [testenv:docstyle]
 description = check doc style
 basepython = python3
-deps = -rrequirements.txt
 commands_pre =
 commands =
     pydocstyle snorkel
@@ -50,6 +56,8 @@ commands =
 description = run coverage checks
 basepython = python3
 usedevelop = True
+# Note: make sure this matches testenv since this is used
+# on CI as the default unit test runner
 commands = python -m pytest -m 'not spark and not complex' --cov=snorkel test/
 
 [testenv:dev]
@@ -63,7 +71,6 @@ commands =
 [testenv:fix]
 description = run code stylers
 basepython = python3
-deps = -rrequirements.txt
 usedevelop = True
 commands_pre =
 commands =


### PR DESCRIPTION
See title. A little (well documented) tox fanciness to avoid slow reinstalls. Removed develop mode where it wasn't necessary to avoid reinstalls. See

* https://tox.readthedocs.io/en/latest/config.html
* https://blog.ionelmc.ro/2015/04/14/tox-tricks-and-patterns/#environment-reuse

Note: for some reason, we reinstall when calling `tox` after `tox --notest`. We could get a couple minutes back by removing `tox --notest` but that would make it extremely hard to debug install issues. Leaving for now.

**Test plan:**
* Travis speed-up 18m -> 11m. Manually validated outputs.
* Ran the following series of typical developer commands and validated correct outputs (e.g. things fixed by `-e fix` and correct coverage from `-e coverage`

```bash
rm -rf .tox
rm -rf .env
tox -e dev
source .env/bin/activate
tox
# Messed some formatting up
tox
tox -e fix
tox
tox -e check
tox -e spark
tox -e coverage
```