### PR TITLE
Add option for complex tests in tox

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ tox -e py36  # Run unit tests pytest in Python 3.6
 tox -e check  # Check style/linting with black, isort, and flake8
 tox -e type  # Run static type checking with mypy
 tox -e fix  # Fix style issues with black and isort
+tox -e spark  # Run spark-based tests (marked with @pytest.mark.spark)
+tox -e complex  # Run more complex, integration tests (marked with @pytest.mark.complex)
 tox  # Run unit tests, style checks, linting, and type checking
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ tox -e py36  # Run unit tests pytest in Python 3.6
 tox -e check  # Check style/linting with black, isort, and flake8
 tox -e type  # Run static type checking with mypy
 tox -e fix  # Fix style issues with black and isort
-tox -e spark  # Run spark-based tests (marked with @pytest.mark.spark)
+tox -e spark  # Run Spark-based tests (marked with @pytest.mark.spark)
 tox -e complex  # Run more complex, integration tests (marked with @pytest.mark.complex)
 tox  # Run unit tests, style checks, linting, and type checking
 ```

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,16 @@ deps =
     -rrequirements.txt
     -rrequirements-pyspark.txt
 commands_pre = python -m spacy download en_core_web_sm
-commands = python -m pytest -m 'not spark and not complex' {posargs}
+commands = python -m pytest {posargs:-m 'not spark and not complex'}
+
+[testenv:spark]
+description = run the test driver for spark tests with {basepython}
+passenv = JAVA_HOME
+commands = python -m pytest -m spark {posargs}
+
+[testenv:complex]
+description = run the test driver for integration tests with {basepython}
+commands = python -m pytest -m 'complex and not spark' {posargs}
 
 [testenv:check]
 description = check the code style
@@ -69,16 +78,4 @@ commands_pre =
 commands =
     isort -rc .
     black .
-
-[testenv:spark]
-description = run the test driver with {basepython}
-passenv = JAVA_HOME
-commands_pre = python -m spacy download en_core_web_sm
-commands = python -m pytest -m spark {posargs}
-
-[testenv:complex]
-description = run the test driver with {basepython}
-passenv = JAVA_HOME
-commands_pre = python -m spacy download en_core_web_sm
-commands = python -m pytest -m complex {posargs}
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,12 +24,6 @@ deps =
 commands_pre = python -m spacy download en_core_web_sm
 commands = python -m pytest -m 'not spark and not complex' {posargs}
 
-[testenv:spark]
-description = run the test driver with {basepython}
-passenv = JAVA_HOME
-commands_pre = python -m spacy download en_core_web_sm
-commands = python -m pytest -m spark {posargs}
-
 [testenv:check]
 description = check the code style
 basepython = python3
@@ -75,3 +69,16 @@ commands_pre =
 commands =
     isort -rc .
     black .
+
+[testenv:spark]
+description = run the test driver with {basepython}
+passenv = JAVA_HOME
+commands_pre = python -m spacy download en_core_web_sm
+commands = python -m pytest -m spark {posargs}
+
+[testenv:complex]
+description = run the test driver with {basepython}
+passenv = JAVA_HOME
+commands_pre = python -m spacy download en_core_web_sm
+commands = python -m pytest -m complex {posargs}
+


### PR DESCRIPTION
Add option to run complex (`@pytest.mark.complex`) tests with `tox`

**Test plan**: Ran all previous `tox` tests: `tox -e py36 -- ''`