### PR TITLE
Add docstrings to data and drop verbose helper

### DIFF
--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -27,17 +27,24 @@ Batch = Tuple[XDict, YDict]
 
 
 class DictDataset(Dataset):
-    """An advanced dataset class to handle input data with multipled fields and output
-    data with multiple label sets
+    """A dataset where both the data fields and labels are stored in as dictionaries.
 
-    :param name: the name of the dataset
-    :type name: str
-    :param X_dict: the feature dict where key is the feature name and value is the
-    feature
-    :type X_dict: dict
-    :param Y_dict: the label dict where key is the label name and value is
-    the label
-    :type Y_dict: dict
+    Parameters
+    ----------
+    name
+        The name of the dataset (e.g., this will be used to report metrics on a
+        per-dataset basis)
+    split
+        The name of the split that the data in this object represents
+    X_dict
+        A map from field name to values (e.g., {"tokens": ..., "uids": ...})
+    Y_dict
+        A map from task name to its corresponding set of labels
+
+    Raises
+    ------
+    ValueError
+        All values in the Y_dict must be of type torch.Tensor
     """
 
     def __init__(self, name: str, split: str, X_dict: XDict, Y_dict: YDict) -> None:
@@ -65,7 +72,18 @@ class DictDataset(Dataset):
 
 
 def collate_dicts(batch: List[Batch]) -> Batch:
+    """Combine many one-element dicts into a single many-element dict for both X and Y.
 
+    Parameters
+    ----------
+    batch
+        A list of (x_dict, y_dict) where the values of each are a single element
+
+    Returns
+    -------
+    Batch
+        A tuple of X_dict, Y_dict where the values of each are a merged list or tensor
+    """
     X_batch: Dict[str, Any] = defaultdict(list)
     Y_batch: Dict[str, Any] = defaultdict(list)
 
@@ -87,18 +105,16 @@ def collate_dicts(batch: List[Batch]) -> Batch:
 
 
 class DictDataLoader(DataLoader):
-    """An advanced dataloader class which contains mapping from task to label (which
-    label(s) to use in dataset's Y_dict for this task), and split (which part this
-    dataset belongs to) information.
+    """A DataLoader that uses the appropriate collate_fn for a `DictDataset`.
 
-    value is the labels for that task and should be the key in Y_dict
-    :param dataset: the dataset to construct the dataloader
-    :type dataset: torch.utils.data.Dataset
-    :param split: the split information, defaults to "train"
-    :param split: str, optional
-    :param collate_fn: the function that merges a list of samples to form a
-    mini-batch, defaults to collate_dicts
-    :param collate_fn: function, optional
+    Parameters
+    ----------
+    dataset
+        A DictDataset to wrap
+    collate_fn
+        The collate function to use when combining multiple indexed examples for a
+        single batch. Usually the default collate_dicts() method should be used, but
+        it can be overriden if you want to use different collate logic.
     """
 
     def __init__(
@@ -107,122 +123,5 @@ class DictDataLoader(DataLoader):
         collate_fn: Callable[..., Any] = collate_dicts,
         **kwargs: Any,
     ) -> None:
-
         assert isinstance(dataset, DictDataset)
         super().__init__(dataset, collate_fn=collate_fn, **kwargs)
