### PR TITLE
PySpark monkey patcher

### DIFF
--- a/snorkel/labeling/preprocess/spark.py
+++ b/snorkel/labeling/preprocess/spark.py
@@ -1,1 +1,1 @@
-from snorkel.map.spark import SparkMapper as SparkPreprocessor  # noqa: F401
+from snorkel.map.spark import make_spark_mapper as make_spark_preprocessor  # noqa: F401

--- a/snorkel/map/spark.py
+++ b/snorkel/map/spark.py
@@ -5,7 +5,7 @@ from snorkel.types import FieldMap
 from .core import Mapper
 
 
-def _update_fields(self, x: Row, mapped_fields: FieldMap) -> Row:
+def _update_fields(x: Row, mapped_fields: FieldMap) -> Row:
     # `pyspark.sql.Row` objects are not mutable, so need to
     # reconstruct
     all_fields = x.asDict()

--- a/snorkel/map/spark.py
+++ b/snorkel/map/spark.py
@@ -5,42 +5,21 @@ from snorkel.types import FieldMap
 from .core import Mapper
 
 
-class SparkMapper(Mapper):
-    """Base class for any `Mapper` that runs on PySpark `Row` objects.
+def _update_fields(self, x: Row, mapped_fields: FieldMap) -> Row:
+    # `pyspark.sql.Row` objects are not mutable, so need to
+    # reconstruct
+    all_fields = x.asDict()
+    all_fields.update(mapped_fields)
+    return Row(**all_fields)
 
-    See `snorkel.map.core.Mapper`.
+
+def make_spark_mapper(mapper: Mapper) -> Mapper:
+    """Convert `Mapper` to be compatible with PySpark.
 
     Parameters
     ----------
-    field_names
-        A map from attribute names of the incoming data points
-        to the input argument names of the `run` method. If None,
-        the parameter names in the function signature are used.
-    mapped_field_names
-        A map from output keys of the `run` method to attribute
-        names of the output data points. If None, the original
-        output keys are used.
-    memoize
-        Memoize mapper outputs?
-
-    Attributes
-    ----------
-    field_names
-        See above
-    mapped_field_names
-        See above
-    memoize
-        Memoize mapper outputs?
-
-    Raises
-    ------
-    NotImplementedError
-        Subclasses must implement the `run` method
+    mapper
+        Mapper to make compatible with PySpark
     """
-
-    def _update_fields(self, x: Row, mapped_fields: FieldMap) -> Row:
-        # `pyspark.sql.Row` objects are not mutable, so need to
-        # reconstruct
-        all_fields = x.asDict()
-        all_fields.update(mapped_fields)
-        return Row(**all_fields)
+    mapper._update_fields = _update_fields  # type: ignore
+    return mapper


### PR DESCRIPTION
`SparkMapper` worked fine, but you'd have to define a separate preprocessor to create a Spark version. For example, I'd have to do some weird MRO and/or mixin madness to get a Spark version of `SpacyPreprocessor`. But now, I can just do

```python
spacy_preprocessor = make_spark_preprocessor(SpacyPreprocessor())
```

**Test plan**
Shifted all Spark mapper unit tests to new version