### PR TITLE
Remove task_to_label_dict (use task names as keys in Y_dict)

### DIFF
--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -78,9 +78,7 @@ class DictDataLoader(DataLoader):
     label(s) to use in dataset's Y_dict for this task), and split (which part this
     dataset belongs to) information.
 
-    :param task_to_label_dict: the task to label mapping where key is the task name and
     value is the labels for that task and should be the key in Y_dict
-    :type task_to_label_dict: dict
     :param dataset: the dataset to construct the dataloader
     :type dataset: torch.utils.data.Dataset
     :param split: the split information, defaults to "train"
@@ -94,20 +92,11 @@ class DictDataLoader(DataLoader):
         self,
         dataset: DictDataset,
         collate_fn: Callable[..., Any] = collate_dicts,
-        task_to_label_dict: Dict[str, str] = None,
         **kwargs,
     ) -> None:
 
         assert isinstance(dataset, DictDataset)
         super().__init__(dataset, collate_fn=collate_fn, **kwargs)
-
-        self.task_to_label_dict = task_to_label_dict or {}
-
-        for label in self.task_to_label_dict.values():
-            if label not in dataset.Y_dict:
-                raise ValueError(
-                    f"Label {label} specified in task_to_label_dict could not be found in Y_dict"
-                )
 
 
 def split_data(

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -175,16 +175,12 @@ class SnorkelClassifier(nn.Module):
         return outputs
 
     def calculate_loss(
-        self,
-        X_dict: Mapping[str, Any],
-        Y_dict: Dict[str, torch.Tensor],
-        task_to_label_dict: Dict[str, str],
+        self, X_dict: Mapping[str, Any], Y_dict: Dict[str, torch.Tensor]
     ) -> Tuple[Dict[str, torch.Tensor], Dict[str, float]]:
         """Calculate the loss
 
         :param X_dict: The input data
         :param Y_dict: The output data
-        :param task_to_label_dict: The task to label mapping
         :return: The loss and the number of samples in the batch of all tasks
         :rtype: dict, dict
         """
@@ -192,13 +188,11 @@ class SnorkelClassifier(nn.Module):
         loss_dict = dict()
         count_dict = dict()
 
-        task_names = task_to_label_dict.keys()
+        task_names = Y_dict.keys()
         outputs = self.forward(X_dict, task_names)
 
         # Calculate loss for each task
-        for task_name, label_name in task_to_label_dict.items():
-
-            Y = Y_dict[label_name]
+        for task_name, Y in Y_dict.items():
 
             # Select the active samples
             if len(Y.size()) == 1:
@@ -251,14 +245,10 @@ class SnorkelClassifier(nn.Module):
         prob_dict_list: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
         for batch_num, (X_batch_dict, Y_batch_dict) in enumerate(dataloader):
-            prob_batch_dict = self._calculate_probs(
-                X_batch_dict, dataloader.task_to_label_dict.keys()
-            )
-            for task_name in dataloader.task_to_label_dict.keys():
+            prob_batch_dict = self._calculate_probs(X_batch_dict, Y_batch_dict.keys())
+            for task_name, Y in Y_batch_dict.items():
                 prob_dict_list[task_name].extend(prob_batch_dict[task_name])
-                gold_dict_list[task_name].extend(
-                    Y_batch_dict[dataloader.task_to_label_dict[task_name]].cpu().numpy()
-                )
+                gold_dict_list[task_name].extend(Y.cpu().numpy())
 
         gold_dict: Dict[str, np.ndarray] = {}
         prob_dict: Dict[str, np.ndarray] = {}

--- a/snorkel/classification/task.py
+++ b/snorkel/classification/task.py
@@ -60,6 +60,8 @@ class Task:
         assert isinstance(module_pool, nn.ModuleDict) is True
         self.module_pool = module_pool
         self.task_flow = task_flow
+        # By default, apply cross entropy loss and softmax to the output of the last
+        # operation in the task flow.
         self.loss_func = loss_func or partial(ce_loss, task_flow[-1].name)
         self.output_func = output_func or partial(softmax, task_flow[-1].name)
         self.scorer = scorer

--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -95,9 +95,7 @@ class Trainer(object):
                 self.optimizer.zero_grad()
 
                 # Perform forward pass and calcualte the loss and count
-                loss_dict, count_dict = model.calculate_loss(
-                    X_dict, Y_dict, dataloader.task_to_label_dict
-                )
+                loss_dict, count_dict = model.calculate_loss(X_dict, Y_dict)
 
                 # Update running loss and count
                 for task_name in loss_dict.keys():

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -25,9 +25,8 @@ def add_slice_labels(
     slice_labels, slice_names = _add_base_slice(slice_labels, slice_names)
     assert slice_labels.shape[1] == len(slice_names)
 
-    label_name = dataloader.task_to_label_dict[base_task.name]
     Y_dict: Dict[str, ArrayLike] = dataloader.dataset.Y_dict  # type: ignore
-    labels = Y_dict[label_name]
+    labels = Y_dict[base_task.name]
     for i, slice_name in enumerate(slice_names):
 
         # Convert labels
@@ -41,9 +40,6 @@ def add_slice_labels(
         # Update dataloaders
         Y_dict[ind_task_name] = ind_labels
         Y_dict[pred_task_name] = pred_labels
-
-        dataloader.task_to_label_dict[ind_task_name] = ind_task_name
-        dataloader.task_to_label_dict[pred_task_name] = pred_task_name
 
 
 def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task]:

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -23,12 +23,12 @@ class DatasetTest(unittest.TestCase):
         y1 = torch.Tensor([0, 0, 0, 0, 0])
 
         dataset = DictDataset(
-            X_dict={"data1": x1}, Y_dict={"label1": y1}, name="new_data", split="train"
+            X_dict={"data1": x1}, Y_dict={"task1": y1}, name="new_data", split="train"
         )
 
         # Check if the dataset is correctly constructed
         self.assertTrue(torch.equal(dataset[0][0]["data1"], x1[0]))
-        self.assertTrue(torch.equal(dataset[0][1]["label1"], y1[0]))
+        self.assertTrue(torch.equal(dataset[0][1]["task1"], y1[0]))
 
     def test_classifier_dataloader(self):
         """Unit test of DictDataLoader"""
@@ -57,17 +57,14 @@ class DatasetTest(unittest.TestCase):
             name="new_data",
             split="train",
             X_dict={"data1": x1, "data2": x2},
-            Y_dict={"label1": y1, "label2": y2},
+            Y_dict={"task1": y1, "task2": y2},
         )
 
-        dataloader1 = DictDataLoader(
-            task_to_label_dict={"task1": "label1"}, dataset=dataset, batch_size=2
-        )
+        dataloader1 = DictDataLoader(dataset=dataset, batch_size=2)
 
         x_batch, y_batch = next(iter(dataloader1))
 
         # Check if the dataloader is correctly constructed
-        self.assertEqual(dataloader1.task_to_label_dict, {"task1": "label1"})
         self.assertEqual(dataloader1.dataset.split, "train")
         self.assertTrue(torch.equal(x_batch["data1"], torch.Tensor([[1, 0], [1, 2]])))
         self.assertTrue(
@@ -75,17 +72,14 @@ class DatasetTest(unittest.TestCase):
                 x_batch["data2"], torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0]])
             )
         )
