### PR TITLE
Label model: complex tests

### DIFF
--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -135,7 +135,7 @@ def lf_empirical_accuracies(L: Matrix, Y: ArrayLike) -> np.ndarray:
     return np.nan_to_num(0.5 * (X.sum(axis=0) / (L != 0).sum(axis=0) + 1))
 
 
-def lf_empirical_probs(L: Matrix, Y: ArrayLike, k: Optional[int] = None) -> np.ndarray:
+def lf_empirical_probs(L: Matrix, Y: ArrayLike, k: int) -> np.ndarray:
     """Returns the conditional probability tables, P(L | Y), for each of the labeling
     functions, computed empirically using the provided true labels Y.
 
@@ -160,10 +160,6 @@ def lf_empirical_probs(L: Matrix, Y: ArrayLike, k: Optional[int] = None) -> np.n
     # Assume labeled set is small, work with dense matrices
     Y = arraylike_to_numpy(Y)
     L = L.toarray()
-
-    # Infer cardinality if not provided
-    if k is None:
-        k = Y.max()
 
     # Compute empirical conditional probabilities
     # Note: Can do this more efficiently...

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -9,7 +9,6 @@ from scipy.sparse import issparse
 
 from snorkel.analysis.utils import set_seed
 from snorkel.classification.utils import recursive_merge_dicts
-
 from snorkel.labeling.model.graph_utils import get_clique_tree
 from snorkel.labeling.model.lm_defaults import lm_default_config
 from snorkel.labeling.model.logger import Logger

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -10,9 +10,9 @@ from scipy.sparse import issparse
 from snorkel.analysis.utils import set_seed
 from snorkel.classification.utils import recursive_merge_dicts
 
-from .graph_utils import get_clique_tree
-from .lm_defaults import lm_default_config
-from .logger import Logger
+from snorkel.labeling.model.graph_utils import get_clique_tree
+from snorkel.labeling.model.lm_defaults import lm_default_config
+from snorkel.labeling.model.logger import Logger
 
 
 class LabelModel(nn.Module):

--- a/snorkel/synthetic/synthetic_data.py
+++ b/snorkel/synthetic/synthetic_data.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import List, Tuple, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -18,7 +18,7 @@ def generate_simple_label_matrix(
     This function generates a set of labeling function conditional probability tables,
     P(LF=l | Y=y), stored as a matrix P, and true labels Y, and then generates the
     resulting label matrix L.
-    
+
     Parameters
     ----------
     n
@@ -27,7 +27,7 @@ def generate_simple_label_matrix(
         Number of labeling functions
     k
         Cardinality of true labels (i.e. not including abstains)
-    
+
     Returns
     -------
     Tuple[np.ndarray, np.ndarray, csr_matrix]

--- a/snorkel/synthetic/synthetic_data.py
+++ b/snorkel/synthetic/synthetic_data.py
@@ -1,12 +1,59 @@
 from functools import partial
-from typing import List, Optional, Union
+from typing import List, Tuple, Optional, Union
 
 import numpy as np
 import pandas as pd
+from scipy.sparse import csr_matrix, lil_matrix
 
 from snorkel.augmentation.tf import LambdaTransformationFunction
 from snorkel.labeling.lf import LabelingFunction
 from snorkel.types import DataPoint
+
+
+def generate_simple_label_matrix(
+    n: int, m: int, k: int
+) -> Tuple[np.ndarray, np.ndarray, csr_matrix]:
+    """Generate a synthetic label matrix with true parameters and labels.
+
+    This function generates a set of labeling function conditional probability tables,
+    P(LF=l | Y=y), stored as a matrix P, and true labels Y, and then generates the
+    resulting label matrix L.
+    
+    Parameters
+    ----------
+    n
+        Number of data points
+    m
+        Number of labeling functions
+    k
+        Cardinality of true labels (i.e. not including abstains)
+    
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, csr_matrix]
+        A tuple containing the LF conditional probabilities P, the true labels Y, and the output label matrix L
+    """
+    # Generate the conditional probability tables for the LFs
+    # The first axis is LF, second is LF output label, third is true class label
+    # Note that we include abstains in the LF output space, and that we bias the
+    # conditional probabilities towards being non-adversarial
+    P = np.zeros((m, k + 1, k))
+    for i in range(m):
+        p = np.random.rand(k + 1, k)
+        p[1:, :] += (k - 1) * np.eye(k)
+        P[i] = p @ np.diag(1 / p.sum(axis=0))
+
+    # Generate the true datapoint labels
+    # Note: Assuming balanced classes to start
+    Y = np.random.choice(k, n) + 1  # Note y \in {1,...,self.k}
+
+    # Generate the label matrix L
+    L = lil_matrix((n, m))
+    for i in range(n):
+        for j in range(m):
+            L[i, j] = np.random.choice(k + 1, p=P[j, :, Y[i] - 1])
+    L = L.tocsr()
+    return P, Y, L
 
 
 def generate_mog_dataset(

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -296,15 +296,25 @@ class TestLabelModelAdvanced(unittest.TestCase):
         P, Y, L = self._generate_data()
         P_emp = lf_empirical_probs(L, Y, k=self.k)
         np.testing.assert_array_almost_equal(P, P_emp, decimal=2)
-
+    
     def test_label_model(self) -> None:
         """Test the LabelModel's estimate of P and Y."""
         np.random.seed(123)
         P, Y, L = self._generate_data()
