### PR TITLE
Add slicing docstrings

### DIFF
--- a/snorkel/slicing/modules/slice_combiner.py
+++ b/snorkel/slicing/modules/slice_combiner.py
@@ -6,7 +6,22 @@ import torch.nn.functional as F
 
 
 class SliceCombinerModule(nn.Module):
-    """A module for combining the weighted representations learned by slices."""
+    """A module for combining the weighted representations learned by slices.
+
+    Intended for use with task flow including:
+        * Indicator operations
+        * Prediction operations
+        * Prediction transform features
+
+    Parameters
+    ----------
+    slice_ind_key : optional
+        Suffix of operation corresponding to the slice indicator heads
+    slice_pred_key : optional
+        Suffix of operation corresponding to the slice predictor heads
+    slice_pred_feat_key : optional
+        Suffix of operation corresponding to the slice predictor features heads
+    """
 
     def __init__(
         self,
@@ -21,9 +36,22 @@ class SliceCombinerModule(nn.Module):
         self.slice_pred_feat_key = slice_pred_feat_key
 
     def forward(self, outputs: Dict[str, torch.Tensor]) -> torch.Tensor:  # type: ignore
-        """Reweights and combines predictor representations."""
+        """Reweights and combines predictor representations given output dict.
+
+        Parameters
+        ----------
+        outputs
+            A dict of data fields containing indicator, predictor, and predictor
+            transform ops
+
+        Returns
+        -------
+        torch.Tensor
+            The reweighted predictor representation
+        """
 
         # Gather names of slice heads (both indicator and predictor heads)
+        # This provides a static ordering by which to index into the 'outputs' dict
         slice_ind_op_names = sorted(
             [
                 flow_name
@@ -38,6 +66,9 @@ class SliceCombinerModule(nn.Module):
                 if self.slice_pred_key in flow_name
             ]
         )
+
+        # Concatenate the predictions from the predictor head/indicator head
+        # into a [batch_size x num_slices] tensor
         indicator_preds = torch.cat(
             [
                 F.softmax(outputs[slice_ind_name][0])[:, 0].unsqueeze(1)
@@ -53,6 +84,8 @@ class SliceCombinerModule(nn.Module):
             dim=-1,
         )
 
+        # Collect names of predictor "features" that will be combined into the final
+        # reweighted representation
         slice_feat_names = sorted(
             [
                 flow_name
@@ -61,6 +94,7 @@ class SliceCombinerModule(nn.Module):
             ]
         )
 
+        # Concatenate each predictor feature into [batch_size x 1 x feat_dim] tensor
         slice_representations = torch.cat(
             [
                 outputs[slice_feat_name][0].unsqueeze(1)
@@ -69,12 +103,15 @@ class SliceCombinerModule(nn.Module):
             dim=1,
         )
 
+        # Attention weights used to combine each of the slice_representations
         A = (
+            # Combine the indicator (whether we are in the slice or not) and
+            # predictor (confidence of a learned slice head) as attention weights
             F.softmax(indicator_preds * predictor_preds, dim=1)
-            .unsqueeze(-1)
-            .expand([-1, -1, slice_representations.size(-1)])
+            # Match the dimensions of the slice_representations
+            .unsqueeze(-1).expand([-1, -1, slice_representations.size(-1)])
         )
 
-        reweighted_rep = torch.sum(A * slice_representations, 1)
-
+        # Reweight representations by class Sum across all classes
+        reweighted_rep = torch.sum(A * slice_representations, dim=1)
         return reweighted_rep

--- a/snorkel/slicing/modules/slice_combiner.py
+++ b/snorkel/slicing/modules/slice_combiner.py
@@ -6,7 +6,7 @@ import torch.nn.functional as F
 
 
 class SliceCombinerModule(nn.Module):
-    """A module for combining the weighted representations learned by slices"""
+    """A module for combining the weighted representations learned by slices."""
 
     def __init__(
         self,
@@ -21,6 +21,8 @@ class SliceCombinerModule(nn.Module):
         self.slice_pred_feat_key = slice_pred_feat_key
 
     def forward(self, outputs: Dict[str, torch.Tensor]) -> torch.Tensor:  # type: ignore
+        """Reweights and combines predictor representations."""
+
         # Gather names of slice heads (both indicator and predictor heads)
         slice_ind_op_names = sorted(
             [

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -135,6 +135,7 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
             name=ind_task_name,
             module_pool=ind_module_pool,
             task_flow=ind_task_flow,
+            # NOTE: F1 by default because indicator task is often class imbalanced 
             scorer=Scorer(metrics=["f1"]),
         )
         tasks.append(ind_task)

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -135,7 +135,7 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
             name=ind_task_name,
             module_pool=ind_module_pool,
             task_flow=ind_task_flow,
-            # NOTE: F1 by default because indicator task is often class imbalanced 
+            # NOTE: F1 by default because indicator task is often class imbalanced
             scorer=Scorer(metrics=["f1"]),
         )
         tasks.append(ind_task)


### PR DESCRIPTION
@bhancock8 would be particularly helpful to get a look from you given you wrote the first pass.

**Test Plan**: 
* Adds compliance with `pydocstyle snorkel/slicing`
* Ran `tox` locally; passes all tests.