### PR TITLE
Add a bunch of unit tests for trainer.py

### DIFF
--- a/snorkel/classification/snorkel_config.py
+++ b/snorkel/classification/snorkel_config.py
@@ -26,7 +26,7 @@ default_config = {
     "logging": False,  # Whether to write logs (to json/tensorboard)
     "log_writer_config": {
         "writer": "tensorboard",  # [json, tensorboard]
-        "log_root": "logs",  # The path to the root of the directory where logs are written
+        "log_dir": "logs",  # The path to the root of the directory where logs are written
         "run_name": None,  # The name of this particular run (default to date/time)
     },
     "optimizer_config": {
@@ -39,13 +39,13 @@ default_config = {
         "adamax_config": {"betas": (0.9, 0.999), "eps": 0.00000001},
     },
     "lr_scheduler_config": {
-        "lr_scheduler": "constant",  # [constant, linear, exponential, step, multi_step, reduce_on_plateau]
+        "lr_scheduler": "constant",  # [constant, linear, exponential, step]
         "warmup_steps": 0,  # warm up steps
         "warmup_unit": "batches",  # [epochs, batches]
         "warmup_percentage": 0.0,  # warm up percentage
         "min_lr": 0.0,  # minimum learning rate
         "exponential_config": {"gamma": 0.9},
-        "plateau_config": {"factor": 0.5, "patience": 10, "threshold": 0.0001},
+        "step_config": {"step_size": 5, "gamma": 0.9},
     },
     "batch_scheduler": "shuffled",  # [sequential, shuffled]
 }

--- a/snorkel/classification/training/loggers/checkpointer.py
+++ b/snorkel/classification/training/loggers/checkpointer.py
@@ -14,8 +14,12 @@ class Checkpointer(object):
     def __init__(self, **kwargs):
 
         # Checkpointer requires both checkpointer_config and log_manager_config
-        checkpointer_config = default_config["checkpointer_config"]
-        checkpointer_config.update(default_config["log_manager_config"])
+        # Use recursive_merge_dict instead of dict.update() to ensure copies are made
+        checkpointer_config = recursive_merge_dicts(
+            default_config["checkpointer_config"],
+            default_config["log_manager_config"],
+            misses="insert",
+        )
         self.config = recursive_merge_dicts(checkpointer_config, kwargs)
 
         # Pull out checkpoint settings

--- a/snorkel/classification/training/loggers/log_writer.py
+++ b/snorkel/classification/training/loggers/log_writer.py
@@ -18,8 +18,7 @@ class LogWriter:
         time = datetime.now().strftime("%H_%M_%S")
         self.run_name = self.config["run_name"] or f"{date}/{time}/"
 
-        self.log_root = self.config["log_root"]
-        self.log_dir = os.path.join(self.log_root, self.run_name)
+        self.log_dir = os.path.join(self.config["log_dir"], self.run_name)
         if not os.path.exists(self.log_dir):
             os.makedirs(self.log_dir)
 

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -1,30 +1,33 @@
 import copy
+import tempfile
 import unittest
 
 import torch
 import torch.nn as nn
+import torch.optim as optim
 
 from snorkel.classification.data import DictDataLoader, DictDataset
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
 from snorkel.classification.training import Trainer
+from snorkel.classification.training.loggers import LogWriter, TensorBoardWriter
 
 TASK_NAMES = ["task1", "task2"]
-trainer_config = {"n_epochs": 2, "progress_bar": False}
+trainer_config = {"n_epochs": 1, "progress_bar": False}
+NUM_EXAMPLES = 6
+BATCH_SIZE = 2
+BATCHES_PER_EPOCH = NUM_EXAMPLES / BATCH_SIZE
 
 
 def create_dataloader(task_name="task", split="train"):
-    X = torch.FloatTensor([[1, 1], [2, 2], [3, 3], [4, 4]])
-    Y = torch.LongTensor([1, 1, 2, 2])
+    X = torch.FloatTensor([[i, i] for i in range(NUM_EXAMPLES)])
+    Y = torch.ones(NUM_EXAMPLES, 1).long()
 
     dataset = DictDataset(
-        name="dataset",
-        split=split,
-        X_dict={"data": X},
-        Y_dict={task_name: Y},
+        name="dataset", split=split, X_dict={"data": X}, Y_dict={task_name: Y}
     )
 
-    dataloader = DictDataLoader(dataset, batch_size=2)
+    dataloader = DictDataLoader(dataset, batch_size=BATCH_SIZE)
     return dataloader
 
 
@@ -59,24 +62,22 @@ tasks = [
     create_task(TASK_NAMES[0], module_suffixes=["A", "A"]),
     create_task(TASK_NAMES[1], module_suffixes=["A", "B"]),
 ]
+model = SnorkelClassifier([tasks[0]])
 
 
 class TrainerTest(unittest.TestCase):
-
     def test_trainer_onetask(self):
         """Train a single-task model"""
-        model = SnorkelClassifier([tasks[0]])
         trainer = Trainer(**trainer_config)
         trainer.train_model(model, [dataloaders[0]])
 
     def test_trainer_twotask(self):
         """Train a model with overlapping modules and flows"""
-        model = SnorkelClassifier(tasks)
+        multitask_model = SnorkelClassifier(tasks)
         trainer = Trainer(**trainer_config)
-        trainer.train_model(model, dataloaders)
+        trainer.train_model(multitask_model, dataloaders)
 
     def test_trainer_errors(self):
-        model = SnorkelClassifier([tasks[0]])
         dataloader = copy.deepcopy(dataloaders[0])
 
         # No train split
@@ -89,6 +90,94 @@ class TrainerTest(unittest.TestCase):
         trainer = Trainer(**trainer_config, valid_split="val")
         with self.assertRaises(ValueError):
             trainer.train_model(model, [dataloader])
+
+    def test_checkpointer_init(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            trainer = Trainer(
+                **trainer_config, checkpointing=True, checkpoint_dir=temp_dir
+            )
+            trainer.train_model(model, [dataloaders[0]])
+            self.assertIsNotNone(trainer.checkpointer)
+
+            trainer = Trainer(
+                **trainer_config,
+                checkpointing=True,
+                logging=True,
+                log_dir=temp_dir,
+                checkpoint_dir=None,
+            )
+            trainer.train_model(model, [dataloaders[0]])
+            self.assertIsNotNone(trainer.checkpointer)
+            self.assertEqual(
+                trainer.checkpointer.checkpoint_dir, trainer.log_writer.log_dir
+            )
+
+    def test_log_writer_init(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            trainer = Trainer(
+                **trainer_config, logging=True, log_dir=temp_dir, writer="json"
+            )
+            trainer.train_model(model, [dataloaders[0]])
+            self.assertIsInstance(trainer.log_writer, LogWriter)
+
+            trainer = Trainer(
+                **trainer_config, logging=True, log_dir=temp_dir, writer="tensorboard"
+            )
+            trainer.train_model(model, [dataloaders[0]])
+            self.assertIsInstance(trainer.log_writer, TensorBoardWriter)
+
+            with self.assertRaises(ValueError):
+                trainer = Trainer(
+                    **trainer_config, logging=True, log_dir=temp_dir, writer="foo"
+                )
+                trainer.train_model(model, [dataloaders[0]])
+
+    def test_optimizer_init(self):
+        trainer = Trainer(**trainer_config, optimizer="sgd")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertIsInstance(trainer.optimizer, optim.SGD)
+
+        trainer = Trainer(**trainer_config, optimizer="adam")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertIsInstance(trainer.optimizer, optim.Adam)
+
+        trainer = Trainer(**trainer_config, optimizer="adamax")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertIsInstance(trainer.optimizer, optim.Adamax)
+
+        with self.assertRaises(ValueError):
+            trainer = Trainer(**trainer_config, optimizer="foo")
+            trainer.train_model(model, [dataloaders[0]])
+
+    def test_scheduler_init(self):
+        trainer = Trainer(**trainer_config, lr_scheduler="linear")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertIsInstance(trainer.lr_scheduler, optim.lr_scheduler.LambdaLR)
+
+        trainer = Trainer(**trainer_config, lr_scheduler="exponential")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertIsInstance(trainer.lr_scheduler, optim.lr_scheduler.ExponentialLR)
+
+        trainer = Trainer(**trainer_config, lr_scheduler="step")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertIsInstance(trainer.lr_scheduler, optim.lr_scheduler.StepLR)
+
+        with self.assertRaises(ValueError):
+            trainer = Trainer(**trainer_config, lr_scheduler="foo")
+            trainer.train_model(model, [dataloaders[0]])
+
+    def test_warmup(self):
+        trainer = Trainer(**trainer_config, warmup_steps=1, warmup_unit="batches")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertEqual(trainer.warmup_steps, 1)
+
+        trainer = Trainer(**trainer_config, warmup_steps=1, warmup_unit="epochs")
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertEqual(trainer.warmup_steps, BATCHES_PER_EPOCH)
+
+        trainer = Trainer(**trainer_config, warmup_percentage=1 / BATCHES_PER_EPOCH)
+        trainer.train_model(model, [dataloaders[0]])
+        self.assertEqual(trainer.warmup_steps, 1)
 
 
 if __name__ == "__main__":

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -83,12 +83,12 @@ class TrainerTest(unittest.TestCase):
         # No train split
         trainer = Trainer(**trainer_config)
         dataloader.dataset.split = "valid"
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "Cannot find any dataloaders"):
             trainer.train_model(model, [dataloader])
 
         # Unused split
         trainer = Trainer(**trainer_config, valid_split="val")
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "Dataloader splits must be"):
             trainer.train_model(model, [dataloader])
 
     def test_checkpointer_init(self):
@@ -126,7 +126,7 @@ class TrainerTest(unittest.TestCase):
             trainer.train_model(model, [dataloaders[0]])
             self.assertIsInstance(trainer.log_writer, TensorBoardWriter)
 
-            with self.assertRaises(ValueError):
+            with self.assertRaisesRegex(ValueError, "Unrecognized writer"):
                 trainer = Trainer(
                     **trainer_config, logging=True, log_dir=temp_dir, writer="foo"
                 )
@@ -145,7 +145,7 @@ class TrainerTest(unittest.TestCase):
         trainer.train_model(model, [dataloaders[0]])
         self.assertIsInstance(trainer.optimizer, optim.Adamax)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "Unrecognized optimizer"):
             trainer = Trainer(**trainer_config, optimizer="foo")
             trainer.train_model(model, [dataloaders[0]])
 
@@ -162,7 +162,7 @@ class TrainerTest(unittest.TestCase):
         trainer.train_model(model, [dataloaders[0]])
         self.assertIsInstance(trainer.lr_scheduler, optim.lr_scheduler.StepLR)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "Unrecognized lr scheduler"):
             trainer = Trainer(**trainer_config, lr_scheduler="foo")
             trainer.train_model(model, [dataloaders[0]])
 


### PR DESCRIPTION
Primarily adds unit tests for trainer.py. Also:
- Drop unsupported optimizer/scheduler options (ones that were in the code that was ported over, but didn't have tests to show that they wouldn't actually be usable in their current state)
- Update "batch" -> "batches" and "epoch" -> "epochs" for consistent usage between lr_scheduler and LogManager.

**Test plan**:
New unit tests! These focus primarily on whether or not the appropriate optimizer/scheduler/checkpointer/etc. is found and initialized appropriately, not whether it functions as expected (which would be tested in the unit tests for the individual classes).