+
+        # Train LabelModel
         label_model = LabelModel(cardinality=self.k, verbose=False)
         label_model.train_model(L, lr=0.01, l2=0.0, n_epochs=100)
+
+        # Test estimated LF conditional probabilities
         P_lm = label_model.get_conditional_probs().reshape((self.m, self.k + 1, -1))
         np.testing.assert_array_almost_equal(P, P_lm, decimal=2)
+
+        # Test predicted labels
+        L = L.todense()  # Note: Remove once Label Model L typing is cleaned up!
+        Y_lm = label_model.predict_proba(L).argmax(axis=1) + 1
+        err = np.where(Y != Y_lm, 1, 0).sum() / self.n
+        self.assertLess(err, 0.1)
 
 
 if __name__ == "__main__":

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -1,13 +1,11 @@
 import unittest
-from typing import Tuple
 
 import numpy as np
 import pytest
 import torch
 import torch.nn as nn
-from scipy.sparse import csr_matrix, lil_matrix
+from scipy.sparse import csr_matrix
 
-from snorkel.labeling.analysis import lf_empirical_probs
 from snorkel.labeling.model.label_model import LabelModel
 from snorkel.synthetic.synthetic_data import generate_simple_label_matrix
 

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -9,6 +9,7 @@ from scipy.sparse import csr_matrix, lil_matrix
 
 from snorkel.labeling.analysis import lf_empirical_probs
 from snorkel.labeling.model.label_model import LabelModel
+from snorkel.synthetic.synthetic_data import generate_simple_label_matrix
 
 
 class LabelModelTest(unittest.TestCase):
@@ -260,47 +261,10 @@ class TestLabelModelAdvanced(unittest.TestCase):
         self.n = 10000  # Number of data points
         self.k = 2  # Number of classes
 
