### PR TITLE
Add `predict(), score()` to LabelModel, add new tie breaking option

### DIFF
--- a/snorkel/analysis/utils.py
+++ b/snorkel/analysis/utils.py
@@ -13,7 +13,7 @@ def set_seed(seed: int) -> None:
     torch.manual_seed(seed)
 
 
-def _hash(i):
+def _hash(i: int) -> int:
     """Deterministic hash function."""
     byte_string = str(i).encode("utf-8")
     return int(hashlib.sha1(byte_string).hexdigest(), 16)

--- a/snorkel/analysis/utils.py
+++ b/snorkel/analysis/utils.py
@@ -19,10 +19,10 @@ def _hash(i: int) -> int:
     return int(hashlib.sha1(byte_string).hexdigest(), 16)
 
 
-def break_ties(
-    Y_prob: np.ndarray, tie_break_policy: Optional[str] = "random"
+def probs_to_preds(
+    probs: np.ndarray, tie_break_policy: Optional[str] = "random", tol: float = 1e-5
 ) -> np.ndarray:
-    """Break ties among probabilistic labels according to given policy.
+    """Convert an array of probabilistic labels into an array of predictions.
 
     Policies to break ties include:
     "abstain": return an abstain vote (0)
@@ -33,24 +33,33 @@ def break_ties(
 
     Parameters
     ----------
-    Y_prob
-        An [n,k] array of probabilistic labels
+    prob
+        A [num_datapoints, num_classes] array of probabilistic labels such that each
+        row sums to 1.
     tie_break_policy
-        Policy to break ties, by default 'random'
+        Policy to break ties when converting probabilistic labels to predictions, by default 'abstain'
+    tol
+        The minimum difference among probabilities to be considered a tie, by deafult 1e-5
+
 
     Returns
     -------
     np.ndarray
-        An [n] array of integer labels
+        A [n] array of predictions (integers in [1, ..., num_classes])
+
+    Examples
+    --------
+    >>> probs_to_preds(np.array([[0.5, 0.5, 0.5]]), tie_break_policy="abstain")
+    array([0])
+    >>> probs_to_preds(np.array([[0.8, 0.1, 0.1]]))
+    array([1])
     """
-
-    n, k = Y_prob.shape
+    n, k = probs.shape
     Y_pred = np.zeros(n)
-    diffs = np.abs(Y_prob - Y_prob.max(axis=1).reshape(-1, 1))
+    diffs = np.abs(probs - probs.max(axis=1).reshape(-1, 1))
 
-    TOL = 1e-5
     for i in range(n):
-        max_idxs = np.where(diffs[i, :] < TOL)[0]
+        max_idxs = np.where(diffs[i, :] < tol)[0]
         if len(max_idxs) == 1:
             Y_pred[i] = max_idxs[0] + 1
         # Deal with "tie votes" according to the specified policy
@@ -64,28 +73,7 @@ def break_ties(
             raise ValueError(
                 f"tie_break_policy={tie_break_policy} policy not recognized."
             )
-    return Y_pred
-
-
-def probs_to_preds(
-    probs: np.ndarray, tie_break_policy: Optional[str] = "random"
-) -> np.ndarray:
-    """Convert an array of probabilistic labels into an array of predictions.
-
-    Parameters
-    ----------
-    prob
-        A [num_datapoints, num_classes] array of probabilistic labels such that each
-        row sums to 1.
-    tie_break_policy
-            Policy to break ties when converting probabilistic labels to predictions, by default 'abstain'
-
-    Returns
-    -------
-    np.ndarray
-        A [num_datapoints, 1] array of predictions (integers in [1, ..., num_classes])
-    """
-    return break_ties(probs, tie_break_policy)
+    return Y_pred.astype(np.int)
 
 
 def preds_to_probs(preds: np.ndarray, num_classes: int) -> np.ndarray:

--- a/snorkel/analysis/utils.py
+++ b/snorkel/analysis/utils.py
@@ -1,3 +1,4 @@
+import hashlib
 import random
 from typing import Dict, List, Optional, Union
 
@@ -10,6 +11,12 @@ def set_seed(seed: int) -> None:
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
+
+
+def _hash(i):
+    """Deterministic hash function."""
+    byte_string = str(i).encode("utf-8")
+    return int(hashlib.sha1(byte_string).hexdigest(), 16)
 
 
 def break_ties(
@@ -34,7 +41,7 @@ def break_ties(
     Returns
     -------
     np.ndarray
-        An [n,1] array of integer labels
+        An [n] array of integer labels
     """
 
     n, k = Y_prob.shape
@@ -48,7 +55,7 @@ def break_ties(
             Y_pred[i] = max_idxs[0] + 1
         # Deal with "tie votes" according to the specified policy
         elif tie_break_policy == "random":
-            Y_pred[i] = max_idxs[i % len(max_idxs)] + 1
+            Y_pred[i] = max_idxs[_hash(i) % len(max_idxs)] + 1
         elif tie_break_policy == "true-random":
             Y_pred[i] = np.random.choice(max_idxs) + 1
         elif tie_break_policy == "abstain":

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -414,7 +414,7 @@ class LabelModel(nn.Module):
         array([1, 2, 1])
         """
         Y_probs = self.predict_proba(L)
-        Y_p = probs_to_preds(Y_probs, tie_break_policy).astype(np.int)
+        Y_p = probs_to_preds(Y_probs, tie_break_policy)
         if return_probs:
             return Y_p, Y_probs
         return Y_p

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -354,8 +354,10 @@ class LabelModel(nn.Module):
         >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
         >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
-        >>> label_model.predict_proba(L)
-        np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]])
+        >>> np.around(label_model.predict_proba(L), 1)
+        array([[1., 0.],
+               [0., 1.],
+               [1., 0.]])
         """
         L = L.todense()
         self._set_constants(L)
@@ -406,7 +408,7 @@ class LabelModel(nn.Module):
         Example
         -------
         >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
-        >>> label_model = LabelModel()
+        >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
         >>> label_model.predict(L)
         np.array([1, 2, 1])
@@ -448,7 +450,7 @@ class LabelModel(nn.Module):
         Example
         -------
         >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
-        >>> label_model = LabelModel()
+        >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
         >>> label_model.score(L, Y=np.array([1, 1, 1]))
         {'accuracy': 0.66667}
@@ -732,8 +734,7 @@ class LabelModel(nn.Module):
 
         Example
         -------
-        >>> label_model = LabelModel()
-        >>> label_model.save('./saved_label_model')
+        >>> label_model.save('./saved_label_model')  # doctest: +SKIP
         """
         with open(destination, "wb") as f:
             torch.save(self, f, **kwargs)
@@ -757,9 +758,7 @@ class LabelModel(nn.Module):
         Example
         -------
         Load parameters saved in ``saved_label_model``
-
-        >>> label_model = LabelModel()
-        >>> label_model.load('./saved_label_model')
+        >>> label_model.load('./saved_label_model')  # doctest: +SKIP
         """
         with open(source, "rb") as f:
             return torch.load(f, **kwargs)

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -368,7 +368,9 @@ class LabelModel(nn.Module):
         Z = np.tile(X.sum(axis=1).reshape(-1, 1), self.cardinality)
         return X / Z
 
-    def _break_ties(self, Y_prob: np.ndarray, break_ties: Optional[str] = 'abstain') -> np.ndarray:
+    def _break_ties(
+        self, Y_prob: np.ndarray, break_ties: Optional[str] = "abstain"
+    ) -> np.ndarray:
         """Break ties among probabilistic labels according to given policy.
 
         Policies to break ties include:
@@ -407,7 +409,9 @@ class LabelModel(nn.Module):
                 raise ValueError(f"break_ties={break_ties} policy not recognized.")
         return Y_pred
 
-    def predict(self, L: sparse.spmatrix, break_ties: Optional[str] = 'abstain') -> np.ndarray:
+    def predict(
+        self, L: sparse.spmatrix, break_ties: Optional[str] = "abstain"
+    ) -> np.ndarray:
         """Return predicted labels, with ties broken according to policy.
 
         Policies to break ties include:
@@ -439,7 +443,6 @@ class LabelModel(nn.Module):
         Y_probs = self.predict_proba(L)
         Y_p = self._break_ties(Y_probs, break_ties).astype(np.int)
         return Y_p
-
 
     # These loss functions get all their data directly from the LabelModel
     # (for better or worse). The unused *args make these compatible with the

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -463,45 +463,6 @@ class LabelModel(nn.Module):
         results = scorer.score(Y, Y_pred, Y_prob)
         return results
 
-    def score(
-        self,
-        L: sparse.spmatrix,
-        Y: np.ndarray,
-        metrics: Optional[List[str]] = ["accuracy"],
-    ) -> Dict[str, float]:
-        """Calculate one or more scores from user-specified and/or user-defined metrics.
-
-        Parameters
-        ----------
-        L
-            An [n,m] matrix with values in {0,1,...,k}
-        Y
-            Gold labels associated with datapoints in L
-        metrics
-            A list of metric names, by default ["accuracy"]
-
-        Returns
-        -------
-        Dict[str, float]
-            A dictionary mapping metric names to metric scores
-
-        Example
-        -------
-        >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
-        >>> label_model = LabelModel()
-        >>> label_model.train_model(L)
-        >>> label_model.score(L, Y=np.array([1, 1, 1]))
-        {'accuracy': 0.66667}
-        >>> label_model.score(L, Y=np.array([1, 1, 1], metrics=["f1"]))
-        {'accuracy': 0.66667}
-        """
-        Y_prob = self.predict_proba(L)
-        Y_pred = self.predict(L)
-
-        scorer = Scorer(metrics=metrics)
-        results = scorer.score(Y, Y_pred, Y_prob)
-        return results
-
     # These loss functions get all their data directly from the LabelModel
     # (for better or worse). The unused *args make these compatible with the
     # Classifer._train() method which expect loss functions to accept an input.

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -450,8 +450,10 @@ class LabelModel(nn.Module):
         >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
         >>> label_model = LabelModel()
         >>> label_model.train_model(L)
-        >>> label_model.predict(L)
-        np.array([1, 2, 1])
+        >>> label_model.score(L, Y=np.array([1, 1, 1]))
+        {'accuracy': 0.66667}
+        >>> label_model.score(L, Y=np.array([1, 1, 1]), metrics=["f1"])
+        {'f1': 0.8}
         """
         Y_pred, Y_prob = self.predict(
             L, return_probs=True, tie_break_policy=tie_break_policy

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -450,10 +450,8 @@ class LabelModel(nn.Module):
         >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
         >>> label_model = LabelModel()
         >>> label_model.train_model(L)
-        >>> label_model.score(L, Y=np.array([1, 1, 1]))
-        {'accuracy': 0.66667}
-        >>> label_model.score(L, Y=np.array([1, 1, 1]), metrics=["f1"])
-        {'f1': 0.8}
+        >>> label_model.predict(L)
+        np.array([1, 2, 1])
         """
         Y_pred, Y_prob = self.predict(
             L, return_probs=True, tie_break_policy=tie_break_policy

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -463,6 +463,45 @@ class LabelModel(nn.Module):
         results = scorer.score(Y, Y_pred, Y_prob)
         return results
 
+    def score(
+        self,
+        L: sparse.spmatrix,
+        Y: np.ndarray,
+        metrics: Optional[List[str]] = ["accuracy"],
+    ) -> Dict[str, float]:
+        """Calculate one or more scores from user-specified and/or user-defined metrics.
+
+        Parameters
+        ----------
+        L
+            An [n,m] matrix with values in {0,1,...,k}
+        Y
+            Gold labels associated with datapoints in L
+        metrics
+            A list of metric names, by default ["accuracy"]
+
+        Returns
+        -------
+        Dict[str, float]
+            A dictionary mapping metric names to metric scores
+
+        Example
+        -------
+        >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
+        >>> label_model = LabelModel()
+        >>> label_model.train_model(L)
+        >>> label_model.score(L, Y=np.array([1, 1, 1]))
+        {'accuracy': 0.66667}
+        >>> label_model.score(L, Y=np.array([1, 1, 1], metrics=["f1"]))
+        {'accuracy': 0.66667}
+        """
+        Y_prob = self.predict_proba(L)
+        Y_pred = self.predict(L)
+
+        scorer = Scorer(metrics=metrics)
+        results = scorer.score(Y, Y_pred, Y_prob)
+        return results
+
     # These loss functions get all their data directly from the LabelModel
     # (for better or worse). The unused *args make these compatible with the
     # Classifer._train() method which expect loss functions to accept an input.

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -320,7 +320,7 @@ class LabelModel(nn.Module):
         Example
         -------
         >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
-        >>> label_model = LabelModel()
+        >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
         >>> np.around(label_model.get_accuracies(), 2)
         array([0.9 , 0.9 , 0.01])
@@ -756,6 +756,7 @@ class LabelModel(nn.Module):
         Example
         -------
         Load parameters saved in ``saved_label_model``
+
         >>> label_model.load('./saved_label_model')  # doctest: +SKIP
         """
         with open(source, "rb") as f:

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -411,9 +411,7 @@ class LabelModel(nn.Module):
         >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
         >>> label_model.predict(L)
-        np.array([1, 2, 1])
-        >>> label_model.predict(L, return_probs=True)
-        (np.array([1, 2, 1]),  np.array([[1.0, 0.0], [0.0, 1.0], [1.0, 0.0]]))
+        array([1, 2, 1])
         """
         Y_probs = self.predict_proba(L)
         Y_p = probs_to_preds(Y_probs, tie_break_policy).astype(np.int)
@@ -453,7 +451,7 @@ class LabelModel(nn.Module):
         >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
         >>> label_model.score(L, Y=np.array([1, 1, 1]))
-        {'accuracy': 0.66667}
+        {'accuracy': 0.6666666666666666}
         >>> label_model.score(L, Y=np.array([1, 1, 1]), metrics=["f1"])
         {'f1': 0.8}
         """

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -49,11 +49,6 @@ class MetricsTest(unittest.TestCase):
     def test_pred_to_prob(self):
         np.testing.assert_array_equal(preds_to_probs(PREDS, 2), PREDS_ROUND)
 
-    def test_hash(self):
-        last_hash = _hash("hashtest")
-        for _ in range(4):
-            self.assertEqual(_hash("hashtest"), last_hash)
-
     def test_break_ties(self):
         # abtains with ties
         probs = np.array([[0.33, 0.33, 0.33]])

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -3,7 +3,10 @@ import unittest
 import numpy as np
 
 from snorkel.analysis.utils import (
+<<<<<<< HEAD
     _hash,
+=======
+>>>>>>> d012aefb... move tie_break, add tie_break to predict, add tests for tie break
     break_ties,
     convert_labels,
     filter_labels,

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -3,8 +3,6 @@ import unittest
 import numpy as np
 
 from snorkel.analysis.utils import (
-    _hash,
-    break_ties,
     convert_labels,
     filter_labels,
     preds_to_probs,
@@ -49,10 +47,12 @@ class MetricsTest(unittest.TestCase):
     def test_pred_to_prob(self):
         np.testing.assert_array_equal(preds_to_probs(PREDS, 2), PREDS_ROUND)
 
-    def test_break_ties(self):
+    def test_prob_to_pred(self):
+        np.testing.assert_array_equal(probs_to_preds(PROBS), PREDS)
+
         # abtains with ties
         probs = np.array([[0.33, 0.33, 0.33]])
-        preds = break_ties(probs, tie_break_policy="abstain")
+        preds = probs_to_preds(probs, tie_break_policy="abstain")
         true_preds = np.array([0.0])
         np.testing.assert_array_equal(preds, true_preds)
 
@@ -60,7 +60,7 @@ class MetricsTest(unittest.TestCase):
         probs = np.array([[0.33, 0.33, 0.33]])
         random_preds = []
         for seed in range(10):
-            preds = break_ties(probs, tie_break_policy="true-random")
+            preds = probs_to_preds(probs, tie_break_policy="true-random")
             random_preds.append(preds[0])
 
         # check predicted labels within range
@@ -73,7 +73,7 @@ class MetricsTest(unittest.TestCase):
         )
         random_preds = []
         for _ in range(10):
-            preds = break_ties(probs, tie_break_policy="random")
+            preds = probs_to_preds(probs, tie_break_policy="random")
             random_preds.append(preds)
 
         # check labels are same across seeds
@@ -86,10 +86,7 @@ class MetricsTest(unittest.TestCase):
 
         # check invalid policy
         with self.assertRaisesRegex(ValueError, "policy not recognized"):
-            preds = break_ties(probs, tie_break_policy="negative")
-
-    def test_prob_to_pred(self):
-        np.testing.assert_array_equal(probs_to_preds(PROBS), PREDS)
+            preds = probs_to_preds(probs, tie_break_policy="negative")
 
     def test_filter_labels(self):
         golds = np.array([0, 1, 1, 2, 2])

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -3,10 +3,7 @@ import unittest
 import numpy as np
 
 from snorkel.analysis.utils import (
-<<<<<<< HEAD
     _hash,
-=======
->>>>>>> d012aefb... move tie_break, add tie_break to predict, add tests for tie break
     break_ties,
     convert_labels,
     filter_labels,

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from snorkel.analysis.utils import (
+    _hash,
     break_ties,
     convert_labels,
     filter_labels,
@@ -48,6 +49,11 @@ class MetricsTest(unittest.TestCase):
     def test_pred_to_prob(self):
         np.testing.assert_array_equal(preds_to_probs(PREDS, 2), PREDS_ROUND)
 
+    def test_hash(self):
+        last_hash = _hash("hashtest")
+        for _ in range(4):
+            self.assertEqual(_hash("hashtest"), last_hash)
+
     def test_break_ties(self):
         # abtains with ties
         probs = np.array([[0.33, 0.33, 0.33]])
@@ -71,7 +77,7 @@ class MetricsTest(unittest.TestCase):
             [[0.33, 0.33, 0.33], [0.0, 0.5, 0.5], [0.33, 0.33, 0.33], [0.5, 0.5, 0]]
         )
         random_preds = []
-        for seed in range(10):
+        for _ in range(10):
             preds = break_ties(probs, tie_break_policy="random")
             random_preds.append(preds)
 

--- a/test/analysis/test_utils.py
+++ b/test/analysis/test_utils.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 
 from snorkel.analysis.utils import (
+    break_ties,
     convert_labels,
     filter_labels,
     preds_to_probs,
@@ -46,6 +47,45 @@ class MetricsTest(unittest.TestCase):
 
     def test_pred_to_prob(self):
         np.testing.assert_array_equal(preds_to_probs(PREDS, 2), PREDS_ROUND)
+
+    def test_break_ties(self):
+        # abtains with ties
+        probs = np.array([[0.33, 0.33, 0.33]])
+        preds = break_ties(probs, tie_break_policy="abstain")
+        true_preds = np.array([0.0])
+        np.testing.assert_array_equal(preds, true_preds)
+
+        # true random with ties
+        probs = np.array([[0.33, 0.33, 0.33]])
+        random_preds = []
+        for seed in range(10):
+            preds = break_ties(probs, tie_break_policy="true-random")
+            random_preds.append(preds[0])
+
+        # check predicted labels within range
+        self.assertLessEqual(max(random_preds), 3)
+        self.assertGreaterEqual(min(random_preds), 1)
+
+        # deterministic random with ties
+        probs = np.array(
+            [[0.33, 0.33, 0.33], [0.0, 0.5, 0.5], [0.33, 0.33, 0.33], [0.5, 0.5, 0]]
+        )
+        random_preds = []
+        for seed in range(10):
+            preds = break_ties(probs, tie_break_policy="random")
+            random_preds.append(preds)
+
+        # check labels are same across seeds
+        for i in range(len(random_preds) - 1):
+            np.testing.assert_array_equal(random_preds[i], random_preds[i + 1])
+
+        # check predicted labels within range (only one instance since should all be same)
+        self.assertLessEqual(max(random_preds[0]), 3)
+        self.assertGreaterEqual(min(random_preds[0]), 1)
+
+        # check invalid policy
+        with self.assertRaisesRegex(ValueError, "policy not recognized"):
+            preds = break_ties(probs, tie_break_policy="negative")
 
     def test_prob_to_pred(self):
         np.testing.assert_array_equal(probs_to_preds(PROBS), PREDS)

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -80,7 +80,7 @@ class ClassifierTest(unittest.TestCase):
         # deterministic random tie breaking alternates predicted labels
         np.testing.assert_array_equal(
             results["preds"]["task1"],
-            np.array([1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0]),
+            np.array([1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 2.0]),
         )
 
     def test_empty_batch(self):
@@ -96,7 +96,7 @@ class ClassifierTest(unittest.TestCase):
         model = SnorkelClassifier([self.task1])
         metrics = model.score([self.dataloader])
         # deterministic random tie breaking alternates predicted labels
-        self.assertEqual(metrics["task1/dataset/train/accuracy"], 0.5)
+        self.assertEqual(metrics["task1/dataset/train/accuracy"], 0.6)
 
     def test_save_load(self):
         fd, checkpoint_path = tempfile.mkstemp()

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -77,8 +77,10 @@ class ClassifierTest(unittest.TestCase):
 
         results = model.predict(self.dataloader, return_preds=True)
         self.assertEqual(sorted(list(results.keys())), ["golds", "preds", "probs"])
+        # deterministic random tie breaking alternates predicted labels
         np.testing.assert_array_equal(
-            results["preds"]["task1"], np.ones((NUM_EXAMPLES,))
+            results["preds"]["task1"],
+            np.array([1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0]),
         )
 
     def test_empty_batch(self):
@@ -93,7 +95,8 @@ class ClassifierTest(unittest.TestCase):
     def test_score(self):
         model = SnorkelClassifier([self.task1])
         metrics = model.score([self.dataloader])
-        self.assertEqual(metrics["task1/dataset/train/accuracy"], 1.0)
+        # deterministic random tie breaking alternates predicted labels
+        self.assertEqual(metrics["task1/dataset/train/accuracy"], 0.5)
 
     def test_save_load(self):
         fd, checkpoint_path = tempfile.mkstemp()

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -247,34 +247,6 @@ class LabelModelTest(unittest.TestCase):
         results_expected = dict(accuracy=0.5, f1=2 / 3)
         self.assertEqual(results, results_expected)
 
-    def test_break_ties(self):
-        #abtains with ties
-        label_model = LabelModel(k=3)
-        probs = np.array([[0.33, 0.33, 0.33]])
-        preds = label_model._break_ties(probs, break_ties='abstain')
-        true_preds = np.array([0.])
-        np.testing.assert_array_equal(preds, true_preds)
-
-        #random with ties
-        probs = np.array([[0.33, 0.33, 0.33]])
-        random_preds = []
-        for seed in range(10):
-            label_model = LabelModel(k=3, seed=seed)
-            preds = label_model._break_ties(probs, break_ties='random')
-            random_preds.append(preds[0])
-
-        #check predicted labels within range
-        self.assertLessEqual(max(random_preds), 3)
-        self.assertGreaterEqual(min(random_preds), 1)
-
-        #check labels are different across seeds
-        for class_idx in range(1, 4):
-            self.assertGreaterEqual(random_preds.count(class_idx), 1)
-
-        #check invalid policy
-        with self.assertRaises(ValueError):
-            preds = label_model._break_ties(probs, break_ties='negative')
-
     def test_loss(self):
         L = np.array([[1, 0, 1], [1, 2, 0]])
         label_model = self._set_up_model(L)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -247,6 +247,34 @@ class LabelModelTest(unittest.TestCase):
         results_expected = dict(accuracy=0.5, f1=2 / 3)
         self.assertEqual(results, results_expected)
 
+    def test_break_ties(self):
+        #abtains with ties
+        label_model = LabelModel(k=3)
+        probs = np.array([[0.33, 0.33, 0.33]])
+        preds = label_model._break_ties(probs, break_ties='abstain')
+        true_preds = np.array([0.])
+        np.testing.assert_array_equal(preds, true_preds)
+
+        #random with ties
+        probs = np.array([[0.33, 0.33, 0.33]])
+        random_preds = []
+        for seed in range(10):
+            label_model = LabelModel(k=3, seed=seed)
+            preds = label_model._break_ties(probs, break_ties='random')
+            random_preds.append(preds[0])
+
+        #check predicted labels within range
+        self.assertLessEqual(max(random_preds), 3)
+        self.assertGreaterEqual(min(random_preds), 1)
+
+        #check labels are different across seeds
+        for class_idx in range(1, 4):
+            self.assertGreaterEqual(random_preds.count(class_idx), 1)
+
+        #check invalid policy
+        with self.assertRaises(ValueError):
+            preds = label_model._break_ties(probs, break_ties='negative')
+
     def test_loss(self):
         L = np.array([[1, 0, 1], [1, 2, 0]])
         label_model = self._set_up_model(L)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -253,7 +253,7 @@ class LabelModelTest(unittest.TestCase):
             self.assertGreaterEqual(random_preds.count(class_idx), 1)
 
         # check invalid policy
-        with self.assertRaisesRegexp(ValueError, "policy not recognized"):
+        with self.assertRaisesRegex(ValueError, "policy not recognized"):
             preds = label_model._break_ties(probs, break_ties="negative")
 
     def test_score(self):

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -228,33 +228,9 @@ class LabelModelTest(unittest.TestCase):
         true_preds = np.array([1, 1])
         np.testing.assert_array_equal(preds, true_preds)
 
-    def test_break_ties(self):
-        # abtains with ties
-        label_model = LabelModel(k=3)
-        probs = np.array([[0.33, 0.33, 0.33]])
-        preds = label_model._break_ties(probs, break_ties="abstain")
-        true_preds = np.array([0.0])
-        np.testing.assert_array_equal(preds, true_preds)
-
-        # random with ties
-        probs = np.array([[0.33, 0.33, 0.33]])
-        random_preds = []
-        for seed in range(10):
-            label_model = LabelModel(k=3, seed=seed)
-            preds = label_model._break_ties(probs, break_ties="random")
-            random_preds.append(preds[0])
-
-        # check predicted labels within range
-        self.assertLessEqual(max(random_preds), 3)
-        self.assertGreaterEqual(min(random_preds), 1)
-
-        # check labels are different across seeds
-        for class_idx in range(1, 4):
-            self.assertGreaterEqual(random_preds.count(class_idx), 1)
-
-        # check invalid policy
-        with self.assertRaisesRegex(ValueError, "policy not recognized"):
-            preds = label_model._break_ties(probs, break_ties="negative")
+        preds, probs = label_model.predict(csr_matrix(L), return_probs=True)
+        true_probs = np.array([[0.99, 0.01], [0.99, 0.01]])
+        np.testing.assert_array_almost_equal(probs, true_probs)
 
     def test_score(self):
         L = np.array([[1, 2, 1], [1, 2, 1]])
@@ -268,7 +244,7 @@ class LabelModelTest(unittest.TestCase):
         results = label_model.score(
             L=csr_matrix(L), Y=np.array([2, 1]), metrics=["accuracy", "f1"]
         )
-        results_expected = dict(accuracy=0.5, f1=2 / 3.0)
+        results_expected = dict(accuracy=0.5, f1=2 / 3)
         self.assertEqual(results, results_expected)
 
     def test_loss(self):

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -253,8 +253,23 @@ class LabelModelTest(unittest.TestCase):
             self.assertGreaterEqual(random_preds.count(class_idx), 1)
 
         # check invalid policy
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegexp(ValueError, "policy not recognized"):
             preds = label_model._break_ties(probs, break_ties="negative")
+
+    def test_score(self):
+        L = np.array([[1, 2, 1], [1, 2, 1]])
+        label_model = self._set_up_model(L)
+        label_model.mu = nn.Parameter(label_model.mu_init.clone())
+
+        results = label_model.score(csr_matrix(L), Y=np.array([1, 2]))
+        results_expected = dict(accuracy=0.5)
+        self.assertEqual(results, results_expected)
+
+        results = label_model.score(
+            L=csr_matrix(L), Y=np.array([2, 1]), metrics=["accuracy", "f1"]
+        )
+        results_expected = dict(accuracy=0.5, f1=2 / 3.0)
+        self.assertEqual(results, results_expected)
 
     def test_loss(self):
         L = np.array([[1, 0, 1], [1, 2, 0]])

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -229,32 +229,32 @@ class LabelModelTest(unittest.TestCase):
         np.testing.assert_array_equal(preds, true_preds)
 
     def test_break_ties(self):
-        #abtains with ties
+        # abtains with ties
         label_model = LabelModel(k=3)
         probs = np.array([[0.33, 0.33, 0.33]])
-        preds = label_model._break_ties(probs, break_ties='abstain')
-        true_preds = np.array([0.])
+        preds = label_model._break_ties(probs, break_ties="abstain")
+        true_preds = np.array([0.0])
         np.testing.assert_array_equal(preds, true_preds)
 
-        #random with ties
+        # random with ties
         probs = np.array([[0.33, 0.33, 0.33]])
         random_preds = []
         for seed in range(10):
             label_model = LabelModel(k=3, seed=seed)
-            preds = label_model._break_ties(probs, break_ties='random')
+            preds = label_model._break_ties(probs, break_ties="random")
             random_preds.append(preds[0])
 
-        #check predicted labels within range
+        # check predicted labels within range
         self.assertLessEqual(max(random_preds), 3)
         self.assertGreaterEqual(min(random_preds), 1)
 
-        #check labels are different across seeds
+        # check labels are different across seeds
         for class_idx in range(1, 4):
             self.assertGreaterEqual(random_preds.count(class_idx), 1)
 
-        #check invalid policy
+        # check invalid policy
         with self.assertRaises(ValueError):
-            preds = label_model._break_ties(probs, break_ties='negative')
+            preds = label_model._break_ties(probs, break_ties="negative")
 
     def test_loss(self):
         L = np.array([[1, 0, 1], [1, 2, 0]])


### PR DESCRIPTION
* Add `predict()` to LabelModel
* Add `score()` function to LabelModel

* Add `break_ties()` to `snorkel/analysis/utils.py` to help convert probabilistic labels to integer labels
     * Add `random` and `true-random` options for tie breaking: first is truly random and second is deterministically random
     * use `prob_to_pred` in LabelModel `predict()` function


__Test Plan__
* Add tests for `predict()` and `score()` in LabelModel tests
* Add tests for `tie_break()` in utils tests
* Add tests for both random options
* Fix `snorkel/classifier` tests to match deterministic random tie breaking results 