### PR TITLE
Disable complex tests off main branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,19 @@ dist: xenial
 
 jobs:
   include:
-    - if: branch = master OR branch = redux OR branch =~ release-*
+    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
       name: "Python 3.6: unit tests"
       python: 3.6
       env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - if: branch = master OR branch = redux OR branch =~ release-*
+    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
       name: "Python 3.7: unit tests"
       python: 3.7
       env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
+    - if: branch = master OR branch = redux OR branch =~ release-*
       name: "Python 3.6: unit + integration tests"
       python: 3.6
       env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
+    - if: branch = master OR branch = redux OR branch =~ release-*
       name: "Python 3.7: unit + integration tests"
       python: 3.7
       env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,24 @@ cache: pip
 # python3.7 only available on xenial
 dist: xenial
 
-env:
-  TOXENV=coverage,spark,complex,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-
 jobs:
   include:
-    - name: "Tests: python3.6"
+    - if: branch = master OR branch = redux OR branch =~ release-*
+      name: "Python 3.6: unit tests"
       python: 3.6
-    - name: "Tests: python3.7"
+      env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - if: branch = master OR branch = redux OR branch =~ release-*
+      name: "Python 3.7: unit tests"
       python: 3.7
+      env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
+      name: "Python 3.6: unit + integration tests"
+      python: 3.6
+      env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
+      name: "Python 3.7: unit + integration tests"
+      python: 3.7
+      env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # Install JDK8 for PySpark tests
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,19 @@ dist: xenial
 
 jobs:
   include:
-    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
+    - if: type = pull_request
       name: "Python 3.6: unit tests"
       python: 3.6
       env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - if: NOT (branch = master OR branch = redux OR branch =~ release-*)
+    - if: type = pull_request
       name: "Python 3.7: unit tests"
       python: 3.7
       env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - if: branch = master OR branch = redux OR branch =~ release-*
+    - if: type != pull_request
       name: "Python 3.6: unit + integration tests"
       python: 3.6
       env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
-    - if: branch = master OR branch = redux OR branch =~ release-*
+    - if: type != pull_request
       name: "Python 3.7: unit + integration tests"
       python: 3.7
       env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,7 +88,23 @@ Note that we use PEP 484 type hints, so parameter types should be removed from t
 }
 ```
 
+
+### Complex/integration/long-running tests
+
+Any test that runs longer than half a second should be marked with the
+`@pytest.mark.complex` decorator.
+Typically, these will be integration tests or tests that verify complex
+properties like model convergence.
+We exclude long-running tests from the default `tox` and Travis builds
+on non-master and non-release branches to keep things moving fast.
+If you're touching areas of the code that could break a long-running test,
+you should include the results of `tox -e complex` in the PR's test plan.
+In order to see the durations of the 10 longest-running tests, run
+`tox -e py3 -- -m 'not complex and not spark' --durations 10`.
+
+
 ### PySpark tests
+
 PySpark tests are invoked separately from the rest since they require
 installing Java and the large PySpark package.
 They are executed on Travis, but not by default for a local `tox` command.


### PR DESCRIPTION
cc @vincentschen Sounding like slicing integration tests will add too much overhead, so let's do this now. Adding complex test instructions to CONTRIBUTING.

**Test plan**
Manual verification of Travis stages