-    def _generate_data(self) -> Tuple[np.ndarray, np.ndarray, csr_matrix]:
-        """Generate a synthetic dataset.
-
-        Returns
-        -------
-        Tuple[np.ndarray, np.ndarray, csr_matrix]
-            A tuple containing the LF conditional probabilities P, the true labels Y, and the output label matrix L
-        """
-        # Generate the conditional probability tables for the LFs
-        # The first axis is LF, second is LF output label, third is true class label
-        # Note that we include abstains in the LF output space, and that we bias the
-        # conditional probabilities towards being non-adversarial
-        P = np.zeros((self.m, self.k + 1, self.k))
-        for i in range(self.m):
-            p = np.random.rand(self.k + 1, self.k)
-            p[1:, :] += (self.k - 1) * np.eye(self.k)
-            P[i] = p @ np.diag(1 / p.sum(axis=0))
-
-        # Generate the true datapoint labels
-        # Note: Assuming balanced classes to start
-        Y = np.random.choice(self.k, self.n) + 1  # Note y \in {1,...,self.k}
-
-        # Generate the label matrix L
-        L = lil_matrix((self.n, self.m))
-        for i in range(self.n):
-            for j in range(self.m):
-                L[i, j] = np.random.choice(self.k + 1, p=P[j, :, Y[i] - 1])
-        L = L.tocsr()
-        return P, Y, L
-
-    def test_generate_L(self) -> None:
-        """Test the generated dataset for consistency."""
-        np.random.seed(123)
-        P, Y, L = self._generate_data()
-        P_emp = lf_empirical_probs(L, Y, k=self.k)
-        np.testing.assert_array_almost_equal(P, P_emp, decimal=2)
-    
     def test_label_model(self) -> None:
         """Test the LabelModel's estimate of P and Y."""
         np.random.seed(123)
-        P, Y, L = self._generate_data()
+        P, Y, L = generate_simple_label_matrix(self.n, self.m, self.k)
 
         # Train LabelModel
         label_model = LabelModel(cardinality=self.k, verbose=False)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -251,7 +251,7 @@ class LabelModelTest(unittest.TestCase):
 
 
 @pytest.mark.complex
-class LabelModelTestAdvanced(unittest.TestCase):
+class TestLabelModelAdvanced(unittest.TestCase):
     """Advanced (marked complex) tests for the LabelModel."""
 
     def setUp(self) -> None:
@@ -272,12 +272,11 @@ class LabelModelTestAdvanced(unittest.TestCase):
         # The first axis is LF, second is LF output label, third is true class label
         # Note that we include abstains in the LF output space, and that we bias the
         # conditional probabilities towards being non-adversarial
-        P = []
+        P = np.zeros((self.m, self.k + 1, self.k))
         for i in range(self.m):
             p = np.random.rand(self.k + 1, self.k)
             p[1:, :] += (self.k - 1) * np.eye(self.k)
-            P.append(p @ np.diag(1 / p.sum(axis=0)))
-        P = np.array(P)
+            P[i] = p @ np.diag(1 / p.sum(axis=0))
 
         # Generate the true datapoint labels
         # Note: Assuming balanced classes to start
@@ -302,8 +301,8 @@ class LabelModelTestAdvanced(unittest.TestCase):
         """Test the LabelModel's estimate of P and Y."""
         np.random.seed(123)
         P, Y, L = self._generate_data()