-
-
-def split_data(
-    *inputs: ArrayLike,
-    splits: List[float] = [0.5, 0.5],
-    shuffle: bool = True,
-    stratify_by: Optional[np.ndarray] = None,
-    index_only: bool = False,
-    seed: Optional[Iterable[int]] = None,
-) -> Union[List[List[int]], List[List[ArrayLike]], List[ArrayLike]]:
-    """Splits inputs into multiple splits of defined sizes
-
-    Args:
-        inputs: correlated tuples/lists/arrays/matrices/tensors to split
-        splits: list containing split sizes (fractions or counts);
-        shuffle: if True, shuffle the data before splitting
-        stratify_by: (None or an input) if not None, use these labels to
-            stratify the splits (separating the data into groups by these
-            labels and sampling from those, rather than from the population at
-            large); overrides shuffle
-        index_only: if True, return only the indices of the new splits, not the
-            split data itself
-        seed: (int) random seed
-
-    Example usage:
-        Ls, Xs, Ys = split_data(L, X, Y, splits=[0.8, 0.1, 0.1])
-        OR
-        assignments = split_data(Y, splits=[0.8, 0.1, 0.1], index_only=True)
-
-    Note: This is very similar to scikit-learn's train_test_split() method,
-        but with support for more than two splits.
-    """
-
-    def fractions_to_counts(fracs: Iterable[float], n: int) -> List[int]:
-        """Converts a list of fractions to a list of counts that sum to n"""
-        counts = [int(np.round(n * frac)) for frac in fracs]
-        # Ensure sum of split counts sums to n
-        counts[-1] = n - sum(counts[:-1])
-        return counts
-
-    def slice_data(data: ArrayLike, indices: List[int]) -> ArrayLike:
-        if isinstance(data, list) or isinstance(data, tuple):
-            return [d for i, d in enumerate(data) if i in set(indices)]
-        else:
-            try:
-                # Works for np.ndarray, scipy.sparse, torch.Tensor
-                return data[indices]
-            except TypeError:
-                raise Exception(
-                    f"split_data() currently only accepts inputs "
-                    f"of type tuple, list, np.ndarray, scipy.sparse, or "
-                    f"torch.Tensor; not {type(data)}"
-                )
-
-    # Setting random seed
-    if seed is not None:
-        random.seed(seed)
-
-    try:
-        n = len(inputs[0])  # type: ignore
-    except TypeError:
-        assert isinstance(inputs[0], (np.ndarray, Tensor, sparse.spmatrix))
-        n = inputs[0].shape[0]
-    num_splits = len(splits)
-
-    # Check splits for validity and convert to fractions
-    if all(isinstance(x, int) for x in splits):
-        if not sum(splits) == n:
-            raise ValueError(
-                f"Provided split counts must sum to n ({n}), not {sum(splits)}."
-            )
-        fracs = [count / n for count in splits]
-
-    elif all(isinstance(x, float) for x in splits):
-        if not sum(splits) == 1.0:
-            raise ValueError(f"Split fractions must sum to 1.0, not {sum(splits)}.")
-        fracs = splits
-
-    else:
-        raise ValueError("Splits must contain all ints or all floats.")
-
-    # Make sampling pools
-    if stratify_by is None:
-        pools = [np.arange(n)]
-    else:
-        pools_dict: DefaultDict[int, List[int]] = defaultdict(list)
-        for i, val in enumerate(stratify_by):
-            pools_dict[val].append(i)
-        pools = list(pools_dict.values())
-
-    # Make index assignments
-    assignments: List[List[int]] = [[] for _ in range(num_splits)]
-    for pool in pools:
-        if shuffle or stratify_by is not None:
-            random.shuffle(pool)
-
-        counts = fractions_to_counts(fracs, len(pool))
-        counts.insert(0, 0)
-        cum_counts = np.cumsum(counts)
-        for i in range(num_splits):
-            assignments[i].extend(pool[cum_counts[i] : cum_counts[i + 1]])
-
-    if index_only:
-        return assignments
-    else:
-        outputs = []
-        for data in inputs:
-            data_splits = []
-            for split in range(num_splits):
-                data_splits.append(slice_data(data, assignments[split]))
-            outputs.append(data_splits)
-
-        if len(outputs) == 1:
-            return outputs[0]
-        else:
-            return outputs

--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -26,6 +26,17 @@ class DictDataset(Dataset):
     Y_dict
         A map from task name to its corresponding set of labels
 
+    Attributes
+    ----------
+    name
+        See above
+    split
+        See above
+    X_dict
+        See above
+    Y_dict
+        See above
+
     Raises
     ------
     ValueError
@@ -95,11 +106,13 @@ class DictDataLoader(DataLoader):
     Parameters
     ----------
     dataset
-        A DictDataset to wrap
+        A dataset to wrap
     collate_fn
         The collate function to use when combining multiple indexed examples for a
         single batch. Usually the default collate_dicts() method should be used, but
         it can be overriden if you want to use different collate logic.
