### PR TITLE
Slicing refactor + fixes

### DIFF
--- a/snorkel/classification/utils.py
+++ b/snorkel/classification/utils.py
@@ -169,7 +169,7 @@ def move_to_device(
 
 
 def collect_flow_outputs_by_suffix(
-    flow_dict: Dict[str, torch.Tensor], suffix: str
+    flow_dict: Dict[str, List[torch.Tensor]], suffix: str
 ) -> List[torch.Tensor]:
     """Return flow_dict outputs specified by suffix, ordered by sorted flow_name."""
     return [

--- a/snorkel/classification/utils.py
+++ b/snorkel/classification/utils.py
@@ -1,5 +1,5 @@
 import copy
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -166,3 +166,14 @@ def move_to_device(
         return tuple([move_to_device(item, device) for item in obj])
     else:
         return obj
+
+
+def collect_flow_outputs_by_suffix(
+    flow_dict: Dict[str, torch.Tensor], suffix: str
+) -> List[torch.Tensor]:
+    """Return flow_dict outputs specified by suffix, ordered by sorted flow_name."""
+    return [
+        flow_dict[flow_name][0]
+        for flow_name in sorted(flow_dict.keys())
+        if flow_name.endswith(suffix)
+    ]

--- a/snorkel/slicing/modules/slice_combiner.py
+++ b/snorkel/slicing/modules/slice_combiner.py
@@ -44,9 +44,7 @@ class SliceCombinerModule(nn.Module):
         self.slice_pred_key = slice_pred_key
         self.slice_pred_feat_key = slice_pred_feat_key
 
-    def forward(
-        self, flow_dict: Dict[str, torch.Tensor]
-    ) -> torch.Tensor:  # type: ignore
+    def forward(self, flow_dict: Dict[str, torch.Tensor]) -> torch.Tensor: # type:ignore
         """Reweights and combines predictor representations given output dict.
 
         Parameters

--- a/snorkel/slicing/modules/slice_combiner.py
+++ b/snorkel/slicing/modules/slice_combiner.py
@@ -44,9 +44,9 @@ class SliceCombinerModule(nn.Module):
         self.slice_pred_key = slice_pred_key
         self.slice_pred_feat_key = slice_pred_feat_key
 
-    def forward(
+    def forward(  # type:ignore
         self, flow_dict: Dict[str, torch.Tensor]
-    ) -> torch.Tensor:  # type:ignore
+    ) -> torch.Tensor:
         """Reweights and combines predictor representations given output dict.
 
         Parameters
@@ -54,8 +54,8 @@ class SliceCombinerModule(nn.Module):
         flow_dict
             A dict of data fields from slicing task flow containing specific keys
             from indicator ops, pred ops, and pred transform ops (slice_ind_key,
-            slice_pred_key, slice_pred_feat_key) for each slice. 
-            
+            slice_pred_key, slice_pred_feat_key) for each slice.
+
             NOTE: The flow_dict outputs for the ind/pred heads must be raw logits.
 
         Returns

--- a/snorkel/slicing/modules/slice_combiner.py
+++ b/snorkel/slicing/modules/slice_combiner.py
@@ -42,7 +42,7 @@ class SliceCombinerModule(nn.Module):
         slice_ind_key: str = "_ind_head",
         slice_pred_key: str = "_pred_head",
         slice_pred_feat_key: str = "_pred_transform",
-        tau: int = 0.1,
+        tau: float = 0.1,
     ) -> None:
         super().__init__()
 

--- a/snorkel/slicing/modules/slice_combiner.py
+++ b/snorkel/slicing/modules/slice_combiner.py
@@ -4,6 +4,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from snorkel.classification.utils import collect_flow_outputs_by_suffix
+
 
 class SliceCombinerModule(nn.Module):
     """A module for combining the weighted representations learned by slices.
@@ -45,16 +47,16 @@ class SliceCombinerModule(nn.Module):
         self.slice_pred_feat_key = slice_pred_feat_key
 
     def forward(  # type:ignore
-        self, flow_dict: Dict[str, torch.Tensor]
+        self, flow_dict: Dict[str, List[torch.Tensor]]
     ) -> torch.Tensor:
-        """Reweights and combines predictor representations given output dict.
+        """Reweight and combine predictor representations given output dict.
 
         Parameters
         ----------
         flow_dict
-            A dict of data fields from slicing task flow containing specific keys
-            from indicator ops, pred ops, and pred transform ops (slice_ind_key,
-            slice_pred_key, slice_pred_feat_key) for each slice.
+            A dict of data fields cached operation outputs from indicator head,
+            predictor head, and predictor transform (corresponding to slice_ind_key,
+            slice_pred_key, slice_pred_feat_key, respectively).
 
             NOTE: The flow_dict outputs for the ind/pred heads must be raw logits.
 
@@ -65,7 +67,7 @@ class SliceCombinerModule(nn.Module):
         """
 
         # Concatenate indicator head predictions into tensor [batch_size x num_slices]
-        indicator_outputs = self._collect_flow_outputs_by_key(
+        indicator_outputs = collect_flow_outputs_by_suffix(
             flow_dict, self.slice_ind_key
         )
         indicator_preds = torch.cat(
@@ -77,7 +79,7 @@ class SliceCombinerModule(nn.Module):
         )
 
         # Concatenate predictor head confidences into tensor [batch_size x num_slices]
-        predictor_outputs = self._collect_flow_outputs_by_key(
+        predictor_outputs = collect_flow_outputs_by_suffix(
             flow_dict, self.slice_pred_key
         )
 
@@ -92,31 +94,19 @@ class SliceCombinerModule(nn.Module):
 
         # Concatenate each predictor feature (to be combined into reweighted
         # representation) into [batch_size x 1 x feat_dim] tensor
-        predictor_feat_outputs = self._collect_flow_outputs_by_key(
+        predictor_feat_outputs = collect_flow_outputs_by_suffix(
             flow_dict, self.slice_pred_feat_key
         )
-        slice_representations = torch.cat(
-            [output.unsqueeze(1) for output in predictor_feat_outputs], dim=1
-        )
+        slice_representations = torch.stack(predictor_feat_outputs, dim=1)
 
         # Attention weights used to combine each of the slice_representations
         # incorporates the indicator (whether we are in the slice or not) and
         # predictor (confidence of a learned slice head)
         A = F.softmax(indicator_preds * predictor_confidences, dim=1)
 
-        # Match dims [bach_size x num_slices x feat_dim] of slice_representations
+        # Match dims [batch_size x num_slices x feat_dim] of slice_representations
         A = A.unsqueeze(-1).expand([-1, -1, slice_representations.size(-1)])
 
         # Reweight representations with weighted sum across slices
         reweighted_rep = torch.sum(A * slice_representations, dim=1)
         return reweighted_rep
-
-    def _collect_flow_outputs_by_key(
-        self, flow_dict: Dict[str, torch.Tensor], key: str
-    ) -> List[torch.Tensor]:
-        """Return flow_dict outputs specified by key, ordered by sorted flow_name."""
-        return [
-            flow_dict[flow_name][0]
-            for flow_name in sorted(flow_dict.keys())
-            if key in flow_name
-        ]

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -118,8 +118,7 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
     for slice_name in slice_names:
 
         ind_task_name = f"{base_task.name}_slice:{slice_name}_ind"
-
-        ind_head_module_name = f"{ind_task_name}_ind_head"
+        ind_head_module_name = f"{ind_task_name}_head"
         # Indicator head always predicts "in the slice or not", so is always binary
         ind_head_module = nn.Linear(neck_size, 2)
 
@@ -151,8 +150,8 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
 
         pred_task_name = f"{base_task.name}_slice:{slice_name}_pred"
 
-        pred_head_module_name = f"{pred_task_name}_pred_head"
-        pred_transform_module_name = f"{pred_task_name}_pred_transform"
+        pred_head_module_name = f"{pred_task_name}_head"
+        pred_transform_module_name = f"{pred_task_name}_transform"
         pred_transform_module = nn.Linear(neck_size, neck_size)
 
         # Create module_pool

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -211,8 +211,7 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
         task_flow=master_task_flow,
         scorer=base_task.scorer,
     )
-    tasks = slice_tasks + [master_task]
-    return tasks
+    return slice_tasks + [master_task]
 
 
 def _add_base_slice(

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -126,13 +126,15 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
         ind_module_pool = base_task.module_pool
         ind_module_pool[ind_head_module_name] = ind_head_module
 
-        # Create task_flow
+        # Define operations for task head
         ind_head_op = Operation(
             module_name=ind_head_module_name, inputs=head_module_op.inputs
         )
         ind_task_ops = [ind_head_op]
-        ind_task_flow = body_flow + ind_task_ops
         slice_task_ops.extend(ind_task_ops)
+
+        # Create task flow
+        ind_task_flow = body_flow + ind_task_ops
 
         # Create ind task
         ind_task = Task(
@@ -160,7 +162,7 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
         pred_module_pool[pred_transform_module_name] = pred_transform_module
         pred_module_pool[pred_head_module_name] = shared_pred_head_module
 
-        # Create task_flow
+        # Define operations for task head
         pred_transform_op = Operation(
             module_name=pred_transform_module_name, inputs=head_module_op.inputs
         )
@@ -168,8 +170,10 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
             module_name=pred_head_module_name, inputs=[(pred_transform_op.name, 0)]
         )
         pred_task_ops = [pred_transform_op, pred_head_op]
-        pred_task_flow = body_flow + pred_task_ops
         slice_task_ops.extend(pred_task_ops)
+
+        # Create task flow
+        pred_task_flow = body_flow + pred_task_ops
 
         # Create pred task
         pred_task = Task(

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -196,11 +196,6 @@ def convert_to_slice_tasks(base_task: Task, slice_names: List[str]) -> List[Task
         }
     )
 
-    #    master_combiner_op = Operation(
-    #        module_name=master_combiner_module_name,
-    #        # Combiner takes all previous slice tasks as inputs
-    #        inputs=[(t.name, 0) for t in slice_tasks]
-    #    )
     master_combiner_op = Operation(module_name=master_combiner_module_name, inputs=[])
     master_head_op = Operation(
         module_name=master_head_module_name, inputs=[(master_combiner_op.name, 0)]

--- a/test/classification/test_utils.py
+++ b/test/classification/test_utils.py
@@ -2,7 +2,11 @@ import unittest
 
 import torch
 
-from snorkel.classification.utils import list_to_tensor, pad_batch
+from snorkel.classification.utils import (
+    collect_flow_outputs_by_suffix,
+    list_to_tensor,
+    pad_batch,
+)
 
 
 class UtilsTest(unittest.TestCase):
@@ -110,3 +114,13 @@ class UtilsTest(unittest.TestCase):
                 padded_batch, torch.Tensor([[1, 2, 2, 3], [4, 5, 6, 0], [7, 8, 9, 0]])
             )
         )
+
+    def test_collect_flow_outputs_by_suffix(self):
+        flow_dict = {
+            "a_pred_head": torch.Tensor([1]),
+            "b_pred_head": torch.Tensor([2]),
+            "c_pred": torch.Tensor([3]),
+        }
+        outputs = collect_flow_outputs_by_suffix(flow_dict, "_head")
+        self.assertIn(torch.Tensor([1]), outputs)
+        self.assertIn(torch.Tensor([2]), outputs)

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -87,14 +87,14 @@ class SlicingConvergenceTest(unittest.TestCase):
         model = SnorkelClassifier(tasks=tasks)
 
         # Train
-        trainer = Trainer(lr=0.01, n_epochs=30, progress_bar=False)
+        trainer = Trainer(lr=0.01, n_epochs=50, progress_bar=False)
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 
         # Confirm near perfect scores
-        self.assertGreater(scores["task/TestData/valid/accuracy"], 0.9)
-        self.assertGreater(scores["task_slice:h_pred/TestData/valid/accuracy"], 0.9)
-        self.assertGreater(scores["task_slice:h_ind/TestData/valid/f1"], 0.9)
+        self.assertGreater(scores["task/TestData/valid/accuracy"], 0.95)
+        self.assertGreater(scores["task_slice:h_pred/TestData/valid/accuracy"], 0.95)
+        self.assertGreater(scores["task_slice:h_ind/TestData/valid/f1"], 0.95)
 
         # Calculate/check train/val loss
         train_dataset = dataloaders[0].dataset
@@ -102,12 +102,12 @@ class SlicingConvergenceTest(unittest.TestCase):
             train_dataset.X_dict, train_dataset.Y_dict
         )
         train_loss = train_loss_output[0]["task"].item()
-        self.assertLess(train_loss, 0.5)
+        self.assertLess(train_loss, 0.1)
 
         val_dataset = dataloaders[1].dataset
         val_loss_output = model.calculate_loss(val_dataset.X_dict, val_dataset.Y_dict)
         val_loss = val_loss_output[0]["task"].item()
-        self.assertLess(val_loss, 0.5)
+        self.assertLess(val_loss, 0.1)
 
     @pytest.mark.complex
     def test_performance(self):
@@ -137,17 +137,17 @@ class SlicingConvergenceTest(unittest.TestCase):
         model = SnorkelClassifier(tasks=tasks)
 
         # Train
-        trainer = Trainer(lr=0.01, n_epochs=30, progress_bar=False)
+        trainer = Trainer(lr=0.01, n_epochs=50, progress_bar=False)
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 
         # Confirm reasonably high slice scores
-        self.assertGreater(scores["task/TestData/valid/f1"], 0.8)
-        self.assertGreater(scores["task_slice:f_pred/TestData/valid/f1"], 0.8)
-        self.assertGreater(scores["task_slice:f_ind/TestData/valid/f1"], 0.8)
-        self.assertGreater(scores["task_slice:g_pred/TestData/train/f1"], 0.8)
-        self.assertGreater(scores["task_slice:g_ind/TestData/train/f1"], 0.8)
-        self.assertGreater(scores["task_slice:base_pred/TestData/valid/f1"], 0.8)
+        self.assertGreater(scores["task/TestData/valid/f1"], 0.95)
+        self.assertGreater(scores["task_slice:f_pred/TestData/valid/f1"], 0.95)
+        self.assertGreater(scores["task_slice:f_ind/TestData/valid/f1"], 0.95)
+        self.assertGreater(scores["task_slice:g_pred/TestData/train/f1"], 0.95)
+        self.assertGreater(scores["task_slice:g_ind/TestData/train/f1"], 0.95)
+        self.assertGreater(scores["task_slice:base_pred/TestData/valid/f1"], 0.95)
         # base_ind is trivial: all labels are positive
         self.assertEqual(scores["task_slice:base_ind/TestData/valid/f1"], 1.0)
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -138,7 +138,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Train
         # NOTE: Needs more epochs to convergence with more heads
-        trainer = Trainer(lr=0.001, n_epochs=100, progress_bar=False)
+        trainer = Trainer(lr=0.001, n_epochs=110, progress_bar=False)
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -137,7 +137,8 @@ class SlicingConvergenceTest(unittest.TestCase):
         model = SnorkelClassifier(tasks=tasks)
 
         # Train
-        trainer = Trainer(lr=0.01, n_epochs=50, progress_bar=False)
+        # NOTE: Needs more epochs to convergence with more heads
+        trainer = Trainer(lr=0.01, n_epochs=70, progress_bar=False)
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -87,7 +87,7 @@ class SlicingConvergenceTest(unittest.TestCase):
         model = SnorkelClassifier(tasks=tasks)
 
         # Train
-        trainer = Trainer(lr=0.01, n_epochs=50, progress_bar=False)
+        trainer = Trainer(lr=0.001, n_epochs=50, progress_bar=False)
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 
@@ -138,7 +138,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Train
         # NOTE: Needs more epochs to convergence with more heads
-        trainer = Trainer(lr=0.001, n_epochs=80, progress_bar=False)
+        trainer = Trainer(lr=0.001, n_epochs=100, progress_bar=False)
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -138,7 +138,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Train
         # NOTE: Needs more epochs to convergence with more heads
-        trainer = Trainer(lr=0.01, n_epochs=70, progress_bar=False)
+        trainer = Trainer(lr=0.001, n_epochs=80, progress_bar=False)
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 

--- a/test/slicing/test_slice_combiner.py
+++ b/test/slicing/test_slice_combiner.py
@@ -1,3 +1,4 @@
+import random
 import unittest
 
 import torch
@@ -11,23 +12,191 @@ class SliceCombinerTest(unittest.TestCase):
     def setup_class(cls):
         set_seed(123)
 
-    def test_init_and_forward(self):
+    def test_forward_shape(self):
+        """Test that the reweight representation shape matches expected feature size."""
+
+        # common case
         batch_size = 4
         h_dim = 20
+        num_classes = 2
 
         outputs = {
-            "_input_": {"data": torch.FloatTensor(batch_size, 2).uniform_(0, 1)},
-            "linear": [torch.FloatTensor(batch_size, 2).uniform_(0, 1)],
             "task_slice:base_ind_head": [
+                # Always 2-dim binary outputs
                 torch.FloatTensor(batch_size, 2).uniform_(0, 1)
             ],
             "task_slice:base_pred_transform": [
-                torch.FloatTensor(batch_size, 20).uniform_(0, 1)
+                torch.FloatTensor(batch_size, h_dim).uniform_(0, 1)
             ],
             "task_slice:base_pred_head": [
-                torch.FloatTensor(batch_size, 2).uniform_(0, 1)
+                torch.FloatTensor(batch_size, num_classes).uniform_(0, 1)
             ],
         }
         combiner_module = SliceCombinerModule()
         combined_rep = combiner_module(outputs)
         self.assertEqual(tuple(combined_rep.shape), (batch_size, h_dim))
+
+        # edge case (all ones)
+        batch_size = 1
+        h_dim = 1
+        num_classes = 1
+
+        outputs = {
+            "task_slice:base_ind_head": [
+                # Always 2-dim binary outputs
+                torch.FloatTensor(batch_size, 2).uniform_(0, 1)
+            ],
+            "task_slice:base_pred_transform": [
+                torch.FloatTensor(batch_size, h_dim).uniform_(0, 1)
+            ],
+            "task_slice:base_pred_head": [
+                torch.FloatTensor(batch_size, num_classes).uniform_(0, 1)
+            ],
+        }
+        combiner_module = SliceCombinerModule()
+        combined_rep = combiner_module(outputs)
+        self.assertEqual(tuple(combined_rep.shape), (batch_size, h_dim))
+
+    def test_average_reweighting(self):
+        """Test average reweighting (equal weight across two slices)."""
+        batch_size = 4
+        h_dim = 20
+        num_classes = 2
+
+        outputs = {
+            "task_slice:a_ind_head": [torch.ones(batch_size, 2) * 10.0],
+            "task_slice:a_pred_transform": [torch.ones(batch_size, h_dim) * 4],
+            "task_slice:a_pred_head": [torch.ones(batch_size, num_classes) * 10.0],
+            "task_slice:b_ind_head": [torch.ones(batch_size, 2) * -10.0],
+            "task_slice:b_pred_transform": [torch.ones(batch_size, h_dim) * 2],
+            "task_slice:b_pred_head": [torch.ones(batch_size, num_classes) * -10.0],
+        }
+        combiner_module = SliceCombinerModule()
+        combined_rep = combiner_module(outputs)
+        self.assertTrue(torch.allclose(combined_rep, torch.ones(batch_size, h_dim) * 3))
+
+    def test_average_reweighting_by_ind(self):
+        """Test average reweighting by ind (zeros in pred head)."""
+        batch_size = 4
+        h_dim = 20
+        num_classes = 2
+
+        outputs = {
+            "task_slice:a_ind_head": [torch.ones(batch_size, 2) * 10.0],
+            "task_slice:a_pred_transform": [torch.ones(batch_size, h_dim) * 4],
+            "task_slice:a_pred_head": [torch.zeros(batch_size, num_classes)],
+            "task_slice:b_ind_head": [torch.ones(batch_size, 2) * -10.0],
+            "task_slice:b_pred_transform": [torch.ones(batch_size, h_dim) * 2],
+            "task_slice:b_pred_head": [torch.zeros(batch_size, num_classes)],
+        }
+        combiner_module = SliceCombinerModule()
+        combined_rep = combiner_module(outputs)
+        self.assertTrue(torch.allclose(combined_rep, torch.ones(batch_size, h_dim) * 3))
+
+    def test_average_reweighting_by_pred_confidence(self):
+        """Test average reweighting by pred confidence (zeros in ind head)."""
+        batch_size = 4
+        h_dim = 20
+        num_classes = 2
+
+        outputs = {
+            "task_slice:a_ind_head": [torch.zeros(batch_size, 2)],
+            "task_slice:a_pred_transform": [torch.ones(batch_size, h_dim) * 4],
+            "task_slice:a_pred_head": [torch.ones(batch_size, num_classes) * 5],
+            "task_slice:b_ind_head": [torch.zeros(batch_size, 2)],
+            "task_slice:b_pred_transform": [torch.ones(batch_size, h_dim) * 2],
+            "task_slice:b_pred_head": [torch.ones(batch_size, num_classes) * 5],
+        }
+        combiner_module = SliceCombinerModule()
+        combined_rep = combiner_module(outputs)
+        self.assertTrue(torch.all(combined_rep == torch.ones(batch_size, h_dim) * 3))
+
+        # Changing sign of prediction shouldn't change confidence
+        outputs = {
+            "task_slice:a_ind_head": [torch.zeros(batch_size, 2)],
+            "task_slice:a_pred_transform": [torch.ones(batch_size, h_dim) * 4],
+            "task_slice:a_pred_head": [torch.ones(batch_size, num_classes) * -5],
+            "task_slice:b_ind_head": [torch.zeros(batch_size, 2)],
+            "task_slice:b_pred_transform": [torch.ones(batch_size, h_dim) * 2],
+            "task_slice:b_pred_head": [torch.ones(batch_size, num_classes) * 5],
+        }
+        combiner_module = SliceCombinerModule()
+        combined_rep = combiner_module(outputs)
+        self.assertTrue(torch.allclose(combined_rep, torch.ones(batch_size, h_dim) * 3))
+
+    def test_many_slices(self):
+        """Test combiner on 1000 synthetic generated slices."""
+
+        batch_size = 4
+        h_dim = 20
+        num_classes = 2
+
+        outputs = {}
+        for i in range(1000):
+            if i % 2 == 0:
+                outputs[f"task_slice:{i}_ind_head"] = [torch.ones(batch_size, 2) * 20.0]
+                outputs[f"task_slice:{i}_pred_transform"] = [
+                    torch.ones(batch_size, h_dim) * 4
+                ]
+                outputs[f"task_slice:{i}_pred_head"] = [
+                    torch.ones(batch_size, num_classes) * 20.0
+                ]
+            else:
+                outputs[f"task_slice:{i}_ind_head"] = [
+                    torch.ones(batch_size, 2) * -20.0
+                ]
+                outputs[f"task_slice:{i}_pred_transform"] = [
+                    torch.ones(batch_size, h_dim) * 2
+                ]
+                outputs[f"task_slice:{i}_pred_head"] = [
+                    torch.ones(batch_size, num_classes) * -20.0
+                ]
+
+        combiner_module = SliceCombinerModule()
+        combined_rep = combiner_module(outputs)
+        self.assertTrue(torch.allclose(combined_rep, torch.ones(batch_size, h_dim) * 3))
+
+    def test_combiner_multiclass(self):
+        """Test combiner in multiclass setting."""
+        batch_size = 4
+        h_dim = 20
+        num_classes = 10
+
+        # For each class, make one class (at random) the maximum score
+        # For everything else, set to "logit" between [-5, 5]
+        max_score_indexes_a = [
+            random.randint(0, num_classes) for _ in range(batch_size)
+        ]
+        pred_outputs_a = torch.FloatTensor(batch_size, num_classes).uniform_(-5, 5)
+        pred_outputs_a = pred_outputs_a.scatter_(
+            # scatter max score (10.0) at indexes
+            1,
+            torch.tensor(max_score_indexes_a).unsqueeze(1),
+            10.0,
+        )
+
+        max_score_indexes_b = [
+            random.randint(0, num_classes) for _ in range(batch_size)
+        ]
+        pred_outputs_b = torch.FloatTensor(batch_size, num_classes).uniform_(-5, 5)
+        pred_outputs_b = pred_outputs_b.scatter_(
+            # scatter max score (-10.0) at indexes
+            1,
+            torch.tensor(max_score_indexes_b).unsqueeze(1),
+            10.0,
+        )
+
+        outputs = {
+            "task_slice:a_ind_head": [torch.ones(batch_size, 2) * -10.0],
+            "task_slice:a_pred_transform": [torch.ones(batch_size, h_dim) * 4],
+            "task_slice:a_pred_head": [pred_outputs_a],
+            "task_slice:b_ind_head": [torch.ones(batch_size, 2) * 10.0],
+            "task_slice:b_pred_transform": [torch.ones(batch_size, h_dim) * 2],
+            "task_slice:b_pred_head": [pred_outputs_b],
+        }
+        combiner_module = SliceCombinerModule()
+        combined_rep = combiner_module(outputs)
+        # higher tolerance because randomness in non-max class outputs -> for softmax
+        self.assertTrue(
+            torch.allclose(combined_rep, torch.ones(batch_size, h_dim) * 3, atol=1e-2)
+        )

--- a/test/slicing/test_slice_combiner.py
+++ b/test/slicing/test_slice_combiner.py
@@ -152,7 +152,7 @@ class SliceCombinerTest(unittest.TestCase):
                     torch.ones(batch_size, num_classes) * -20.0
                 ]
 
-        combiner_module = SliceCombinerModule()
+        combiner_module = SliceCombinerModule(tau=1.0)
         combined_rep = combiner_module(outputs)
         self.assertTrue(torch.allclose(combined_rep, torch.ones(batch_size, h_dim) * 3))
 
@@ -194,7 +194,7 @@ class SliceCombinerTest(unittest.TestCase):
             "task_slice:b_pred_transform": [torch.ones(batch_size, h_dim) * 2],
             "task_slice:b_pred_head": [pred_outputs_b],
         }
-        combiner_module = SliceCombinerModule()
+        combiner_module = SliceCombinerModule(tau=1.0)
         combined_rep = combiner_module(outputs)
         # higher tolerance because randomness in non-max class outputs -> for softmax
         self.assertTrue(


### PR DESCRIPTION
- [x] Bugfix: `add_slice_tasks` was missing some of the `slice_ind` or `slice_pred` operations when adding to master_combiner's`task_flow`
- [x] SliceCombiner now uses the max score across pred classes as the "confidence"
- [x] Refactor SlicePred into helper functions 
- [x] Cleanup slice task naming (e.g. `task_slice:pred_pred_head` --> `task_slice:pred_head`)
- [x] Fix deprecated pytorch warnings

**Test Plan**: 
- [x] Add tighter tests for convergence (> 95 F1-score) (downside: takes slightly longer to run tests)
- [x] Add additional unit tests for specific SliceCombiner functionality
    - SliceCombiner test cases for different attention weights
    - Check that `task_flow` and `module_pool` elements are correctly configured