### PR TITLE
Add unit tests for SnorkelClassifier.predict(), score()

### DIFF
--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, NamedTuple
+from typing import Any, Callable, Dict, List, NamedTuple, Optional
 
 import numpy as np
 import sklearn.metrics as skmetrics
@@ -18,7 +18,7 @@ def metric_score(
     preds: np.ndarray,
     probs: np.ndarray,
     metric: str,
-    filter_dict: Dict[str, List[int]] = {"golds": [0]},
+    filter_dict: Optional[Dict[str, List[int]]] = None,
     **kwargs: Any,
 ) -> float:
     """A method for evaluating a standard metric on a set of predictions/probabilities
@@ -52,6 +52,9 @@ def metric_score(
     if metric not in METRICS:
         msg = f"The metric you provided ({metric}) is not currently implemented."
         raise ValueError(msg)
+
+    if filter_dict is None:
+        filter_dict = {"golds": [0]}
 
     # Convert to numpy
     golds = arraylike_to_numpy(golds) if golds is not None else None

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, NamedTuple, Optional
+from typing import Any, Callable, Dict, List, NamedTuple
 
 import numpy as np
 import sklearn.metrics as skmetrics
@@ -18,7 +18,7 @@ def metric_score(
     preds: np.ndarray,
     probs: np.ndarray,
     metric: str,
-    filter_dict: Optional[Dict[str, List[int]]] = None,
+    filter_dict: Dict[str, List[int]] = {"golds": [0]},
     **kwargs: Any,
 ) -> float:
     """A method for evaluating a standard metric on a set of predictions/probabilities

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -257,14 +257,6 @@ class SnorkelClassifier(nn.Module):
         for task_name in gold_dict_list:
             gold_dict[task_name] = np.array(gold_dict_list[task_name])
             prob_dict[task_name] = np.array(prob_dict_list[task_name])
-            if gold_dict[task_name].ndim == 1:
-                active = (gold_dict[task_name] != 0).reshape(-1)
-            else:
-                active = np.sum(gold_dict[task_name] != 0, axis=1) > 0
-
-            if 0 in active:
-                gold_dict[task_name] = gold_dict[task_name][active]
-                prob_dict[task_name] = prob_dict[task_name][active]
 
         if return_preds:
             pred_dict: Dict[str, ArrayLike] = defaultdict(list)

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -260,7 +260,7 @@ class SnorkelClassifier(nn.Module):
             if gold_dict[task_name].ndim == 1:
                 active = (gold_dict[task_name] != 0).reshape(-1)
             else:
-                active = np.sum(gold_dict[task_name] == 0, axis=1) > 0
+                active = np.sum(gold_dict[task_name] != 0, axis=1) > 0
 
             if 0 in active:
                 gold_dict[task_name] = gold_dict[task_name][active]

--- a/test/classification/test_scorer.py
+++ b/test/classification/test_scorer.py
@@ -8,8 +8,8 @@ from snorkel.classification.scorer import Scorer
 
 class ScorerTest(unittest.TestCase):
     def _get_labels(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        golds = np.array([1, 0, 1, 0, 1])
-        preds = np.array([1, 0, 1, 1, 0])
+        golds = np.array([1, 2, 1, 2, 1])
+        preds = np.array([1, 2, 1, 1, 2])
         probs = np.array([0.8, 0.6, 0.9, 0.7, 0.4])
         return golds, preds, probs
 
@@ -22,7 +22,7 @@ class ScorerTest(unittest.TestCase):
         )
 
         results = scorer.score(*self._get_labels())
-        results_expected = dict(accuracy=0.6, f1=2 / 3, pred_sum=3)
+        results_expected = dict(accuracy=0.6, f1=2 / 3, pred_sum=7)
         self.assertEqual(results, results_expected)
 
     def test_dict_metric(self) -> None:

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -65,11 +65,15 @@ class ClassifierTest(unittest.TestCase):
         np.testing.assert_array_equal(
             results["golds"]["task1"], self.dataloader.dataset.Y_dict["task1"].numpy()
         )
