### PR TITLE
Refactor Dataset, DataLoader, and Model names

### DIFF
--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -13,7 +13,7 @@ YDict = Dict[str, Tensor]
 Batch = Tuple[XDict, YDict]
 
 
-class ClassifierDataset(Dataset):
+class DictDataset(Dataset):
     """An advanced dataset class to handle input data with multipled fields and output
     data with multiple label sets
 
@@ -73,7 +73,7 @@ def collate_dicts(batch: List[Batch]) -> Batch:
     return dict(X_batch), dict(Y_batch)
 
 
-class ClassifierDataLoader(DataLoader):
+class DictDataLoader(DataLoader):
     """An advanced dataloader class which contains mapping from task to label (which
     label(s) to use in dataset's Y_dict for this task), and split (which part this
     dataset belongs to) information.
@@ -92,13 +92,13 @@ class ClassifierDataLoader(DataLoader):
 
     def __init__(
         self,
-        dataset: ClassifierDataset,
+        dataset: DictDataset,
         collate_fn: Callable[..., Any] = collate_dicts,
         task_to_label_dict: Dict[str, str] = None,
         **kwargs,
     ) -> None:
 
-        assert isinstance(dataset, ClassifierDataset)
+        assert isinstance(dataset, DictDataset)
         super().__init__(dataset, collate_fn=collate_fn, **kwargs)
 
         self.task_to_label_dict = task_to_label_dict or {}

--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -78,9 +78,7 @@ class DictDataLoader(DataLoader):
     label(s) to use in dataset's Y_dict for this task), and split (which part this
     dataset belongs to) information.
 
-    :param task_to_label_dict: the task to label mapping where key is the task name and
     value is the labels for that task and should be the key in Y_dict
-    :type task_to_label_dict: dict
     :param dataset: the dataset to construct the dataloader
     :type dataset: torch.utils.data.Dataset
     :param split: the split information, defaults to "train"
@@ -94,20 +92,11 @@ class DictDataLoader(DataLoader):
         self,
         dataset: DictDataset,
         collate_fn: Callable[..., Any] = collate_dicts,
-        task_to_label_dict: Dict[str, str] = None,
         **kwargs,
     ) -> None:
 
         assert isinstance(dataset, DictDataset)
         super().__init__(dataset, collate_fn=collate_fn, **kwargs)
-
-        self.task_to_label_dict = task_to_label_dict or {}
-
-        for label in self.task_to_label_dict.values():
-            if label not in dataset.Y_dict:
-                raise ValueError(
-                    f"Label {label} specified in task_to_label_dict could not be found in Y_dict"
-                )
 
 
 def split_data(

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -19,7 +19,7 @@ import torch
 import torch.nn as nn
 
 from snorkel.analysis.utils import probs_to_preds
-from snorkel.classification.data import ClassifierDataLoader
+from snorkel.classification.data import DictDataLoader
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_config import default_config
 from snorkel.classification.utils import move_to_device, recursive_merge_dicts
@@ -30,7 +30,7 @@ from .task import Operation, Task
 OutputDict = Dict[str, Mapping[Union[str, int], Any]]
 
 
-class AdvancedClassifier(nn.Module):
+class SnorkelClassifier(nn.Module):
     """A class to build multi-task model.
 
     :param name: Name of the model
@@ -242,7 +242,7 @@ class AdvancedClassifier(nn.Module):
 
     @torch.no_grad()
     def predict(
-        self, dataloader: ClassifierDataLoader, return_preds: bool = False
+        self, dataloader: DictDataLoader, return_preds: bool = False
     ) -> Dict[str, Dict[str, torch.Tensor]]:
 
         self.eval()
@@ -288,7 +288,7 @@ class AdvancedClassifier(nn.Module):
         return results
 
     @torch.no_grad()
-    def score(self, dataloaders: List[ClassifierDataLoader]) -> Dict[str, float]:
+    def score(self, dataloaders: List[DictDataLoader]) -> Dict[str, float]:
         """Score the data from dataloader with the model
 
         :param dataloaders: the dataloader that performs scoring
@@ -309,7 +309,7 @@ class AdvancedClassifier(nn.Module):
                 )
                 for metric_name, metric_value in metric_scores.items():
                     # Type ignore statements are necessary because the DataLoader class