-        self.assertTrue(torch.equal(y_batch["label1"], torch.Tensor([0, 0])))
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([1, 1])))
+        self.assertTrue(torch.equal(y_batch["task1"], torch.Tensor([0, 0])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([1, 1])))
 
-        dataloader2 = DictDataLoader(
-            task_to_label_dict={"task2": "label2"}, dataset=dataset, batch_size=3
-        )
+        dataloader2 = DictDataLoader(dataset=dataset, batch_size=3)
 
         x_batch, y_batch = next(iter(dataloader2))
 
         # Check if the dataloader with differet batch size is correctly constructed
-        self.assertEqual(dataloader2.task_to_label_dict, {"task2": "label2"})
         self.assertEqual(dataloader2.dataset.split, "train")
         self.assertTrue(
             torch.equal(
@@ -98,8 +92,8 @@ class DatasetTest(unittest.TestCase):
                 torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0], [1, 2, 3, 0, 0]]),
             )
         )
-        self.assertTrue(torch.equal(y_batch["label1"], torch.Tensor([0, 0, 0])))
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([1, 1, 1])))
+        self.assertTrue(torch.equal(y_batch["task1"], torch.Tensor([0, 0, 0])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([1, 1, 1])))
 
         y3 = [
             torch.Tensor([2]),
@@ -109,7 +103,7 @@ class DatasetTest(unittest.TestCase):
             torch.Tensor([2]),
         ]
 
-        dataset.Y_dict["label2"] = y3
+        dataset.Y_dict["task2"] = y3
 
         x_batch, y_batch = next(iter(dataloader1))
         # Check dataloader is correctly updated with update dataset
