### PR TITLE
Fix SlicingConvergenceTest

### DIFF
--- a/test/labeling/test_convergence.py
+++ b/test/labeling/test_convergence.py
@@ -65,7 +65,7 @@ def f(x: DataPoint, divisor: int) -> int:
 
 class LabelingConvergenceTest(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
         # Ensure deterministic runs
         set_seed(123)
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -45,7 +45,7 @@ def h(x: DataPoint) -> int:
 
 class SlicingConvergenceTest(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
         # Ensure deterministic runs
         set_seed(123)
 
@@ -87,7 +87,9 @@ class SlicingConvergenceTest(unittest.TestCase):
         model = SnorkelClassifier(tasks=tasks)
 
         # Train
-        trainer = Trainer(lr=0.001, n_epochs=50, progress_bar=False)
+        trainer = Trainer(
+            **{"optimizer_config": {"lr": 0.001}}, n_epochs=50, progress_bar=False
+        )
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 
@@ -138,7 +140,9 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Train
         # NOTE: Needs more epochs to convergence with more heads
-        trainer = Trainer(lr=0.001, n_epochs=110, progress_bar=False)
+        trainer = Trainer(
+            **{"optimizer_config": {"lr": 0.001}}, n_epochs=110, progress_bar=False
+        )
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -88,7 +88,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Train
         trainer = Trainer(
-            **{"optimizer_config": {"lr": 0.001}}, n_epochs=50, progress_bar=False
+            optimizer_config={"lr": 0.001}, n_epochs=50, progress_bar=False
         )
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)
@@ -141,7 +141,7 @@ class SlicingConvergenceTest(unittest.TestCase):
         # Train
         # NOTE: Needs more epochs to convergence with more heads
         trainer = Trainer(
-            **{"optimizer_config": {"lr": 0.001}}, n_epochs=110, progress_bar=False
+            optimizer_config={"lr": 0.001}, n_epochs=110, progress_bar=False
         )
         trainer.train_model(model, dataloaders)
         scores = model.score(dataloaders)

--- a/test/slicing/test_slice_combiner.py
+++ b/test/slicing/test_slice_combiner.py
@@ -9,7 +9,7 @@ from snorkel.slicing.modules.slice_combiner import SliceCombinerModule
 
 class SliceCombinerTest(unittest.TestCase):
     @classmethod
-    def setup_class(cls):
+    def setUpClass(cls):
         set_seed(123)
 
     def test_forward_shape(self):


### PR DESCRIPTION
- Update setUpClass to be recognized by unittest
- Update Trainer intialization to get nested dict (`recursive_merge_dict` is no longer available to find the appropriate depth to update `lr`)

**Test plan:**
Complex tests pass again (were broken).