-        np.testing.assert_array_equal(results["probs"]["task1"], np.ones((NUM_EXAMPLES, 2)) * 0.5)
+        np.testing.assert_array_equal(
+            results["probs"]["task1"], np.ones((NUM_EXAMPLES, 2)) * 0.5
+        )
 
         results = model.predict(self.dataloader, return_preds=True)
         self.assertEqual(sorted(list(results.keys())), ["golds", "preds", "probs"])
-        np.testing.assert_array_equal(results["preds"]["task1"], np.ones((NUM_EXAMPLES,)))
+        np.testing.assert_array_equal(
+            results["preds"]["task1"], np.ones((NUM_EXAMPLES,))
+        )
 
     def test_empty_batch(self):
         # Make the first BATCH_SIZE labels 0 so that one batch will have no labels
@@ -144,10 +148,7 @@ def create_task(task_name, module_suffixes=("", "")):
     linear2.bias.data.copy_(torch.zeros((2,)))
 
     module_pool = nn.ModuleDict(
-        {
-            module1_name: nn.Sequential(linear1, nn.ReLU()),
-            module2_name: linear2,
-        }
+        {module1_name: nn.Sequential(linear1, nn.ReLU()), module2_name: linear2}
     )
 
     op0 = Operation(module_name=module1_name, inputs=[("_input_", "data")], name="op0")

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -14,7 +14,7 @@ NUM_EXAMPLES = 10
 BATCH_SIZE = 2
 
 
-def create_dataloader(task_name="task", split="train"):
+def create_dataloader(task_name="task", split="train", **kwargs):
     X = torch.FloatTensor([[i, i] for i in range(NUM_EXAMPLES)])
     Y = torch.ones(NUM_EXAMPLES, 1).long()
 
@@ -22,7 +22,7 @@ def create_dataloader(task_name="task", split="train"):
         name="dataset", split=split, X_dict={"data": X}, Y_dict={task_name: Y}
     )
 
-    dataloader = DictDataLoader(dataset, batch_size=BATCH_SIZE)
+    dataloader = DictDataLoader(dataset, batch_size=BATCH_SIZE, **kwargs)
     return dataloader
 
 
@@ -105,6 +105,14 @@ class ClassifierTest(unittest.TestCase):
         results = model.predict(dataloader, return_preds=True)
         self.assertEqual(sorted(list(results.keys())), ["golds", "preds", "probs"])
         self.assertEqual(results["preds"]["task1"].shape, (NUM_EXAMPLES,))
+
+    def test_empty_batch(self):
+        # Make the first BATCH_SIZE labels 0 so that one batch will have no labels
+        dataloader = create_dataloader("task1", shuffle=False)
+        for i in range(BATCH_SIZE):
+            dataloader.dataset.Y_dict["task1"][i] = 0
+        model = SnorkelClassifier([task1])
+        model.predict(dataloader)
 
     def test_score(self):
         model = SnorkelClassifier([task1])

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -14,59 +14,22 @@ NUM_EXAMPLES = 10
 BATCH_SIZE = 2
 
 