@@ -118,7 +112,7 @@ class DatasetTest(unittest.TestCase):
                 x_batch["data2"], torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0]])
             )
         )
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([[2], [2]])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([[2], [2]])))
 
         x_batch, y_batch = next(iter(dataloader2))
         self.assertTrue(
@@ -127,7 +121,7 @@ class DatasetTest(unittest.TestCase):
                 torch.Tensor([[1, 2, 3, 4, 5], [1, 2, 3, 4, 0], [1, 2, 3, 0, 0]]),
             )
         )
-        self.assertTrue(torch.equal(y_batch["label2"], torch.Tensor([[2], [2], [2]])))
+        self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([[2], [2], [2]])))
 
     def test_split_data(self):
         N = 1000

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -49,21 +49,16 @@ def create_dataloaders(num_tasks=1):
     splits = ["train", "valid", "test"]
     for X_split, Y_split, split in zip(Xs, Ys, splits):
 
-        Y_dict = {"task1_labels": Y_split[:, 0]}
-        task_to_label_dict = {"task1": "task1_labels"}
+        Y_dict = {"task1": Y_split[:, 0]}
         if num_tasks == 2:
-            Y_dict["task2_labels"] = Y_split[:, 1]
-            task_to_label_dict["task2"] = "task2_labels"
+            Y_dict["task2"] = Y_split[:, 1]
 
         dataset = DictDataset(
             name="dataset", split=split, X_dict={"coordinates": X_split}, Y_dict=Y_dict
         )
 
         dataloader = DictDataLoader(
-            task_to_label_dict=task_to_label_dict,
-            dataset=dataset,
-            batch_size=4,
-            shuffle=(dataset.split == "train"),
+            dataset=dataset, batch_size=4, shuffle=(dataset.split == "train")
         )
         dataloaders.append(dataloader)
     return dataloaders

--- a/test/slicing/test_slicing.py
+++ b/test/slicing/test_slicing.py
@@ -64,16 +64,6 @@ class SlicingTest(unittest.TestCase):
         add_slice_labels(dataloaders[0], task1, S_train, slice_names)
         add_slice_labels(dataloaders[1], task1, S_valid, slice_names)
 
-        self.assertEqual(len(dataloaders[0].task_to_label_dict), 8)
-        self.assertIn("task1", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:f_ind", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:f_pred", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:g_ind", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:g_pred", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:base_ind", dataloaders[0].task_to_label_dict)
-        self.assertIn("task1_slice:base_pred", dataloaders[0].task_to_label_dict)
-        self.assertIn("task2", dataloaders[0].task_to_label_dict)
-
         # Convert to slice tasks
         task1_tasks = convert_to_slice_tasks(task1, slice_names)
         tasks = task1_tasks + [task2]
@@ -98,13 +88,9 @@ def create_data(n):
 
 def create_dataloader(df, split):
     Y_dict = {}
-    task_to_label_dict = {}
 
-    Y_dict[f"task1_labels"] = torch.LongTensor(df["y1"])
-    task_to_label_dict["task1"] = "task1_labels"
-
-    Y_dict[f"task2_labels"] = torch.LongTensor(df["y2"])
-    task_to_label_dict["task2"] = "task2_labels"
+    Y_dict[f"task1"] = torch.LongTensor(df["y1"])
+    Y_dict[f"task2"] = torch.LongTensor(df["y2"])
 
     dataset = DictDataset(
         name="TestData",
@@ -118,10 +104,7 @@ def create_dataloader(df, split):
     )
 
     dataloader = DictDataLoader(
-        task_to_label_dict=task_to_label_dict,
-        dataset=dataset,
-        batch_size=4,
-        shuffle=(dataset.split == "train"),
+        dataset=dataset, batch_size=4, shuffle=(dataset.split == "train")
     )
     return dataloader
 

--- a/tutorials/workshop/utils.py
+++ b/tutorials/workshop/utils.py
@@ -21,10 +21,9 @@ def upgrade_dataloaders(dataloaders: List[DataLoader]):
         new_dataset = DictDataset(
             name=f"data_{dataloader.split}",
             X_dict={"data": dataset.X},  # This op is specific to TensorDataset
-            Y_dict={"labels": dataset.Y},  # Maybe
+            Y_dict={"task": dataset.Y},  # Maybe
         )
         new_dataloader = DictDataLoader(
-            task_to_label_dict={"task": "labels"},
             dataset=new_dataset,
             split=dataloader.split,
             batch_size=dataloader.batch_size,


### PR DESCRIPTION
Previously we required a map linking tasks and label sets. In practice, this feature is almost never used, as each label set is used with only one task and each task only requires one set of labels. Simplify this by having the keys of the Y_dict be the task names that each label set refers to.

**Test plan**
This adds no new functionality, just simplifies specifying a model and its data. 
The result is fewer lines of code and all tests still pass.