### PR TITLE
Remove ArrayLike

### DIFF
--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -3,7 +3,7 @@ from typing import Any, Counter, Iterable, List, Mapping, Optional, Sequence, Tu
 
 import numpy as np
 
-from .utils import to_flattened_int_array
+from .utils import to_int_label_array
 
 
 def error_buckets(
@@ -36,8 +36,8 @@ def error_buckets(
             instead.
     """
     buckets: Mapping[Tuple[int, int], List[Any]] = defaultdict(list)
-    golds = to_flattened_int_array(golds)
-    preds = to_flattened_int_array(preds)
+    golds = to_int_label_array(golds)
+    preds = to_int_label_array(preds)
     for i, (y, l) in enumerate(zip(preds, golds)):
         buckets[y, l].append(X[i] if X is not None else i)
     return dict(buckets)
@@ -76,8 +76,8 @@ def confusion_matrix(
     """
 
     conf = ConfusionMatrix(null_pred=null_pred, null_gold=null_gold)
-    golds = to_flattened_int_array(golds)
-    preds = to_flattened_int_array(preds)
+    golds = to_int_label_array(golds)
+    preds = to_int_label_array(preds)
     conf.add(golds, preds)
     mat = conf.compile()
 

--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -3,13 +3,11 @@ from typing import Any, Counter, Iterable, List, Mapping, Optional, Sequence, Tu
 
 import numpy as np
 
-from snorkel.types import ArrayLike
-
-from .utils import arraylike_to_numpy
+from .utils import to_flattened_int_array
 
 
 def error_buckets(
-    golds: ArrayLike, preds: ArrayLike, X: Optional[Sequence[Any]] = None
+    golds: np.ndarray, preds: np.ndarray, X: Optional[Sequence[Any]] = None
 ) -> Mapping[Tuple[int, int], Any]:
     """Return examples (or their indices) bucketed by gold label/pred label combination.
 
@@ -23,9 +21,9 @@ def error_buckets(
     Parameters
     ----------
     gold
-        An ArrayLike of gold (int) labels
+        An np.ndarray of gold (int) labels
     pred
-        An ArrayLike of (int) predictions
+        An np.ndarray of (int) predictions
     X
         Optional, a sequence of examples corresponding to golds/preds
         If not provided, indices will be returned instead
@@ -38,16 +36,16 @@ def error_buckets(
             instead.
     """
     buckets: Mapping[Tuple[int, int], List[Any]] = defaultdict(list)
-    golds = arraylike_to_numpy(golds)
-    preds = arraylike_to_numpy(preds)
+    golds = to_flattened_int_array(golds)
+    preds = to_flattened_int_array(preds)
     for i, (y, l) in enumerate(zip(preds, golds)):
         buckets[y, l].append(X[i] if X is not None else i)
     return dict(buckets)
 
 
 def confusion_matrix(
-    golds: ArrayLike,
-    preds: ArrayLike,
+    golds: np.ndarray,
+    preds: np.ndarray,
     null_pred: bool = False,
     null_gold: bool = False,
     normalize: bool = False,
@@ -58,9 +56,9 @@ def confusion_matrix(
     Parameters
     ----------
     golds
-        an ArrayLike of gold (int) labels
+        an np.ndarray of gold (int) labels
     preds
-        An Arraylike of (int) predictions
+        An np.ndarray of (int) predictions
     null_pred
         If True, include the row corresponding to null predictions
     null_gold
@@ -78,8 +76,8 @@ def confusion_matrix(
     """
 
     conf = ConfusionMatrix(null_pred=null_pred, null_gold=null_gold)
-    golds = arraylike_to_numpy(golds)
-    preds = arraylike_to_numpy(preds)
+    golds = to_flattened_int_array(golds)
+    preds = to_flattened_int_array(preds)
     conf.add(golds, preds)
     mat = conf.compile()
 

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional
 import numpy as np
 import sklearn.metrics as skmetrics
 
-from .utils import arraylike_to_numpy, filter_labels
+from .utils import filter_labels, to_flattened_int_array
 
 
 class Metric(NamedTuple):
@@ -57,10 +57,10 @@ def metric_score(
         filter_dict = {"golds": [0]}
 
     # Convert to numpy
-    golds = arraylike_to_numpy(golds) if golds is not None else None
-    preds = arraylike_to_numpy(preds) if preds is not None else None
+    golds = to_flattened_int_array(golds) if golds is not None else None
+    preds = to_flattened_int_array(preds) if preds is not None else None
     probs = (
-        arraylike_to_numpy(probs, flatten=False, cast_to_int=False)
+        to_flattened_int_array(probs, flatten=False, cast_to_int=False)
         if probs is not None
         else None
     )

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional
 import numpy as np
 import sklearn.metrics as skmetrics
 
-from .utils import filter_labels, to_flattened_int_array
+from .utils import filter_labels, to_int_label_array
 
 
 class Metric(NamedTuple):
@@ -57,13 +57,8 @@ def metric_score(
         filter_dict = {"golds": [0]}
 
     # Convert to numpy
-    golds = to_flattened_int_array(golds) if golds is not None else None
-    preds = to_flattened_int_array(preds) if preds is not None else None
-    probs = (
-        to_flattened_int_array(probs, flatten=False, cast_to_int=False)
-        if probs is not None
-        else None
-    )
+    golds = to_int_label_array(golds) if golds is not None else None
+    preds = to_int_label_array(preds) if preds is not None else None
 
     # Optionally filter out examples (e.g., abstain predictions or unknown labels)
     label_dict = {"golds": golds, "preds": preds, "probs": probs}

--- a/snorkel/analysis/utils.py
+++ b/snorkel/analysis/utils.py
@@ -46,12 +46,10 @@ def preds_to_probs(preds: np.ndarray, num_classes: int) -> np.ndarray:
     return np.eye(num_classes)[preds.squeeze() - 1]
 
 
-def to_flattened_int_array(
-    X: np.ndarray, flatten: bool = True, cast_to_int: bool = True
-) -> np.ndarray:
-    """Convert an array to a flattened vector of ints.
+def to_int_label_array(X: np.ndarray, flatten: bool = True) -> np.ndarray:
+    """Convert an array to a (possibly flattened) array of ints.
 
-    Flatten [n, 1] arrays to [n] and cast all values to ints.
+    Cast all values to ints and possibly flatten [n, 1] arrays to [n].
     This method is typically used to sanitize labels before use with analysis tools or
     metrics that expect 1D arrays as inputs.
 
@@ -61,8 +59,6 @@ def to_flattened_int_array(
         An array to possibly flatten and possibly cast to int
     flatten
         If True, flatten array into a 1D array
-    cast_to_int
-        If True, cast all values to ints
 
     Returns
     -------
@@ -74,18 +70,16 @@ def to_flattened_int_array(
     ValueError
         Provided input could not be converted to an np.ndarray
     """
+    if np.any(np.not_equal(np.mod(X, 1), 0)):
+        raise ValueError("Input contains at least one non-integer value.")
+    X = X.astype(np.dtype(int))
+
     # Correct shape
     if flatten:
         if (X.ndim > 1) and (1 in X.shape):
             X = X.flatten()
         if X.ndim != 1:
             raise ValueError("Input could not be converted to 1d np.array")
-
-    # Convert to ints
-    if cast_to_int:
-        if np.any(np.not_equal(np.mod(X, 1), 0)):
-            raise ValueError("Input contains at least one non-integer value.")
-        X = X.astype(np.dtype(int))
 
     return X
 

--- a/snorkel/analysis/utils.py
+++ b/snorkel/analysis/utils.py
@@ -46,7 +46,7 @@ def preds_to_probs(preds: np.ndarray, num_classes: int) -> np.ndarray:
     return np.eye(num_classes)[preds.squeeze() - 1]
 
 
-def to_int_label_array(X: np.ndarray, flatten: bool = True) -> np.ndarray:
+def to_int_label_array(X: np.ndarray, flatten_vector: bool = True) -> np.ndarray:
     """Convert an array to a (possibly flattened) array of ints.
 
     Cast all values to ints and possibly flatten [n, 1] arrays to [n].
@@ -57,7 +57,7 @@ def to_int_label_array(X: np.ndarray, flatten: bool = True) -> np.ndarray:
     ----------
     X
         An array to possibly flatten and possibly cast to int
-    flatten
+    flatten_vector
         If True, flatten array into a 1D array
 
     Returns
@@ -73,14 +73,11 @@ def to_int_label_array(X: np.ndarray, flatten: bool = True) -> np.ndarray:
     if np.any(np.not_equal(np.mod(X, 1), 0)):
         raise ValueError("Input contains at least one non-integer value.")
     X = X.astype(np.dtype(int))
-
     # Correct shape
-    if flatten:
-        if (X.ndim > 1) and (1 in X.shape):
-            X = X.flatten()
+    if flatten_vector:
+        X = X.squeeze()
         if X.ndim != 1:
             raise ValueError("Input could not be converted to 1d np.array")
-
     return X
 
 

--- a/snorkel/classification/scorer.py
+++ b/snorkel/classification/scorer.py
@@ -1,8 +1,9 @@
 from functools import partial
 from typing import Callable, Dict, List, Mapping, Optional
 
+import numpy as np
+
 from snorkel.analysis.metrics import METRICS, metric_score
-from snorkel.types import ArrayLike
 
 
 class Scorer:
@@ -50,7 +51,7 @@ class Scorer:
             self.metrics.update(custom_metric_funcs)
 
     def score(
-        self, golds: ArrayLike, preds: ArrayLike, probs: ArrayLike
+        self, golds: np.ndarray, preds: np.ndarray, probs: np.ndarray
     ) -> Dict[str, float]:
         """Calculate one or more scores from user-specified and/or user-defined metrics.
 

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -23,7 +23,6 @@ from snorkel.classification.data import DictDataLoader
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_config import default_config
 from snorkel.classification.utils import move_to_device, recursive_merge_dicts
-from snorkel.types import ArrayLike
 
 from .task import Operation, Task
 
@@ -328,7 +327,7 @@ class SnorkelClassifier(nn.Module):
             prob_dict[task_name] = np.array(prob_dict_list[task_name])
 
         if return_preds:
-            pred_dict: Dict[str, ArrayLike] = defaultdict(list)
+            pred_dict: Dict[str, np.ndarray] = defaultdict(list)
             for task_name, probs in prob_dict.items():
                 pred_dict[task_name] = probs_to_preds(probs)
 

--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -6,7 +6,7 @@ import scipy.sparse as sparse
 from pandas import DataFrame, Series
 
 from snorkel.analysis.error_analysis import confusion_matrix
-from snorkel.analysis.utils import to_flattened_int_array
+from snorkel.analysis.utils import to_int_label_array
 
 Matrix = Union[np.ndarray, sparse.csr_matrix]
 
@@ -276,7 +276,7 @@ def lf_empirical_accuracies(L: sparse.spmatrix, Y: np.ndarray) -> np.ndarray:
         Empirical accuracies for each LF
     """
     # Assume labeled set is small, work with dense matrices
-    Y = to_flattened_int_array(Y)
+    Y = to_int_label_array(Y)
     L = L.toarray()
     X = np.where(L == 0, 0, np.where(L == np.vstack([Y] * L.shape[1]).T, 1, -1))
     return np.nan_to_num(0.5 * (X.sum(axis=0) / (L != 0).sum(axis=0) + 1))
@@ -307,7 +307,7 @@ def lf_empirical_probs(L: sparse.spmatrix, Y: np.ndarray, k: int) -> np.ndarray:
     n, m = L.shape
 
     # Assume labeled set is small, work with dense matrices
-    Y = to_flattened_int_array(Y)
+    Y = to_int_label_array(Y)
     L = L.toarray()
 
     # Compute empirical conditional probabilities
@@ -397,6 +397,6 @@ def single_lf_summary(Y_p: np.ndarray, Y: Optional[np.ndarray] = None) -> DataFr
     pandas.DataFrame
         Summary statistics for LF
     """
-    L = sparse.csr_matrix(to_flattened_int_array(Y_p).reshape(-1, 1))
+    L = sparse.csr_matrix(to_int_label_array(Y_p).reshape(-1, 1))
     summary = lf_summary(L, Y)
     return summary[["Polarity", "Coverage", "Correct", "Incorrect", "Emp. Acc."]]

--- a/snorkel/labeling/model/baselines.py
+++ b/snorkel/labeling/model/baselines.py
@@ -3,9 +3,8 @@ from typing import Any
 import numpy as np
 import scipy.sparse as sparse
 
-from snorkel.analysis.utils import arraylike_to_numpy
+from snorkel.analysis.utils import to_flattened_int_array
 from snorkel.labeling.model.label_model import LabelModel
-from snorkel.types import ArrayLike
 
 
 class BaselineVoter(LabelModel):
@@ -64,7 +63,7 @@ class MajorityClassVoter(LabelModel):
     """Majority class label model."""
 
     def train_model(  # type: ignore
-        self, balance: ArrayLike, *args: Any, **kwargs: Any
+        self, balance: np.ndarray, *args: Any, **kwargs: Any
     ) -> None:
         """Train majority class model.
 
@@ -141,7 +140,8 @@ class MajorityLabelVoter(BaselineVoter):
                [0.5, 0.5],
                [0.5, 0.5]])
         """
-        L = arraylike_to_numpy(L, flatten=False)
+        L = L.todense()
+        L = to_flattened_int_array(L, flatten=False)
         n, m = L.shape
         Y_p = np.zeros((n, self.cardinality))
         for i in range(n):

--- a/snorkel/labeling/model/baselines.py
+++ b/snorkel/labeling/model/baselines.py
@@ -141,7 +141,7 @@ class MajorityLabelVoter(BaselineVoter):
                [0.5, 0.5]])
         """
         L = L.todense()
-        L = to_int_label_array(L, flatten=False)
+        L = to_int_label_array(L, flatten_vector=False)
         n, m = L.shape
         Y_p = np.zeros((n, self.cardinality))
         for i in range(n):

--- a/snorkel/labeling/model/baselines.py
+++ b/snorkel/labeling/model/baselines.py
@@ -3,7 +3,7 @@ from typing import Any
 import numpy as np
 import scipy.sparse as sparse
 
-from snorkel.analysis.utils import to_flattened_int_array
+from snorkel.analysis.utils import to_int_label_array
 from snorkel.labeling.model.label_model import LabelModel
 
 
@@ -141,7 +141,7 @@ class MajorityLabelVoter(BaselineVoter):
                [0.5, 0.5]])
         """
         L = L.todense()
-        L = to_flattened_int_array(L, flatten=False)
+        L = to_int_label_array(L, flatten=False)
         n, m = L.shape
         Y_p = np.zeros((n, self.cardinality))
         for i in range(n):

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -350,7 +350,7 @@ class LabelModel(nn.Module):
 
         Example
         -------
-        >>> L = sparse.csr_matrix(np.array([[1, 1, 0], [2, 2, 0], [1, 1, 0]]))
+        >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
         >>> label_model = LabelModel()
         >>> label_model.train_model(L)
         >>> label_model.predict_proba(L)

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -9,7 +9,6 @@ from snorkel.analysis.utils import convert_labels
 from snorkel.classification.data import DictDataLoader
 from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, Task
-from snorkel.types import ArrayLike
 
 from .modules.slice_combiner import SliceCombinerModule
 
@@ -38,7 +37,7 @@ def add_slice_labels(
     slice_labels, slice_names = _add_base_slice(slice_labels, slice_names)
     assert slice_labels.shape[1] == len(slice_names)
 
-    Y_dict: Dict[str, ArrayLike] = dataloader.dataset.Y_dict  # type: ignore
+    Y_dict: Dict[str, np.ndarray] = dataloader.dataset.Y_dict  # type: ignore
     labels = Y_dict[base_task.name]
     for i, slice_name in enumerate(slice_names):
 

--- a/snorkel/types/__init__.py
+++ b/snorkel/types/__init__.py
@@ -1,2 +1,2 @@
-from .data import ArrayLike, DataPoint, DataPoints, Field, FieldMap  # noqa: F401
+from .data import DataPoint, DataPoints, Field, FieldMap  # noqa: F401
 from .logger import Config  # noqa: F401

--- a/snorkel/types/data.py
+++ b/snorkel/types/data.py
@@ -1,13 +1,7 @@
-from typing import Any, Mapping, Sequence, Union
-
-import numpy as np
-import scipy.sparse as sparse
-from torch import Tensor
+from typing import Any, Mapping, Sequence
 
 DataPoint = Any
 DataPoints = Sequence[DataPoint]
 
 Field = Any
 FieldMap = Mapping[str, Field]
-
-ArrayLike = Union[np.ndarray, list, sparse.spmatrix, Tensor]

--- a/test/analysis/test_error_analysis.py
+++ b/test/analysis/test_error_analysis.py
@@ -15,8 +15,8 @@ class ErrorAnalysisTest(unittest.TestCase):
         )
 
     def test_confusion_matrix(self) -> None:
-        preds = [0, 2, 2, 3, 1, 0, 1, 3]
-        golds = [1, 2, 2, 0, 3, 0, 2, 3]
+        preds = np.array([0, 2, 2, 3, 1, 0, 1, 3])
+        golds = np.array([1, 2, 2, 0, 3, 0, 2, 3])
 
         mat = confusion_matrix(
             golds, preds, null_pred=False, null_gold=False, normalize=False

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -1,23 +1,21 @@
 import unittest
 
 import numpy as np
-import torch
 
 from snorkel.analysis.metrics import metric_score
 
 
 class MetricsTest(unittest.TestCase):
     def test_accuracy_basic(self):
-        golds = [1, 1, 1, 2, 2]
-        preds = [1, 1, 1, 2, 1]
+        golds = np.array([1, 1, 1, 2, 2])
+        preds = np.array([1, 1, 1, 2, 1])
         score = metric_score(golds, preds, probs=None, metric="accuracy")
         self.assertAlmostEqual(score, 0.8)
 
     def test_bad_inputs(self):
-        golds = [1, 1, 1, 2, 2]
-        pred1 = [1, 1, 1, 2, 0.5]
-        pred2 = "1 1 1 2 2"
-        pred3 = np.array([[1, 1, 1, 1, 1], [2, 2, 2, 2, 2]])
+        golds = np.array([1, 1, 1, 2, 2])
+        pred1 = np.array([1, 1, 1, 2, 0.5])
+        pred2 = np.array([[1, 1, 1, 1, 1], [2, 2, 2, 2, 2]])
         with self.assertRaisesRegex(
             ValueError, "Input contains at least one non-integer"
         ):
@@ -26,11 +24,8 @@ class MetricsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Input could not be converted"):
             metric_score(golds, pred2, probs=None, metric="accuracy")
 
-        with self.assertRaisesRegex(ValueError, "Input could not be converted"):
-            metric_score(golds, pred3, probs=None, metric="accuracy")
-
         with self.assertRaisesRegex(ValueError, "The metric you provided"):
-            metric_score(golds, pred3, probs=None, metric="bad_metric")
+            metric_score(golds, pred2, probs=None, metric="bad_metric")
 
         with self.assertRaisesRegex(
             ValueError, "filter_dict must only include keys in"
@@ -43,15 +38,9 @@ class MetricsTest(unittest.TestCase):
                 filter_dict={"bad_map": [0]},
             )
 
-    def test_array_conversion(self):
-        golds = torch.Tensor([1, 1, 1, 2, 2])
-        preds = np.array([1.0, 1.0, 1.0, 2.0, 1.0])
-        score = metric_score(golds, preds, probs=None, metric="accuracy")
-        self.assertAlmostEqual(score, 0.8)
-
     def test_ignores(self):
-        golds = [1, 1, 1, 2, 2]
-        preds = [1, 0, 1, 2, 1]
+        golds = np.array([1, 1, 1, 2, 2])
+        preds = np.array([1, 0, 1, 2, 1])
         score = metric_score(golds, preds, probs=None, metric="accuracy")
         self.assertAlmostEqual(score, 0.6)
         score = metric_score(
@@ -72,8 +61,8 @@ class MetricsTest(unittest.TestCase):
         self.assertAlmostEqual(score, 1.0)
 
     def test_coverage(self):
-        golds = [1, 1, 1, 1, 2]
-        preds = [0, 0, 1, 1, 1]
+        golds = np.array([1, 1, 1, 1, 2])
+        preds = np.array([0, 0, 1, 1, 1])
         score = metric_score(golds, preds, probs=None, metric="coverage")
         self.assertAlmostEqual(score, 0.6)
         score = metric_score(
@@ -82,32 +71,32 @@ class MetricsTest(unittest.TestCase):
         self.assertAlmostEqual(score, 0.5)
 
     def test_precision(self):
-        golds = [1, 1, 1, 2, 2]
-        preds = [2, 2, 1, 1, 2]
+        golds = np.array([1, 1, 1, 2, 2])
+        preds = np.array([2, 2, 1, 1, 2])
         score = metric_score(golds, preds, probs=None, metric="precision")
         self.assertAlmostEqual(score, 0.5)
         score = metric_score(golds, preds, probs=None, metric="precision", pos_label=2)
         self.assertAlmostEqual(score, 0.333, places=2)
 
     def test_recall(self):
-        golds = [1, 1, 1, 1, 2]
-        preds = [2, 2, 1, 1, 2]
+        golds = np.array([1, 1, 1, 1, 2])
+        preds = np.array([2, 2, 1, 1, 2])
         score = metric_score(golds, preds, probs=None, metric="recall")
         self.assertAlmostEqual(score, 0.5)
         score = metric_score(golds, preds, probs=None, metric="recall", pos_label=2)
         self.assertAlmostEqual(score, 1.0)
 
     def test_f1(self):
-        golds = [1, 1, 1, 1, 2]
-        preds = [2, 2, 1, 1, 2]
+        golds = np.array([1, 1, 1, 1, 2])
+        preds = np.array([2, 2, 1, 1, 2])
         score = metric_score(golds, preds, probs=None, metric="f1")
         self.assertAlmostEqual(score, 0.666, places=2)
         score = metric_score(golds, preds, probs=None, pos_label=2, metric="f1")
         self.assertAlmostEqual(score, 0.5, places=2)
 
     def test_fbeta(self):
-        golds = [1, 1, 1, 1, 2]
-        preds = [2, 2, 1, 1, 2]
+        golds = np.array([1, 1, 1, 1, 2])
+        preds = np.array([2, 2, 1, 1, 2])
         pre = metric_score(golds, preds, probs=None, metric="precision")
         rec = metric_score(golds, preds, probs=None, metric="recall")
         self.assertAlmostEqual(
@@ -122,18 +111,18 @@ class MetricsTest(unittest.TestCase):
         )
 
     def test_matthews(self):
-        golds = [1, 1, 1, 1, 2]
-        preds = [2, 1, 1, 1, 1]
+        golds = np.array([1, 1, 1, 1, 2])
+        preds = np.array([2, 1, 1, 1, 1])
         mcc = metric_score(golds, preds, probs=None, metric="matthews_corrcoef")
         self.assertAlmostEqual(mcc, -0.25)
 
-        golds = [1, 1, 1, 1, 2]
-        preds = [1, 1, 1, 1, 2]
+        golds = np.array([1, 1, 1, 1, 2])
+        preds = np.array([1, 1, 1, 1, 2])
         mcc = metric_score(golds, preds, probs=None, metric="matthews_corrcoef")
         self.assertAlmostEqual(mcc, 1.0)
 
     def test_roc_auc(self):
-        golds = [1, 1, 1, 1, 2]
+        golds = np.array([1, 1, 1, 1, 2])
         probs = np.array([[1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [1.0, 0.0], [0.0, 1.0]])
         probs_nonbinary = np.array(
             [

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -29,10 +29,10 @@ class MetricsTest(unittest.TestCase):
     def test_to_int_label_array(self):
         X = np.array([[1], [0], [2.0]])
         Y_expected = np.array([1, 0, 2])
-        Y = to_int_label_array(X, flatten=True)
+        Y = to_int_label_array(X, flatten_vector=True)
         np.testing.assert_array_equal(Y, Y_expected)
 
-        Y = to_int_label_array(X, flatten=False)
+        Y = to_int_label_array(X, flatten_vector=False)
         Y_expected = np.array([[1], [0], [2]])
         np.testing.assert_array_equal(Y, Y_expected)
 
@@ -42,7 +42,7 @@ class MetricsTest(unittest.TestCase):
 
         X = np.array([[1, 0], [0, 1]])
         with self.assertRaisesRegex(ValueError, "1d np.array"):
-            to_int_label_array(X, flatten=True)
+            to_int_label_array(X, flatten_vector=True)
 
     def test_pred_to_prob(self):
         np.testing.assert_array_equal(preds_to_probs(PREDS, 2), PREDS_ROUND)

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -7,7 +7,7 @@ from snorkel.analysis.utils import (
     filter_labels,
     preds_to_probs,
     probs_to_preds,
-    to_flattened_int_array,
+    to_int_label_array,
 )
 
 PROBS = np.array([[0.1, 0.9], [0.7, 0.3]])
@@ -26,23 +26,23 @@ class MetricsTest(unittest.TestCase):
             np.array([1, 1, 1]),
         )
 
-    def test_to_flattened_int_array(self):
-        X = np.array([[0.5]])
-        Y = to_flattened_int_array(X, cast_to_int=False, flatten=False)
-        np.testing.assert_array_equal(X, Y)
-
+    def test_to_int_label_array(self):
         X = np.array([[1], [0], [2.0]])
         Y_expected = np.array([1, 0, 2])
-        Y = to_flattened_int_array(X, cast_to_int=True, flatten=True)
+        Y = to_int_label_array(X, flatten=True)
+        np.testing.assert_array_equal(Y, Y_expected)
+
+        Y = to_int_label_array(X, flatten=False)
+        Y_expected = np.array([[1], [0], [2]])
         np.testing.assert_array_equal(Y, Y_expected)
 
         X = np.array([[1], [0], [2.1]])
         with self.assertRaisesRegex(ValueError, "non-integer value"):
-            to_flattened_int_array(X, cast_to_int=True)
+            to_int_label_array(X)
 
         X = np.array([[1, 0], [0, 1]])
         with self.assertRaisesRegex(ValueError, "1d np.array"):
-            to_flattened_int_array(X, flatten=True)
+            to_int_label_array(X, flatten=True)
 
     def test_pred_to_prob(self):
         np.testing.assert_array_equal(preds_to_probs(PREDS, 2), PREDS_ROUND)

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -3,11 +3,11 @@ import unittest
 import numpy as np
 
 from snorkel.analysis.utils import (
-    arraylike_to_numpy,
     convert_labels,
     filter_labels,
     preds_to_probs,
     probs_to_preds,
+    to_flattened_int_array,
 )
 
 PROBS = np.array([[0.1, 0.9], [0.7, 0.3]])
@@ -17,14 +17,7 @@ PREDS_ROUND = np.array([[0, 1], [1, 0]])
 
 class MetricsTest(unittest.TestCase):
     def test_inputs(self):
-        not_array = "112200"
         Y_nparray = np.ones((3,))
-        with self.assertRaisesRegex(ValueError, "Input could not be converted"):
-            arraylike_to_numpy(not_array)
-
-        with self.assertRaisesRegex(ValueError, "Unrecognized label data type"):
-            convert_labels(Y=not_array, source="categorical", target="plusminus")
-
         self.assertIsNone(
             convert_labels(Y=None, source="categorical", target="plusminus")
         )
@@ -32,6 +25,24 @@ class MetricsTest(unittest.TestCase):
             convert_labels(Y=Y_nparray, source="categorical", target="plusminus"),
             np.array([1, 1, 1]),
         )
+
+    def test_to_flattened_int_array(self):
+        X = np.array([[0.5]])
+        Y = to_flattened_int_array(X, cast_to_int=False, flatten=False)
+        np.testing.assert_array_equal(X, Y)
+
+        X = np.array([[1], [0], [2.0]])
+        Y_expected = np.array([1, 0, 2])
+        Y = to_flattened_int_array(X, cast_to_int=True, flatten=True)
+        np.testing.assert_array_equal(Y, Y_expected)
+
+        X = np.array([[1], [0], [2.1]])
+        with self.assertRaisesRegex(ValueError, "non-integer value"):
+            to_flattened_int_array(X, cast_to_int=True)
+
+        X = np.array([[1, 0], [0, 1]])
+        with self.assertRaisesRegex(ValueError, "1d np.array"):
+            to_flattened_int_array(X, flatten=True)
 
     def test_pred_to_prob(self):
         np.testing.assert_array_equal(preds_to_probs(PREDS, 2), PREDS_ROUND)

--- a/test/labeling/model/test_baseline.py
+++ b/test/labeling/model/test_baseline.py
@@ -1,6 +1,7 @@
 import unittest
 
 import numpy as np
+from scipy.sparse import csr_matrix
 
 from snorkel.labeling.model.baselines import (
     MajorityClassVoter,
@@ -11,7 +12,7 @@ from snorkel.labeling.model.baselines import (
 
 class BaselineModelTest(unittest.TestCase):
     def test_random_vote(self):
-        L = np.array([[1, 2, 1], [0, 4, 3], [3, 0, 0], [1, 2, 2]])
+        L = csr_matrix(np.array([[1, 2, 1], [0, 4, 3], [3, 0, 0], [1, 2, 2]]))
         rand_voter = RandomVoter()
         Y_p = rand_voter.predict_proba(L)
         self.assertLessEqual(Y_p.max(), 1.0)
@@ -21,7 +22,7 @@ class BaselineModelTest(unittest.TestCase):
         )
 
     def test_majority_class_vote(self):
-        L = np.array([[1, 2, 1], [2, 2, 1], [2, 2, 1], [0, 0, 2]])
+        L = csr_matrix(np.array([[1, 2, 1], [2, 2, 1], [2, 2, 1], [0, 0, 2]]))
         mc_voter = MajorityClassVoter()
         mc_voter.train_model(balance=[0.8, 0.2])
         Y_p = mc_voter.predict_proba(L)
@@ -30,7 +31,7 @@ class BaselineModelTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(Y_p, Y_p_true)
 
     def test_majority_label_vote(self):
-        L = np.array([[1, 2, 1], [1, 2, 1], [2, 1, 1], [0, 0, 2]])
+        L = csr_matrix(np.array([[1, 2, 1], [1, 2, 1], [2, 1, 1], [0, 0, 2]]))
         ml_voter = MajorityLabelVoter()
         Y_p = ml_voter.predict_proba(L)
 

--- a/test/labeling/model/test_baseline.py
+++ b/test/labeling/model/test_baseline.py
@@ -12,7 +12,7 @@ from snorkel.labeling.model.baselines import (
 
 class BaselineModelTest(unittest.TestCase):
     def test_random_vote(self):
-        L = csr_matrix(np.array([[1, 2, 1], [0, 4, 3], [3, 0, 0], [1, 2, 2]]))
+        L = csr_matrix([[1, 2, 1], [0, 4, 3], [3, 0, 0], [1, 2, 2]])
         rand_voter = RandomVoter()
         Y_p = rand_voter.predict_proba(L)
         self.assertLessEqual(Y_p.max(), 1.0)
@@ -22,7 +22,7 @@ class BaselineModelTest(unittest.TestCase):
         )
 
     def test_majority_class_vote(self):
-        L = csr_matrix(np.array([[1, 2, 1], [2, 2, 1], [2, 2, 1], [0, 0, 2]]))
+        L = csr_matrix([[1, 2, 1], [2, 2, 1], [2, 2, 1], [0, 0, 2]])
         mc_voter = MajorityClassVoter()
         mc_voter.train_model(balance=[0.8, 0.2])
         Y_p = mc_voter.predict_proba(L)
@@ -31,7 +31,7 @@ class BaselineModelTest(unittest.TestCase):
         np.testing.assert_array_almost_equal(Y_p, Y_p_true)
 
     def test_majority_label_vote(self):
-        L = csr_matrix(np.array([[1, 2, 1], [1, 2, 1], [2, 1, 1], [0, 0, 2]]))
+        L = csr_matrix([[1, 2, 1], [1, 2, 1], [2, 1, 1], [0, 0, 2]])
         ml_voter = MajorityLabelVoter()
         Y_p = ml_voter.predict_proba(L)
 

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -233,7 +233,7 @@ class LabelModelTest(unittest.TestCase):
         self.assertAlmostEqual(label_model._loss_mu().item(), 0.675, 3)
 
     def test_model_loss(self):
-        L = csr_matrix(np.array([[1, 0, 1], [1, 2, 1]]))
+        L = csr_matrix([[1, 0, 1], [1, 2, 1]])
         label_model = LabelModel(k=2, verbose=False)
 
         label_model.train_model(L, n_epochs=1, lr=0.01, momentum=0.9)
@@ -247,7 +247,7 @@ class LabelModelTest(unittest.TestCase):
             label_model.train_model(L, n_epochs=10, lr=1e8)
 
     def test_optimizer(self):
-        L = csr_matrix(np.array([[1, 0, 1], [1, 2, 1]]))
+        L = csr_matrix([[1, 0, 1], [1, 2, 1]])
         label_model = LabelModel(k=2, verbose=False)
         label_model.train_model(L, n_epochs=1, optimizer="rmsprop")
         label_model.train_model(L, n_epochs=1, optimizer="adam")
@@ -255,7 +255,7 @@ class LabelModelTest(unittest.TestCase):
             label_model.train_model(L, n_epochs=1, optimizer="bad_opt")
 
     def test_lr_scheduler(self):
-        L = csr_matrix(np.array([[1, 0, 1], [1, 2, 1]]))
+        L = csr_matrix([[1, 0, 1], [1, 2, 1]])
         label_model = LabelModel(k=2, verbose=False)
         label_model.train_model(L, n_epochs=1, lr_scheduler=None)
         label_model.train_model(L, n_epochs=1, lr_scheduler="exponential")
@@ -265,7 +265,7 @@ class LabelModelTest(unittest.TestCase):
             label_model.train_model(L, n_epochs=1, lr_scheduler="bad_scheduler")
 
     def test_save_and_load(self):
-        L = csr_matrix(np.array([[1, 0, 1], [1, 2, 1]]))
+        L = csr_matrix([[1, 0, 1], [1, 2, 1]])
         label_model = LabelModel(k=2, verbose=False)
         label_model.train_model(L, n_epochs=1, lr_scheduler=None)
         dir_path = tempfile.mkdtemp()

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -32,7 +32,7 @@ Y = [1, 2, 3, 1, 2, 3]
 
 class TestAnalysis(unittest.TestCase):
     def setUp(self) -> None:
-        self.L = sparse.csr_matrix(np.array(L))
+        self.L = sparse.csr_matrix(L)
         self.Y = np.array(Y)
 
     def test_label_coverage(self) -> None:


### PR DESCRIPTION
Get rid of `ArrayLike` and `arraylike_to_numpy`, cleaning up internal types significantly. Lots of little changes necessary. If we find specific places where a specific converter helper function would be useful we can add in later.

**Test plan**
* Added unit test for `to_int_label_array`
* Patched and reran existing unit tests