-def create_dataloader(task_name="task", split="train", **kwargs):
-    X = torch.FloatTensor([[i, i] for i in range(NUM_EXAMPLES)])
-    Y = torch.ones(NUM_EXAMPLES, 1).long()
-
-    dataset = DictDataset(
-        name="dataset", split=split, X_dict={"data": X}, Y_dict={task_name: Y}
-    )
-
-    dataloader = DictDataLoader(dataset, batch_size=BATCH_SIZE, **kwargs)
-    return dataloader
-
-
-def create_task(task_name, module_suffixes=("", "")):
-    module1_name = f"linear1{module_suffixes[0]}"
-    module2_name = f"linear2{module_suffixes[1]}"
-
-    module_pool = nn.ModuleDict(
-        {
-            module1_name: nn.Sequential(nn.Linear(2, 4), nn.ReLU()),
-            module2_name: nn.Linear(4, 2),
-        }
-    )
-
-    op0 = Operation(module_name=module1_name, inputs=[("_input_", "data")], name="op0")
-    op1 = Operation(module_name=module2_name, inputs=[(op0.name, 0)], name="op1")
-
-    task_flow = [op0, op1]
-
-    task = Task(
-        name=task_name,
-        module_pool=module_pool,
-        task_flow=task_flow,
-        scorer=Scorer(metrics=["accuracy"]),
-    )
-
-    return task
-
-
-task1 = create_task("task1", module_suffixes=["A", "A"])
-task2 = create_task("task2", module_suffixes=["B", "B"])
-dataloader = create_dataloader("task1")
-
-
 class ClassifierTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.task1 = create_task("task1", module_suffixes=["A", "A"])
+        cls.task2 = create_task("task2", module_suffixes=["B", "B"])
+        cls.dataloader = create_dataloader("task1")
+
     def test_onetask_model(self):
-        model = SnorkelClassifier(tasks=[task1])
+        model = SnorkelClassifier(tasks=[self.task1])
         self.assertEqual(len(model.task_names), 1)
         self.assertEqual(len(model.task_flows), 1)
         self.assertEqual(len(model.module_pool), 2)
 
     def test_twotask_none_overlap_model(self):
         """Add two tasks with totally separate modules and flows"""