+    kwargs
+        Keyword arguments to pass on to DataLoader.__init__()
     """
 
     def __init__(

--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -1,23 +1,8 @@
-import random
 from collections import defaultdict
-from typing import (
-    Any,
-    Callable,
-    DefaultDict,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Union,
-)
+from typing import Any, Callable, Dict, List, Tuple
 
-import numpy as np
-import scipy.sparse as sparse
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
-
-from snorkel.types import ArrayLike
 
 from .utils import list_to_tensor
 

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -1,11 +1,8 @@
 import unittest
-from collections import Counter
 
-import numpy as np
-import scipy.sparse as sparse
 import torch
 
-from snorkel.classification.data import DictDataLoader, DictDataset, split_data
+from snorkel.classification.data import DictDataLoader, DictDataset
 
 
 class DatasetTest(unittest.TestCase):

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -123,60 +123,6 @@ class DatasetTest(unittest.TestCase):
         )
         self.assertTrue(torch.equal(y_batch["task2"], torch.Tensor([[2], [2], [2]])))
 
-    def test_split_data(self):
-        N = 1000
-        K = 4
-
-        X = np.arange(0, N)
-        Y = np.random.randint(0, K, size=N).astype(int)
-
-        # Creates splits of correct size
-        splits = [800, 100, 100]
-        Xs_1 = split_data(X, splits=splits, shuffle=False)
-        for i, count in enumerate(splits):
-            self.assertEqual(len(Xs_1[i]), count)
-
-        # Accepts floats or ints
-        splits = [0.8, 0.1, 0.1]
-        Xs_2 = split_data(X, splits=splits, shuffle=False)
-        for split in range(len(splits)):
-            self.assertTrue(np.array_equal(Xs_2[split], Xs_1[split]))
-
-        # Shuffles correctly
-        Xs_3 = split_data(X, splits=splits, shuffle=True, seed=123)
-        self.assertNotEqual(Xs_3[0][0], Xs_2[0][0])
-
-        # Indices only
-        splits = [0.8, 0.1, 0.1]
-        Ys = split_data(Y, splits=splits, shuffle=False, index_only=True)
-        self.assertGreater(max(Ys[0]), K)
-
-        # Handles multiple inputs
-        Xs, Ys = split_data(X, Y, splits=splits, shuffle=True, seed=123)
-        self.assertEqual(Ys[0][0], Y[Xs[0][0]])
-
-        # Confirm statification (correct proportion of labels in each split)
-        Ys = split_data(Y, splits=splits, stratify_by=Y, seed=123)
-        counts = [Counter(Y) for Y in Ys]
-        for y in np.unique(Y):
-            ratio0 = counts[0][y] / len(Ys[0])
-            ratio1 = counts[1][y] / len(Ys[1])
-            ratio2 = counts[2][y] / len(Ys[2])
-            self.assertLess(abs(ratio0 - ratio1), 0.05)
-            self.assertLess(abs(ratio0 - ratio2), 0.05)
-
-        # Handles scipy.sparse matrices
-        Z = sparse.csr_matrix([[1, 0, 1, 2], [0, 3, 0, 3], [1, 2, 3, 4], [5, 4, 3, 2]])
-        splits = [0.75, 0.25]
-        Zs = split_data(Z, splits=splits, shuffle=True, seed=123)
-        self.assertEqual(Zs[0].shape, (3, 4))
-
-        # Handles torch.Tensors
-        W = torch.Tensor([[1, 0, 1, 2], [0, 3, 0, 3], [1, 2, 3, 4], [5, 4, 3, 2]])
-        splits = [0.75, 0.25]
-        Ws = split_data(W, splits=splits, shuffle=True, seed=123)
-        self.assertEqual(Ws[0].shape, (3, 4))
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
- Add docstrings to the classes in data.py
- Drop the split_data() helper. It's nice, but its functionality is _mostly_ redundant with scikit-learn's train_test_split() and it's a lot of lines of code for something that's not core to the library's value.

**Test plan:**
- pydocstyle passes
- unit tests pass