-        label_model = LabelModel(k=self.k, verbose=False)
-        label_model.train_model(L)
+        label_model = LabelModel(cardinality=self.k, verbose=False)
+        label_model.train_model(L, lr=0.01, l2=0.0, n_epochs=100)
         P_lm = label_model.get_conditional_probs().reshape((self.m, self.k + 1, -1))
         np.testing.assert_array_almost_equal(P, P_lm, decimal=2)
 

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -11,6 +11,7 @@ from snorkel.labeling.analysis import (
     lf_conflicts,
     lf_coverages,
     lf_empirical_accuracies,
+    lf_empirical_probs,
     lf_overlaps,
     lf_polarities,
     lf_summary,
@@ -74,6 +75,20 @@ class TestAnalysis(unittest.TestCase):
         accs = lf_empirical_accuracies(self.L, self.Y)
         accs_expected = [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4]
         np.testing.assert_array_almost_equal(accs, np.array(accs_expected))
+
+    def test_lf_empirical_probs(self) -> None:
+        P_emp = lf_empirical_probs(self.L, self.Y)
+        P = np.array(
+            [
+                [[1 / 2, 1, 0], [0, 0, 0], [1 / 2, 0, 1 / 2], [0, 0, 1 / 2]],
+                [[1, 1, 1], [0, 0, 0], [0, 0, 0], [0, 0, 0]],
+                [[0, 1, 1 / 2], [1 / 2, 0, 1 / 2], [0, 0, 0], [1 / 2, 0, 0]],
+                [[1, 1 / 2, 1 / 2], [0, 0, 0], [0, 0, 0], [0, 1 / 2, 1 / 2]],
+                [[1 / 2, 1, 1 / 2], [1 / 2, 0, 0], [0, 0, 1 / 2], [0, 0, 0]],
+                [[0, 1, 0], [1, 0, 1], [0, 0, 0], [0, 0, 0]],
+            ]
+        )
+        np.testing.assert_array_almost_equal(P, np.array(P_emp))
 
     def test_lf_summary(self) -> None:
         df = lf_summary(self.L, self.Y, lf_names=None, est_accs=None)

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -77,7 +77,7 @@ class TestAnalysis(unittest.TestCase):
         np.testing.assert_array_almost_equal(accs, np.array(accs_expected))
 
     def test_lf_empirical_probs(self) -> None:
-        P_emp = lf_empirical_probs(self.L, self.Y)
+        P_emp = lf_empirical_probs(self.L, self.Y, 3)
         P = np.array(
             [
                 [[1 / 2, 1, 0], [0, 0, 0], [1 / 2, 0, 1 / 2], [0, 0, 1 / 2]],
@@ -88,7 +88,7 @@ class TestAnalysis(unittest.TestCase):
                 [[0, 1, 0], [1, 0, 1], [0, 0, 0], [0, 0, 0]],
             ]
         )
-        np.testing.assert_array_almost_equal(P, np.array(P_emp))
+        np.testing.assert_array_almost_equal(P, P_emp)
 
     def test_lf_summary(self) -> None:
         df = lf_summary(self.L, self.Y, lf_names=None, est_accs=None)

--- a/test/synthetic/test_synthetic_data.py
+++ b/test/synthetic/test_synthetic_data.py
@@ -1,4 +1,5 @@
 import unittest
+from typing import Optional
 
 import numpy as np
 
@@ -6,10 +7,48 @@ from snorkel.augmentation.apply import PandasTFApplier
 from snorkel.augmentation.policy import ApplyOnePolicy
 from snorkel.labeling.apply import PandasLFApplier
 from snorkel.synthetic.synthetic_data import (
+    generate_simple_label_matrix,
     generate_mog_dataset,
     generate_resampling_tfs,
     generate_single_feature_lfs,
 )
+from snorkel.labeling.analysis import lf_empirical_probs
+
+
+class TestGenerateSimpleLabelMatrix(unittest.TestCase):
+    """Testing the generate_simple_label_matrix function."""
+
+    def setUp(self) -> None:
+        """Set constants for the tests."""
+        self.m = 10  # Number of LFs
+        self.n = 10000  # Number of data points
+    
+    def _test_generate_L(self, k: int, decimal: Optional[int] = 2) -> None:
+        """Test generated label matrix L for consistency with P, Y.
+
+        This tests for consistency between the true conditional LF probabilities, P,
+        and the empirical ones computed from L and Y, where P, L, and Y are generated
+        by the generate_simple_label_matrix function.
+        
+        Parameters
+        ----------
+        k
+            Cardinality
+        decimal
+            Number of decimals to check element-wise error, err < 1.5 * 10**(-decimal)
+        """
+        np.random.seed(123)
+        P, Y, L = generate_simple_label_matrix(self.n, self.m, k)
+        P_emp = lf_empirical_probs(L, Y, k=k)
+        np.testing.assert_array_almost_equal(P, P_emp, decimal=decimal)
+    
+    def test_generate_L(self) -> None:
+        """Test the generated dataset for consistency."""
+        self._test_generate_L(2)
+    
+    def test_generate_L_multiclass(self) -> None:
+        """Test the generated dataset for consistency with cardinality=3."""
+        self._test_generate_L(3, decimal=1)
 
 
 class TestGenerateMOGDataset(unittest.TestCase):

--- a/test/synthetic/test_synthetic_data.py
+++ b/test/synthetic/test_synthetic_data.py
@@ -5,14 +5,14 @@ import numpy as np
 
 from snorkel.augmentation.apply import PandasTFApplier
 from snorkel.augmentation.policy import ApplyOnePolicy
+from snorkel.labeling.analysis import lf_empirical_probs
 from snorkel.labeling.apply import PandasLFApplier
 from snorkel.synthetic.synthetic_data import (
-    generate_simple_label_matrix,
     generate_mog_dataset,
     generate_resampling_tfs,
+    generate_simple_label_matrix,
     generate_single_feature_lfs,
 )
-from snorkel.labeling.analysis import lf_empirical_probs
 
 
 class TestGenerateSimpleLabelMatrix(unittest.TestCase):
@@ -22,14 +22,14 @@ class TestGenerateSimpleLabelMatrix(unittest.TestCase):
         """Set constants for the tests."""
         self.m = 10  # Number of LFs
         self.n = 10000  # Number of data points
-    
+
     def _test_generate_L(self, k: int, decimal: Optional[int] = 2) -> None:
         """Test generated label matrix L for consistency with P, Y.
 
         This tests for consistency between the true conditional LF probabilities, P,
         and the empirical ones computed from L and Y, where P, L, and Y are generated
         by the generate_simple_label_matrix function.
-        
+
         Parameters
         ----------
         k
@@ -41,11 +41,11 @@ class TestGenerateSimpleLabelMatrix(unittest.TestCase):
         P, Y, L = generate_simple_label_matrix(self.n, self.m, k)
         P_emp = lf_empirical_probs(L, Y, k=k)
         np.testing.assert_array_almost_equal(P, P_emp, decimal=decimal)
-    
+
     def test_generate_L(self) -> None:
         """Test the generated dataset for consistency."""
         self._test_generate_L(2)
-    
+
     def test_generate_L_multiclass(self) -> None:
         """Test the generated dataset for consistency with cardinality=3."""
         self._test_generate_L(3, decimal=1)

--- a/test/synthetic/test_synthetic_data.py
+++ b/test/synthetic/test_synthetic_data.py
@@ -21,7 +21,7 @@ class TestGenerateSimpleLabelMatrix(unittest.TestCase):
     def setUp(self) -> None:
         """Set constants for the tests."""
         self.m = 10  # Number of LFs
-        self.n = 10000  # Number of data points
+        self.n = 1000  # Number of data points
 
     def _test_generate_L(self, k: int, decimal: Optional[int] = 2) -> None:
         """Test generated label matrix L for consistency with P, Y.
@@ -44,7 +44,7 @@ class TestGenerateSimpleLabelMatrix(unittest.TestCase):
 
     def test_generate_L(self) -> None:
         """Test the generated dataset for consistency."""
-        self._test_generate_L(2)
+        self._test_generate_L(2, decimal=1)
 
     def test_generate_L_multiclass(self) -> None:
         """Test the generated dataset for consistency with cardinality=3."""


### PR DESCRIPTION
Just adding a simple conditionally independent labelers (with non-symmetric class accuracies) test which is tagged as `complex`, along with a new supporting analysis function, `lf_empirical_probs`, that computes the full conditional probability table given a labeled dataset, i.e. `L` and `Y`, rather than just the accuracies.

Note that this is just an initial stub- will extend these tests to be (a) more thorough and (b) include dependencies once the new LabelModel code is in.