-        model = SnorkelClassifier(tasks=[task1, task2])
+        model = SnorkelClassifier(tasks=[self.task1, self.task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 4)
@@ -91,34 +54,35 @@ class ClassifierTest(unittest.TestCase):
 
     def test_bad_tasks(self):
         with self.assertRaisesRegex(ValueError, "Found duplicate task"):
-            SnorkelClassifier(tasks=[task1, task1])
+            SnorkelClassifier(tasks=[self.task1, self.task1])
         with self.assertRaisesRegex(ValueError, "Unrecognized task type"):
-            SnorkelClassifier(tasks=[task1, {"fake_task": 42}])
+            SnorkelClassifier(tasks=[self.task1, {"fake_task": 42}])
 
     def test_predict(self):
-        model = SnorkelClassifier([task1])
-        results = model.predict(dataloader)
+        model = SnorkelClassifier([self.task1])
+        results = model.predict(self.dataloader)
         self.assertEqual(sorted(list(results.keys())), ["golds", "probs"])
         np.testing.assert_array_equal(
-            results["golds"]["task1"], dataloader.dataset.Y_dict["task1"].numpy()
+            results["golds"]["task1"], self.dataloader.dataset.Y_dict["task1"].numpy()
         )
         self.assertEqual(results["probs"]["task1"].shape, (NUM_EXAMPLES, 2))
 
-        results = model.predict(dataloader, return_preds=True)
+        results = model.predict(self.dataloader, return_preds=True)
         self.assertEqual(sorted(list(results.keys())), ["golds", "preds", "probs"])
         self.assertEqual(results["preds"]["task1"].shape, (NUM_EXAMPLES,))
 
     def test_empty_batch(self):
         # Make the first BATCH_SIZE labels 0 so that one batch will have no labels
-        dataloader = create_dataloader("task1", shuffle=False)
+        dataset = create_dataloader("task1", shuffle=False).dataset
         for i in range(BATCH_SIZE):
-            dataloader.dataset.Y_dict["task1"][i] = 0
-        model = SnorkelClassifier([task1])
-        model.predict(dataloader)
+            dataset.Y_dict["task1"][i] = 0
+        model = SnorkelClassifier([self.task1])
+        loss_dict, count_dict = model.calculate_loss(dataset.X_dict, dataset.Y_dict)
+        self.assertEqual(count_dict["task1"], NUM_EXAMPLES - BATCH_SIZE)
 
     def test_score(self):
-        model = SnorkelClassifier([task1])
-        metrics = model.score([dataloader])
+        model = SnorkelClassifier([self.task1])
+        metrics = model.score([self.dataloader])
         self.assertIsInstance(metrics["task1/dataset/train/accuracy"], float)
 
     def test_save_load(self):
@@ -126,6 +90,8 @@ class ClassifierTest(unittest.TestCase):
 
         task1 = create_task("task1")
         task2 = create_task("task2")
+        # Make task2's second linear layer have different weights
+        task2.module_pool["linear2"] = nn.Linear(2, 2)
 
         model = SnorkelClassifier([task1])
         self.assertTrue(
@@ -151,6 +117,52 @@ class ClassifierTest(unittest.TestCase):
         )
 
         os.close(fd)
+
+
+def create_dataloader(task_name="task", split="train", **kwargs):
+    X = torch.FloatTensor([[i, i] for i in range(NUM_EXAMPLES)])
+    Y = torch.ones(NUM_EXAMPLES, 1).long()
+
+    dataset = DictDataset(
+        name="dataset", split=split, X_dict={"data": X}, Y_dict={task_name: Y}
+    )
+
+    dataloader = DictDataLoader(dataset, batch_size=BATCH_SIZE, **kwargs)
+    return dataloader
+
+
+def create_task(task_name, module_suffixes=("", "")):
+    module1_name = f"linear1{module_suffixes[0]}"
+    module2_name = f"linear2{module_suffixes[1]}"
+
+    linear1 = nn.Linear(2, 2)
+    linear1.weight.data.copy_(torch.eye(2))
+    linear1.bias.data.copy_(torch.zeros((2,)))
+
+    linear2 = nn.Linear(2, 2)
+    linear2.weight.data.copy_(torch.eye(2))
+    linear2.bias.data.copy_(torch.zeros((2,)))
+
+    module_pool = nn.ModuleDict(
+        {
+            module1_name: nn.Sequential(linear1, nn.ReLU()),
+            module2_name: linear2,
+        }
+    )
+
+    op0 = Operation(module_name=module1_name, inputs=[("_input_", "data")], name="op0")
+    op1 = Operation(module_name=module2_name, inputs=[(op0.name, 0)], name="op1")
+
+    task_flow = [op0, op1]
+
+    task = Task(
+        name=task_name,
+        module_pool=module_pool,
+        task_flow=task_flow,
+        scorer=Scorer(metrics=["accuracy"]),
+    )
+
+    return task
 
 
 if __name__ == "__main__":

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -2,38 +2,83 @@ import os
 import tempfile
 import unittest
 
+import numpy as np
 import torch
 import torch.nn as nn
 
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
+from snorkel.classification.data import DictDataset, DictDataLoader
+
+NUM_EXAMPLES = 10
+BATCH_SIZE = 2
 
 
-class TaskTest(unittest.TestCase):
+def create_dataloader(task_name="task", split="train"):
+    X = torch.FloatTensor([[i, i] for i in range(NUM_EXAMPLES)])
+    Y = torch.ones(NUM_EXAMPLES, 1).long()
+
+    dataset = DictDataset(
+        name="dataset", split=split, X_dict={"data": X}, Y_dict={task_name: Y}
+    )
+
+    dataloader = DictDataLoader(dataset, batch_size=BATCH_SIZE)
+    return dataloader
+
+
+def create_task(task_name, module_suffixes=("", "")):
+    module1_name = f"linear1{module_suffixes[0]}"
+    module2_name = f"linear2{module_suffixes[1]}"
+
+    module_pool = nn.ModuleDict(
+        {
+            module1_name: nn.Sequential(nn.Linear(2, 4), nn.ReLU()),
+            module2_name: nn.Linear(4, 2),
+        }
+    )
+
+    op0 = Operation(module_name=module1_name, inputs=[("_input_", "data")], name="op0")
+    op1 = Operation(module_name=module2_name, inputs=[(op0.name, 0)], name="op1")
+
+    task_flow = [op0, op1]
+
+    task = Task(
+        name=task_name,
+        module_pool=module_pool,
+        task_flow=task_flow,
+        scorer=Scorer(metrics=["accuracy"]),
+    )
+
+    return task
+
+
+task1 = create_task("task1", module_suffixes=["A", "A"])
+task2 = create_task("task2", module_suffixes=["B", "B"])
+dataloader = create_dataloader("task1")
+
+
+class ClassifierTest(unittest.TestCase):
     def test_onetask_model(self):
-        task1 = create_task("task1")
         model = SnorkelClassifier(tasks=[task1])
         self.assertEqual(len(model.task_names), 1)
         self.assertEqual(len(model.task_flows), 1)
         self.assertEqual(len(model.module_pool), 2)
 
-    def test_twotask_all_overlap_model(self):
-        """Add two tasks with identical modules and flows"""
-        task1 = create_task("task1")
-        task2 = create_task("task2")
-        model = SnorkelClassifier(tasks=[task1, task2])
-        self.assertEqual(len(model.task_names), 2)
-        self.assertEqual(len(model.task_flows), 2)
-        self.assertEqual(len(model.module_pool), 2)
-
     def test_twotask_none_overlap_model(self):
         """Add two tasks with totally separate modules and flows"""
-        task1 = create_task("task1", module_suffixes=["A", "A"])
-        task2 = create_task("task2", module_suffixes=["B", "B"])
         model = SnorkelClassifier(tasks=[task1, task2])
         self.assertEqual(len(model.task_names), 2)
         self.assertEqual(len(model.task_flows), 2)
         self.assertEqual(len(model.module_pool), 4)
+
+    def test_twotask_all_overlap_model(self):
+        """Add two tasks with identical modules and flows"""
+        task1 = create_task("task1", module_suffixes=["A", "A"])
+        task2 = create_task("task2", module_suffixes=["A", "A"])
+        model = SnorkelClassifier(tasks=[task1, task2])
+        self.assertEqual(len(model.task_names), 2)
+        self.assertEqual(len(model.task_flows), 2)
+        self.assertEqual(len(model.module_pool), 2)
 
     def test_twotask_partial_overlap_model(self):
         """Add two tasks with overlapping modules and flows"""
@@ -45,11 +90,26 @@ class TaskTest(unittest.TestCase):
         self.assertEqual(len(model.module_pool), 3)
 
     def test_bad_tasks(self):
-        task1 = create_task("task1", module_suffixes=["A", "A"])
         with self.assertRaisesRegex(ValueError, "Found duplicate task"):
             SnorkelClassifier(tasks=[task1, task1])
         with self.assertRaisesRegex(ValueError, "Unrecognized task type"):
             SnorkelClassifier(tasks=[task1, {"fake_task": 42}])
+
+    def test_predict(self):
+        model = SnorkelClassifier([task1])
+        results = model.predict(dataloader)
+        self.assertEqual(sorted(list(results.keys())), ["golds", "probs"])
+        np.testing.assert_array_equal(results["golds"]["task1"], dataloader.dataset.Y_dict["task1"].numpy())
+        self.assertEqual(results["probs"]["task1"].shape, (NUM_EXAMPLES, 2))
+
+        results = model.predict(dataloader, return_preds=True)
+        self.assertEqual(sorted(list(results.keys())), ["golds", "preds", "probs"])
+        self.assertEqual(results["preds"]["task1"].shape, (NUM_EXAMPLES,))
+
+    def test_score(self):
+        model = SnorkelClassifier([task1])
+        metrics = model.score([dataloader])
+        self.assertIsInstance(metrics["task1/dataset/train/accuracy"], float)
 
     def test_save_load(self):
         fd, checkpoint_path = tempfile.mkstemp()
@@ -81,32 +141,6 @@ class TaskTest(unittest.TestCase):
         )
 
         os.close(fd)