-                    # that ClassifierDataLoader inherits from is what actually sets
+                    # that DictDataLoader inherits from is what actually sets
                     # the class of Dataset, and it doesn't know about name and split.
                     identifier = "/".join(
                         [

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -175,16 +175,12 @@ class SnorkelClassifier(nn.Module):
         return outputs
 
     def calculate_loss(
-        self,
-        X_dict: Mapping[str, Any],
-        Y_dict: Dict[str, torch.Tensor],
-        task_to_label_dict: Dict[str, str],
+        self, X_dict: Mapping[str, Any], Y_dict: Dict[str, torch.Tensor]
     ) -> Tuple[Dict[str, torch.Tensor], Dict[str, float]]:
         """Calculate the loss
 
         :param X_dict: The input data
         :param Y_dict: The output data
-        :param task_to_label_dict: The task to label mapping
         :return: The loss and the number of samples in the batch of all tasks
         :rtype: dict, dict
         """
@@ -192,13 +188,11 @@ class SnorkelClassifier(nn.Module):
         loss_dict = dict()
         count_dict = dict()
 
-        task_names = task_to_label_dict.keys()
+        task_names = Y_dict.keys()
         outputs = self.forward(X_dict, task_names)
 
         # Calculate loss for each task
-        for task_name, label_name in task_to_label_dict.items():
-
-            Y = Y_dict[label_name]
+        for task_name, Y in Y_dict.items():
 
             # Select the active samples
             if len(Y.size()) == 1:
@@ -251,14 +245,10 @@ class SnorkelClassifier(nn.Module):
         prob_dict_list: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
         for batch_num, (X_batch_dict, Y_batch_dict) in enumerate(dataloader):
-            prob_batch_dict = self._calculate_probs(
-                X_batch_dict, dataloader.task_to_label_dict.keys()
-            )
-            for task_name in dataloader.task_to_label_dict.keys():
+            prob_batch_dict = self._calculate_probs(X_batch_dict, Y_batch_dict.keys())
+            for task_name, Y in Y_batch_dict.items():
                 prob_dict_list[task_name].extend(prob_batch_dict[task_name])
-                gold_dict_list[task_name].extend(
-                    Y_batch_dict[dataloader.task_to_label_dict[task_name]].cpu().numpy()
-                )
+                gold_dict_list[task_name].extend(Y.cpu().numpy())
 
         gold_dict: Dict[str, np.ndarray] = {}
         prob_dict: Dict[str, np.ndarray] = {}

--- a/snorkel/classification/task.py
+++ b/snorkel/classification/task.py
@@ -60,6 +60,8 @@ class Task:
         assert isinstance(module_pool, nn.ModuleDict) is True
         self.module_pool = module_pool
         self.task_flow = task_flow
+        # By default, apply cross entropy loss and softmax to the output of the last
+        # operation in the task flow.
         self.loss_func = loss_func or partial(ce_loss, task_flow[-1].name)
         self.output_func = output_func or partial(softmax, task_flow[-1].name)
         self.scorer = scorer

--- a/snorkel/classification/training/loggers/log_manager.py
+++ b/snorkel/classification/training/loggers/log_manager.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-from snorkel.classification.snorkel_classifier import AdvancedClassifier
+from snorkel.classification.snorkel_classifier import SnorkelClassifier
 from snorkel.classification.snorkel_config import default_config
 from snorkel.classification.utils import recursive_merge_dicts
 
@@ -109,7 +109,7 @@ class LogManager(object):
         self.epoch_count = 0
         self.unit_count = 0
 
-    def close(self, model: AdvancedClassifier) -> AdvancedClassifier:
+    def close(self, model: SnorkelClassifier) -> SnorkelClassifier:
         if self.log_writer is not None:
             self.log_writer.close()
         if self.checkpointer is not None:

--- a/snorkel/classification/training/schedulers/scheduler.py
+++ b/snorkel/classification/training/schedulers/scheduler.py
@@ -3,10 +3,10 @@ from typing import Any, Dict, Iterator, Sequence, Tuple
 
 from torch import Tensor
 
-from snorkel.classification.data import ClassifierDataLoader
+from snorkel.classification.data import DictDataLoader
 
 BatchIterator = Iterator[
-    Tuple[Tuple[Dict[str, Any], Dict[str, Tensor]], ClassifierDataLoader]
+    Tuple[Tuple[Dict[str, Any], Dict[str, Tensor]], DictDataLoader]
 ]
 
 
@@ -18,7 +18,7 @@ class Scheduler(ABC):
         pass
 
     @abstractmethod
-    def get_batches(self, dataloaders: Sequence[ClassifierDataLoader]) -> BatchIterator:
+    def get_batches(self, dataloaders: Sequence[DictDataLoader]) -> BatchIterator:
         """Return batches in shuffled order from dataloaders
 
         Parameters

--- a/snorkel/classification/training/schedulers/sequential_scheduler.py
+++ b/snorkel/classification/training/schedulers/sequential_scheduler.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from snorkel.classification.data import ClassifierDataLoader
+from snorkel.classification.data import DictDataLoader
 
 from .scheduler import BatchIterator, Scheduler
 
@@ -11,7 +11,7 @@ class SequentialScheduler(Scheduler):
     def __init__(self):
         super().__init__()
 
-    def get_batches(self, dataloaders: Sequence[ClassifierDataLoader]) -> BatchIterator:
+    def get_batches(self, dataloaders: Sequence[DictDataLoader]) -> BatchIterator:
         """Return batches from dataloaders sequentially in the order they were given.
 
         Parameters

--- a/snorkel/classification/training/schedulers/shuffled_scheduler.py
+++ b/snorkel/classification/training/schedulers/shuffled_scheduler.py
@@ -1,7 +1,7 @@
 import random
 from typing import Sequence
 
-from snorkel.classification.data import ClassifierDataLoader
+from snorkel.classification.data import DictDataLoader
 
 from .scheduler import BatchIterator, Scheduler
 
@@ -12,7 +12,7 @@ class ShuffledScheduler(Scheduler):
     def __init__(self):
         super().__init__()
 
-    def get_batches(self, dataloaders: Sequence[ClassifierDataLoader]) -> BatchIterator:
+    def get_batches(self, dataloaders: Sequence[DictDataLoader]) -> BatchIterator:
         """Return batches in shuffled order from dataloaders
 
         Note that this shuffles the batch order, but it does not shuffle the datasets

--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -6,7 +6,7 @@ import torch
 import torch.optim as optim
 from tqdm import tqdm
 
-from snorkel.classification.snorkel_classifier import AdvancedClassifier
+from snorkel.classification.snorkel_classifier import SnorkelClassifier
 from snorkel.classification.snorkel_config import default_config
 from snorkel.classification.training import (
     Checkpointer,
@@ -29,11 +29,11 @@ class Trainer(object):
         self.config = recursive_merge_dicts(default_config, kwargs, misses="insert")
         self.name = name if name is not None else type(self).__name__
 
-    def train_model(self, model: AdvancedClassifier, dataloaders):
+    def train_model(self, model: SnorkelClassifier, dataloaders):
         """The learning procedure of MTL
 
         :param model: The multi-task model that needs to learn
-        :type model: AdvancedClassifier
+        :type model: SnorkelClassifier
         :param dataloaders: a list of dataloaders used to learn the model
         :type dataloaders: list
         """

--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -95,9 +95,7 @@ class Trainer(object):
                 self.optimizer.zero_grad()
 
                 # Perform forward pass and calcualte the loss and count
-                loss_dict, count_dict = model.calculate_loss(
-                    X_dict, Y_dict, dataloader.task_to_label_dict
-                )
+                loss_dict, count_dict = model.calculate_loss(X_dict, Y_dict)
 
                 # Update running loss and count
                 for task_name in loss_dict.keys():

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -25,9 +25,8 @@ def add_slice_labels(
     slice_labels, slice_names = _add_base_slice(slice_labels, slice_names)
     assert slice_labels.shape[1] == len(slice_names)
 
-    label_name = dataloader.task_to_label_dict[base_task.name]
     Y_dict: Dict[str, ArrayLike] = dataloader.dataset.Y_dict  # type: ignore
-    labels = Y_dict[label_name]
+    labels = Y_dict[base_task.name]
     for i, slice_name in enumerate(slice_names):
 
         # Convert labels
@@ -41,9 +40,6 @@ def add_slice_labels(
         # Update dataloaders
         Y_dict[ind_task_name] = ind_labels
         Y_dict[pred_task_name] = pred_labels
-
-        dataloader.task_to_label_dict[ind_task_name] = ind_task_name
-        dataloader.task_to_label_dict[pred_task_name] = pred_task_name
 
 
 def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task]:

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -6,7 +6,7 @@ from scipy.sparse import csr_matrix
 from torch import nn
 
 from snorkel.analysis.utils import convert_labels
-from snorkel.classification.data import ClassifierDataLoader
+from snorkel.classification.data import DictDataLoader
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, Task
 from snorkel.types import ArrayLike
@@ -15,7 +15,7 @@ from .modules.slice_combiner import SliceCombinerModule
 
 
 def add_slice_labels(
-    dataloader: ClassifierDataLoader,
+    dataloader: DictDataLoader,
     base_task: Task,
     slice_labels: csr_matrix,
     slice_names: List[str],

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -23,12 +23,12 @@ class DatasetTest(unittest.TestCase):
         y1 = torch.Tensor([0, 0, 0, 0, 0])
 
         dataset = DictDataset(
-            X_dict={"data1": x1}, Y_dict={"label1": y1}, name="new_data", split="train"
+            X_dict={"data1": x1}, Y_dict={"task1": y1}, name="new_data", split="train"
         )
 
         # Check if the dataset is correctly constructed
         self.assertTrue(torch.equal(dataset[0][0]["data1"], x1[0]))
-        self.assertTrue(torch.equal(dataset[0][1]["label1"], y1[0]))
+        self.assertTrue(torch.equal(dataset[0][1]["task1"], y1[0]))
 
     def test_classifier_dataloader(self):
         """Unit test of DictDataLoader"""
@@ -57,17 +57,14 @@ class DatasetTest(unittest.TestCase):
             name="new_data",
             split="train",
             X_dict={"data1": x1, "data2": x2},
-            Y_dict={"label1": y1, "label2": y2},
+            Y_dict={"task1": y1, "task2": y2},
         )
 
-        dataloader1 = DictDataLoader(
-            task_to_label_dict={"task1": "label1"}, dataset=dataset, batch_size=2
-        )
+        dataloader1 = DictDataLoader(dataset=dataset, batch_size=2)
 
         x_batch, y_batch = next(iter(dataloader1))
 
         # Check if the dataloader is correctly constructed
-        self.assertEqual(dataloader1.task_to_label_dict, {"task1": "label1"})
         self.assertEqual(dataloader1.dataset.split, "train")
         self.assertTrue(torch.equal(x_batch["data1"], torch.Tensor([[1, 0], [1, 2]])))
         self.assertTrue(
@@ -75,17 +72,14 @@ class DatasetTest(unittest.TestCase):
                 x_batch["data2"], torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0]])
             )
         )
-        self.assertTrue(torch.equal(y_batch["label1"], torch.Tensor([0, 0])))
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([1, 1])))
+        self.assertTrue(torch.equal(y_batch["task1"], torch.Tensor([0, 0])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([1, 1])))
 
-        dataloader2 = DictDataLoader(
-            task_to_label_dict={"task2": "label2"}, dataset=dataset, batch_size=3
-        )
+        dataloader2 = DictDataLoader(dataset=dataset, batch_size=3)
 
         x_batch, y_batch = next(iter(dataloader2))
 
         # Check if the dataloader with differet batch size is correctly constructed
-        self.assertEqual(dataloader2.task_to_label_dict, {"task2": "label2"})
         self.assertEqual(dataloader2.dataset.split, "train")
         self.assertTrue(
             torch.equal(
@@ -98,8 +92,8 @@ class DatasetTest(unittest.TestCase):
                 torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0], [1, 2, 3, 0, 0]]),
             )
         )
-        self.assertTrue(torch.equal(y_batch["label1"], torch.Tensor([0, 0, 0])))
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([1, 1, 1])))
+        self.assertTrue(torch.equal(y_batch["task1"], torch.Tensor([0, 0, 0])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([1, 1, 1])))
 
         y3 = [
             torch.Tensor([2]),
@@ -109,7 +103,7 @@ class DatasetTest(unittest.TestCase):
             torch.Tensor([2]),
         ]
 
-        dataset.Y_dict["label2"] = y3
+        dataset.Y_dict["task2"] = y3
 
         x_batch, y_batch = next(iter(dataloader1))
         # Check dataloader is correctly updated with update dataset
@@ -118,7 +112,7 @@ class DatasetTest(unittest.TestCase):
                 x_batch["data2"], torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0]])
             )
         )
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([[2], [2]])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([[2], [2]])))
 
         x_batch, y_batch = next(iter(dataloader2))
         self.assertTrue(
@@ -127,7 +121,7 @@ class DatasetTest(unittest.TestCase):
                 torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0], [1, 2, 3, 0, 0]]),
             )
         )
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([[2], [2], [2]])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([[2], [2], [2]])))
 
     def test_split_data(self):
         N = 1000

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -5,11 +5,7 @@ import numpy as np
 import scipy.sparse as sparse
 import torch
 
-from snorkel.classification.data import (
-    DictDataLoader,
-    DictDataset,
-    split_data,
-)
+from snorkel.classification.data import DictDataLoader, DictDataset, split_data
 
 
 class DatasetTest(unittest.TestCase):

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -6,15 +6,15 @@ import scipy.sparse as sparse
 import torch
 
 from snorkel.classification.data import (
-    ClassifierDataLoader,
-    ClassifierDataset,
+    DictDataLoader,
+    DictDataset,
     split_data,
 )
 
 
 class DatasetTest(unittest.TestCase):
     def test_classifier_dataset(self):
-        """Unit test of ClassifierDataset"""
+        """Unit test of DictDataset"""
 
         x1 = [
             torch.Tensor([1]),
@@ -26,7 +26,7 @@ class DatasetTest(unittest.TestCase):
 
         y1 = torch.Tensor([0, 0, 0, 0, 0])
 
-        dataset = ClassifierDataset(
+        dataset = DictDataset(
             X_dict={"data1": x1}, Y_dict={"label1": y1}, name="new_data", split="train"
         )
 
@@ -35,7 +35,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(torch.equal(dataset[0][1]["label1"], y1[0]))
 
     def test_classifier_dataloader(self):
-        """Unit test of ClassifierDataLoader"""
+        """Unit test of DictDataLoader"""
 
         x1 = [
             torch.Tensor([1]),
@@ -57,14 +57,14 @@ class DatasetTest(unittest.TestCase):
 
         y2 = torch.Tensor([1, 1, 1, 1, 1])
 
-        dataset = ClassifierDataset(
+        dataset = DictDataset(
             name="new_data",
             split="train",
             X_dict={"data1": x1, "data2": x2},
             Y_dict={"label1": y1, "label2": y2},
         )
 
-        dataloader1 = ClassifierDataLoader(
+        dataloader1 = DictDataLoader(
             task_to_label_dict={"task1": "label1"}, dataset=dataset, batch_size=2
         )
 
@@ -82,7 +82,7 @@ class DatasetTest(unittest.TestCase):
         self.assertTrue(torch.equal(y_batch["label1"], torch.Tensor([0, 0])))
         self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([1, 1])))
 
-        dataloader2 = ClassifierDataLoader(
+        dataloader2 = DictDataLoader(
             task_to_label_dict={"task2": "label2"}, dataset=dataset, batch_size=3
         )
 

--- a/test/classification/test_model.py
+++ b/test/classification/test_model.py
@@ -6,11 +6,7 @@ import torch
 import torch.nn as nn
 
 from snorkel.classification.scorer import Scorer
-from snorkel.classification.snorkel_classifier import (
-    SnorkelClassifier,
-    Operation,
-    Task,
-)
+from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
 
 
 class TaskTest(unittest.TestCase):

--- a/test/classification/test_model.py
+++ b/test/classification/test_model.py
@@ -7,7 +7,7 @@ import torch.nn as nn
 
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import (
-    AdvancedClassifier,
+    SnorkelClassifier,
     Operation,
     Task,
 )
@@ -16,7 +16,7 @@ from snorkel.classification.snorkel_classifier import (
 class TaskTest(unittest.TestCase):
     def test_onetask_model(self):
         task1 = create_task("task1")
-        model = AdvancedClassifier(tasks=[task1])
+        model = SnorkelClassifier(tasks=[task1])
         self.assertEqual(len(model.task_names), 1)
         self.assertEqual(len(model.task_flows), 1)
         self.assertEqual(len(model.module_pool), 2)
@@ -25,7 +25,7 @@ class TaskTest(unittest.TestCase):
         """Add two tasks with identical modules and flows"""
         task1 = create_task("task1")
         task2 = create_task("task2")
-        model = AdvancedClassifier(tasks=[task1, task2])
+        model = SnorkelClassifier(tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 2)
@@ -34,7 +34,7 @@ class TaskTest(unittest.TestCase):
         """Add two tasks with totally separate modules and flows"""
         task1 = create_task("task1", module_suffixes=["A", "A"])
         task2 = create_task("task2", module_suffixes=["B", "B"])
-        model = AdvancedClassifier(tasks=[task1, task2])
+        model = SnorkelClassifier(tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 4)
@@ -43,7 +43,7 @@ class TaskTest(unittest.TestCase):
         """Add two tasks with overlapping modules and flows"""
         task1 = create_task("task1", module_suffixes=["A", "A"])
         task2 = create_task("task2", module_suffixes=["A", "B"])
-        model = AdvancedClassifier(tasks=[task1, task2])
+        model = SnorkelClassifier(tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 3)
@@ -54,7 +54,7 @@ class TaskTest(unittest.TestCase):
         task1 = create_task("task1")
         task2 = create_task("task2")
 
-        model = AdvancedClassifier([task1])
+        model = SnorkelClassifier([task1])
         self.assertTrue(
             torch.eq(
                 task1.module_pool["linear2"].weight,
@@ -62,7 +62,7 @@ class TaskTest(unittest.TestCase):
             ).all()
         )
         model.save(checkpoint_path)
-        model = AdvancedClassifier([task2])
+        model = SnorkelClassifier([task2])
         self.assertFalse(
             torch.eq(
                 task1.module_pool["linear2"].weight,

--- a/test/classification/training/schedulers/test_schedulers.py
+++ b/test/classification/training/schedulers/test_schedulers.py
@@ -3,27 +3,27 @@ import unittest
 import torch
 
 from snorkel.analysis.utils import set_seed
-from snorkel.classification.data import ClassifierDataLoader, ClassifierDataset
+from snorkel.classification.data import DictDataLoader, DictDataset
 from snorkel.classification.training.schedulers import (
     SequentialScheduler,
     ShuffledScheduler,
 )
 
-dataset1 = ClassifierDataset(
+dataset1 = DictDataset(
     "d1",
     "train",
     X_dict={"data": [0, 1, 2, 3, 4]},
     Y_dict={"labels": torch.LongTensor([1, 1, 1, 1, 1])},
 )
-dataset2 = ClassifierDataset(
+dataset2 = DictDataset(
     "d2",
     "train",
     X_dict={"data": [5, 6, 7, 8, 9]},
     Y_dict={"labels": torch.LongTensor([2, 2, 2, 2, 2])},
 )
 
-dataloader1 = ClassifierDataLoader(dataset1, batch_size=2)
-dataloader2 = ClassifierDataLoader(dataset2, batch_size=2)
+dataloader1 = DictDataLoader(dataset1, batch_size=2)
+dataloader2 = DictDataLoader(dataset2, batch_size=2)
 dataloaders = [dataloader1, dataloader2]
 
 

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -4,10 +4,10 @@ import numpy as np
 import torch
 import torch.nn as nn
 
-from snorkel.classification.data import ClassifierDataLoader, ClassifierDataset
+from snorkel.classification.data import DictDataLoader, DictDataset
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import (
-    AdvancedClassifier,
+    SnorkelClassifier,
     Operation,
     Task,
 )
@@ -20,7 +20,7 @@ class TrainerTest(unittest.TestCase):
     def test_trainer_onetask(self):
         """Train a single-task model"""
         task1 = create_task("task1", module_suffixes=["A", "A"])
-        model = AdvancedClassifier(tasks=[task1])
+        model = SnorkelClassifier(tasks=[task1])
         dataloaders = create_dataloaders(num_tasks=1)
         trainer = Trainer(**trainer_config)
         trainer.train_model(model, dataloaders)
@@ -29,7 +29,7 @@ class TrainerTest(unittest.TestCase):
         """Train a model with overlapping modules and flows"""
         task1 = create_task("task1", module_suffixes=["A", "A"])
         task2 = create_task("task2", module_suffixes=["A", "B"])
-        model = AdvancedClassifier(tasks=[task1, task2])
+        model = SnorkelClassifier(tasks=[task1, task2])
         dataloaders = create_dataloaders(num_tasks=2)
         trainer = Trainer(**trainer_config)
         trainer.train_model(model, dataloaders)
@@ -59,11 +59,11 @@ def create_dataloaders(num_tasks=1):
             Y_dict["task2_labels"] = Y_split[:, 1]
             task_to_label_dict["task2"] = "task2_labels"
 
-        dataset = ClassifierDataset(
+        dataset = DictDataset(
             name="dataset", split=split, X_dict={"coordinates": X_split}, Y_dict=Y_dict
         )
 
-        dataloader = ClassifierDataLoader(
+        dataloader = DictDataLoader(
             task_to_label_dict=task_to_label_dict,
             dataset=dataset,
             batch_size=4,

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -49,21 +49,16 @@ def create_dataloaders(num_tasks=1):
     splits = ["train", "valid", "test"]
     for X_split, Y_split, split in zip(Xs, Ys, splits):
 
-        Y_dict = {"task1_labels": Y_split[:, 0]}
-        task_to_label_dict = {"task1": "task1_labels"}
+        Y_dict = {"task1": Y_split[:, 0]}
         if num_tasks == 2:
-            Y_dict["task2_labels"] = Y_split[:, 1]
-            task_to_label_dict["task2"] = "task2_labels"
+            Y_dict["task2"] = Y_split[:, 1]
 
         dataset = DictDataset(
             name="dataset", split=split, X_dict={"coordinates": X_split}, Y_dict=Y_dict
         )
 
         dataloader = DictDataLoader(
-            task_to_label_dict=task_to_label_dict,
-            dataset=dataset,
-            batch_size=4,
-            shuffle=(dataset.split == "train"),
+            dataset=dataset, batch_size=4, shuffle=(dataset.split == "train")
         )
         dataloaders.append(dataloader)
     return dataloaders

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -6,11 +6,7 @@ import torch.nn as nn
 
 from snorkel.classification.data import DictDataLoader, DictDataset
 from snorkel.classification.scorer import Scorer
-from snorkel.classification.snorkel_classifier import (
-    SnorkelClassifier,
-    Operation,
-    Task,
-)
+from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
 from snorkel.classification.training import Trainer
 
 trainer_config = {"n_epochs": 2, "progress_bar": False}

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -64,16 +64,6 @@ class SlicingTest(unittest.TestCase):
         add_slice_labels(dataloaders[0], task1, S_train, slice_names)
         add_slice_labels(dataloaders[1], task1, S_valid, slice_names)
 
-        self.assertEqual(len(dataloaders[0].task_to_label_dict), 8)
-        self.assertIn("task1", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:f_ind", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:f_pred", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:g_ind", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:g_pred", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:base_ind", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:base_pred", dataloaders[0].task_to_label_dict)
-        self.assertIn("task2", dataloaders[0].task_to_label_dict)
-
         # Convert to slice tasks
         task1_tasks = convert_to_slice_tasks(task1, slice_names)
         tasks = task1_tasks + [task2]
@@ -98,13 +88,9 @@ def create_data(n):
 
 def create_dataloader(df, split):
     Y_dict = {}
-    task_to_label_dict = {}
 
-    Y_dict[f"task1_labels"] = torch.LongTensor(df["y1"])
-    task_to_label_dict["task1"] = "task1_labels"
-
-    Y_dict[f"task2_labels"] = torch.LongTensor(df["y2"])
-    task_to_label_dict["task2"] = "task2_labels"
+    Y_dict[f"task1"] = torch.LongTensor(df["y1"])
+    Y_dict[f"task2"] = torch.LongTensor(df["y2"])
 
     dataset = DictDataset(
         name="TestData",
@@ -118,10 +104,7 @@ def create_dataloader(df, split):
     )
 
     dataloader = DictDataLoader(
-        task_to_label_dict=task_to_label_dict,
-        dataset=dataset,
-        batch_size=4,
-        shuffle=(dataset.split == "train"),
+        dataset=dataset, batch_size=4, shuffle=(dataset.split == "train")
     )
     return dataloader
 

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -5,10 +5,10 @@ import pandas as pd
 import torch
 import torch.nn as nn
 
-from snorkel.classification.data import ClassifierDataLoader, ClassifierDataset
+from snorkel.classification.data import DictDataLoader, DictDataset
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import (
-    AdvancedClassifier,
+    SnorkelClassifier,
     Operation,
     Task,
 )
@@ -81,7 +81,7 @@ class SlicingTest(unittest.TestCase):
         # Convert to slice tasks
         task1_tasks = convert_to_slice_tasks(task1, slice_names)
         tasks = task1_tasks + [task2]
-        model = AdvancedClassifier(tasks=tasks)
+        model = SnorkelClassifier(tasks=tasks)
 
         # Train
         trainer = Trainer(**self.trainer_config)
@@ -110,7 +110,7 @@ def create_dataloader(df, split):
     Y_dict[f"task2_labels"] = torch.LongTensor(df["y2"])
     task_to_label_dict["task2"] = "task2_labels"
 
-    dataset = ClassifierDataset(
+    dataset = DictDataset(
         name="TestData",
         split=split,
         X_dict={
@@ -121,7 +121,7 @@ def create_dataloader(df, split):
         Y_dict=Y_dict,
     )
 
-    dataloader = ClassifierDataLoader(
+    dataloader = DictDataLoader(
         task_to_label_dict=task_to_label_dict,
         dataset=dataset,
         batch_size=4,

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -7,11 +7,7 @@ import torch.nn as nn
 
 from snorkel.classification.data import DictDataLoader, DictDataset
 from snorkel.classification.scorer import Scorer
-from snorkel.classification.snorkel_classifier import (
-    SnorkelClassifier,
-    Operation,
-    Task,
-)
+from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
 from snorkel.classification.training import Trainer
 from snorkel.slicing.apply import PandasSFApplier
 from snorkel.slicing.sf import slicing_function

--- a/tutorials/mtl/Multitask_Tutorial.ipynb
+++ b/tutorials/mtl/Multitask_Tutorial.ipynb
@@ -190,9 +190,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With our data now loaded/created, we can now package it up into `ClassifierDataLoader`s for training. \n",
+    "With our data now loaded/created, we can now package it up into `DictDataLoader`s for training. \n",
     "\n",
-    "In the `ClassifierDataLoader`, we specify a mapping from each `Task` to its corresponding labels.  We'll define these `Task` objects in the following section as we define our model."
+    "In the `DictDataLoader`, we specify a mapping from each `Task` to its corresponding labels.  We'll define these `Task` objects in the following section as we define our model."
    ]
   },
   {
@@ -201,17 +201,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from snorkel.mtl.data import ClassifierDataset, ClassifierDataLoader\n",
+    "from snorkel.mtl.data import DictDataset, DictDataLoader\n",
     "\n",
     "dataloaders = []\n",
     "for split in [0,1,2]:\n",
     "    X_dict = {\"circle_data\": circle_data_splits[split]}\n",
     "    Y_dict = {\"circle_labels\": circle_label_splits[split]}\n",
-    "    dataset = ClassifierDataset(\"Circle\", X_dict, Y_dict)\n",
+    "    dataset = DictDataset(\"Circle\", X_dict, Y_dict)\n",
     "\n",
     "    task_to_label_dict = {\"circle_task\": \"circle_labels\"}\n",
     "\n",
-    "    dataloader = ClassifierDataLoader(\n",
+    "    dataloader = DictDataLoader(\n",
     "        task_to_label_dict,\n",
     "        dataset,\n",
     "        split=[\"train\", \"valid\", \"test\"][split],\n",
@@ -222,11 +222,11 @@
     "for split in [0,1,2]:\n",
     "    X_dict = {\"square_data\": square_data_splits[split]}\n",
     "    Y_dict = {\"square_labels\": square_label_splits[split]}\n",
-    "    dataset = ClassifierDataset(\"Square\", X_dict, Y_dict)\n",
+    "    dataset = DictDataset(\"Square\", X_dict, Y_dict)\n",
     "\n",
     "    task_to_label_dict = {\"square_task\": \"square_labels\"}\n",
     "\n",
-    "    dataloader = ClassifierDataLoader(\n",
+    "    dataloader = DictDataLoader(\n",
     "        task_to_label_dict,\n",
     "        dataset,\n",
     "        split=[\"train\", \"valid\", \"test\"][split],\n",
@@ -246,7 +246,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we'll define the `AdvancedClassifier`, which is build from a list of `Tasks`."
+    "Now we'll define the `SnorkelClassifier`, which is build from a list of `Tasks`."
    ]
   },
   {
@@ -398,9 +398,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from snorkel.mtl.model import AdvancedClassifier\n",
+    "from snorkel.mtl.model import SnorkelClassifier\n",
     "\n",
-    "model = AdvancedClassifier([circle_task, square_task])"
+    "model = SnorkelClassifier([circle_task, square_task])"
    ]
   },
   {

--- a/tutorials/workshop/utils.py
+++ b/tutorials/workshop/utils.py
@@ -21,10 +21,9 @@ def upgrade_dataloaders(dataloaders: List[DataLoader]):
         new_dataset = DictDataset(
             name=f"data_{dataloader.split}",
             X_dict={"data": dataset.X},  # This op is specific to TensorDataset
-            Y_dict={"labels": dataset.Y},  # Maybe
+            Y_dict={"task": dataset.Y},  # Maybe
         )
         new_dataloader = DictDataLoader(
-            task_to_label_dict={"task": "labels"},
             dataset=new_dataset,
             split=dataloader.split,
             batch_size=dataloader.batch_size,

--- a/tutorials/workshop/utils.py
+++ b/tutorials/workshop/utils.py
@@ -10,7 +10,7 @@ from torch.nn.utils.rnn import pad_sequence
 from torch.utils.data import DataLoader
 from torchtext.vocab import Vocab
 
-from snorkel.classification.data import ClassifierDataLoader, ClassifierDataset
+from snorkel.classification.data import DictDataLoader, DictDataset
 
 
 def upgrade_dataloaders(dataloaders: List[DataLoader]):
@@ -18,12 +18,12 @@ def upgrade_dataloaders(dataloaders: List[DataLoader]):
     for dataloader in dataloaders:
         dataset = dataloader.dataset
 
-        new_dataset = ClassifierDataset(
+        new_dataset = DictDataset(
             name=f"data_{dataloader.split}",
             X_dict={"data": dataset.X},  # This op is specific to TensorDataset
             Y_dict={"labels": dataset.Y},  # Maybe
         )
-        new_dataloader = ClassifierDataLoader(
+        new_dataloader = DictDataLoader(
             task_to_label_dict={"task": "labels"},
             dataset=new_dataset,
             split=dataloader.split,


### PR DESCRIPTION
Perform the following refactors:
- `ClassifierDataset` -> `DictDataset`
- `ClassifierDataLoader` -> `DictDataLoader`
- `AdvancedClassifier` -> `SnorkelClassifier`

**Test plan:**
Tests pass post-refactor.