-
-
-def create_task(task_name, module_suffixes=("", "")):
-    module1_name = f"linear1{module_suffixes[0]}"
-    module2_name = f"linear2{module_suffixes[1]}"
-
-    module_pool = nn.ModuleDict(
-        {
-            module1_name: nn.Sequential(nn.Linear(2, 4), nn.ReLU()),
-            module2_name: nn.Linear(4, 2),
-        }
-    )
-
-    op0 = Operation(module_name=module1_name, inputs=[("_input_", "data")], name="op0")
-    op1 = Operation(module_name=module2_name, inputs=[(op0.name, 0)], name="op1")
-
-    task_flow = [op0, op1]
-
-    task = Task(
-        name=task_name,
-        module_pool=module_pool,
-        task_flow=task_flow,
-        scorer=Scorer(metrics=["accuracy"]),
-    )
-
-    return task
 
 
 if __name__ == "__main__":

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -65,11 +65,11 @@ class ClassifierTest(unittest.TestCase):
         np.testing.assert_array_equal(
             results["golds"]["task1"], self.dataloader.dataset.Y_dict["task1"].numpy()
         )
-        self.assertEqual(results["probs"]["task1"].shape, (NUM_EXAMPLES, 2))
+        np.testing.assert_array_equal(results["probs"]["task1"], np.ones((NUM_EXAMPLES, 2)) * 0.5)
 
         results = model.predict(self.dataloader, return_preds=True)
         self.assertEqual(sorted(list(results.keys())), ["golds", "preds", "probs"])
-        self.assertEqual(results["preds"]["task1"].shape, (NUM_EXAMPLES,))
+        np.testing.assert_array_equal(results["preds"]["task1"], np.ones((NUM_EXAMPLES,)))
 
     def test_empty_batch(self):
         # Make the first BATCH_SIZE labels 0 so that one batch will have no labels
@@ -83,7 +83,7 @@ class ClassifierTest(unittest.TestCase):
     def test_score(self):
         model = SnorkelClassifier([self.task1])
         metrics = model.score([self.dataloader])
-        self.assertIsInstance(metrics["task1/dataset/train/accuracy"], float)
+        self.assertEqual(metrics["task1/dataset/train/accuracy"], 1.0)
 
     def test_save_load(self):
         fd, checkpoint_path = tempfile.mkstemp()

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -6,9 +6,9 @@ import numpy as np
 import torch
 import torch.nn as nn
 
+from snorkel.classification.data import DictDataLoader, DictDataset
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
-from snorkel.classification.data import DictDataset, DictDataLoader
 
 NUM_EXAMPLES = 10
 BATCH_SIZE = 2
@@ -99,7 +99,9 @@ class ClassifierTest(unittest.TestCase):
         model = SnorkelClassifier([task1])
         results = model.predict(dataloader)
         self.assertEqual(sorted(list(results.keys())), ["golds", "probs"])
-        np.testing.assert_array_equal(results["golds"]["task1"], dataloader.dataset.Y_dict["task1"].numpy())
+        np.testing.assert_array_equal(
+            results["golds"]["task1"], dataloader.dataset.Y_dict["task1"].numpy()
+        )
         self.assertEqual(results["probs"]["task1"].shape, (NUM_EXAMPLES, 2))
 
         results = model.predict(dataloader, return_preds=True)


### PR DESCRIPTION
- Adds basic tests for the predict() and score() methods
- Also fixes a bug discovered by the unit tests (yay unit tests!) when calculating abstain mask
- Moves filtering of examples with unknown gold labels to the metrics instead of the predict() method so that predict returns a label for every example in the dataset.

**Test plan:**
Adds unit test confirming that predict() and score() yield outputs of the right types and shapes.