### PR TITLE
Add doctest to check docstring examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,19 +15,19 @@ jobs:
     - if: type = pull_request
       name: "Python 3.6: unit tests"
       python: 3.6
-      env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      env: TOXENV=coverage,doctest,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - if: type = pull_request
       name: "Python 3.7: unit tests"
       python: 3.7
-      env: TOXENV=coverage,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      env: TOXENV=coverage,doctest,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - if: type != pull_request
       name: "Python 3.6: unit + integration tests"
       python: 3.6
-      env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      env: TOXENV=coverage,complex,spark,doctest,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
     - if: type != pull_request
       name: "Python 3.7: unit + integration tests"
       python: 3.7
-      env: TOXENV=coverage,complex,spark,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+      env: TOXENV=coverage,complex,spark,doctest,type,check TOX_INSTALL_DIR=.env JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 
 # Install JDK8 for PySpark tests
 before_install:

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,4 +49,5 @@ mypy
 pydocstyle
 pytest
 pytest-cov
+pytest-doctestplus
 tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,10 @@ markers =
     spark
     complex
 norecursedirs = .tox
+doctest_optionflags =
+    NORMALIZE_WHITESPACE
+    ELLIPSIS
+    FLOAT_CMP
 
 [flake8]
 ignore =

--- a/snorkel/labeling/lf/nlp.py
+++ b/snorkel/labeling/lf/nlp.py
@@ -80,12 +80,12 @@ class NLPLabelingFunction(LabelingFunction):
 
     Example
     -------
-    >>> def f(x: DataPoint) -> int:
+    >>> def f(x):
     ...     person_ents = [ent for ent in x.doc.ents if ent.label_ == "PERSON"]
     ...     return 1 if len(person_ents) > 0 else 0
     >>> has_person_mention = NLPLabelingFunction(name="has_person_mention", f=f)
     >>> has_person_mention
-    NLPLabelingFunction has_person_mention
+    NLPLabelingFunction has_person_mention, Preprocessors: [SpacyPreprocessor...]
 
     >>> from types import SimpleNamespace
     >>> x = SimpleNamespace(text="The movie was good.")
@@ -167,11 +167,11 @@ class nlp_labeling_function:
     Example
     -------
     >>> @nlp_labeling_function()
-    ... def has_person_mention(x: DataPoint) -> int:
+    ... def has_person_mention(x):
     ...     person_ents = [ent for ent in x.doc.ents if ent.label_ == "PERSON"]
     ...     return 1 if len(person_ents) > 0 else 0
     >>> has_person_mention
-    NLPLabelingFunction has_person_mention
+    NLPLabelingFunction has_person_mention, Preprocessors: [SpacyPreprocessor...]
 
     >>> from types import SimpleNamespace
     >>> x = SimpleNamespace(text="The movie was good.")

--- a/snorkel/labeling/model/baselines.py
+++ b/snorkel/labeling/model/baselines.py
@@ -133,7 +133,7 @@ class MajorityLabelVoter(BaselineVoter):
 
         Example
         -------
-        >>> L = np.array([[1, 1, 0], [0, 1, 2], [2, 0, 1]])
+        >>> L = sparse.csr_matrix([[1, 1, 0], [0, 1, 2], [2, 0, 1]])
         >>> maj_voter = MajorityLabelVoter()
         >>> maj_voter.predict_proba(L)
         array([[1. , 0. ],

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -318,11 +318,11 @@ class LabelModel(nn.Module):
 
         Example
         -------
-        >>> L = np.array([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
-        >>> label_model = LabelModel()
+        >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
+        >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
-        >>> label_model.get_accuracies()
-        array([0.9, 0.9, 0.01])
+        >>> np.around(label_model.get_accuracies(), 2)
+        array([0.9 , 0.9 , 0.01])
         """
         accs = np.zeros(self.m)
         for i in range(self.m):
@@ -351,10 +351,12 @@ class LabelModel(nn.Module):
         Example
         -------
         >>> L = sparse.csr_matrix([[1, 1, 0], [2, 2, 0], [1, 1, 0]])
-        >>> label_model = LabelModel()
+        >>> label_model = LabelModel(verbose=False)
         >>> label_model.train_model(L)
-        >>> label_model.predict_proba(L)
-        np.array([1.0, 0.0], [0.0, 1.0], [1.0, 0.0])
+        >>> np.around(label_model.predict_proba(L), 1)
+        array([[1., 0.],
+               [0., 1.],
+               [1., 0.]])
         """
         L = L.todense()
         self._set_constants(L)
@@ -455,7 +457,7 @@ class LabelModel(nn.Module):
         metrics_dict = {"train/loss": self.running_loss / self.running_examples}
 
         if self.logger.check():
-            self.logger.log(metrics_dict)
+            self.logger.log(metrics_dict if self.config["verbose"] else None)
 
             # Reset running loss and examples counts
             self.running_loss = 0.0
@@ -544,9 +546,9 @@ class LabelModel(nn.Module):
 
         Examples
         --------
-        >>> L = np.array([[1, 1, 0], [0, 1, 2], [2, 0, 1]])
+        >>> L = sparse.csr_matrix([[1, 1, 0], [0, 1, 2], [2, 0, 1]])
         >>> Y_dev = [1, 2, 1]
-        >>> label_model = LabelModel()
+        >>> label_model = LabelModel(n_epochs=10, verbose=False)
         >>> label_model.train_model(L)
         >>> label_model.train_model(L, Y_dev=Y_dev)
         >>> label_model.train_model(L, class_balance=[0.7, 0.3])
@@ -637,7 +639,7 @@ class LabelModel(nn.Module):
 
         Example
         -------
-        >>> label_model.save('./saved_label_model')
+        >>> label_model.save('./saved_label_model')  # doctest: +SKIP
         """
         with open(destination, "wb") as f:
             torch.save(self, f, **kwargs)
@@ -662,7 +664,7 @@ class LabelModel(nn.Module):
         -------
         Load parameters saved in ``saved_label_model``
 
-        >>> label_model.load('./saved_label_model')
+        >>> label_model.load('./saved_label_model')  # doctest: +SKIP
         """
         with open(source, "rb") as f:
             return torch.load(f, **kwargs)

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -457,7 +457,8 @@ class LabelModel(nn.Module):
         metrics_dict = {"train/loss": self.running_loss / self.running_examples}
 
         if self.logger.check():
-            self.logger.log(metrics_dict if self.config["verbose"] else None)
+            if self.config["verbose"]:
+                self.logger.log(metrics_dict)
 
             # Reset running loss and examples counts
             self.running_loss = 0.0

--- a/snorkel/labeling/model/logger.py
+++ b/snorkel/labeling/model/logger.py
@@ -50,7 +50,7 @@ class Logger:
         -------
         >>> logger = Logger(log_train_every=5)
         >>> metrics_dict = {"train/loss": 5.00}
-        >>> logger.print_to_screen(metrics_dict)
+        >>> logger.log(metrics_dict)
         [0 epochs]: TRAIN:[loss=5.000]
         """
         score_strings: DefaultDict[str, List[str]] = defaultdict(list)

--- a/snorkel/labeling/model/logger.py
+++ b/snorkel/labeling/model/logger.py
@@ -34,23 +34,6 @@ class Logger:
         return self.unit_count - 1 % self.log_train_every == 0
 
     def log(self, metrics_dict: Dict[str, float]) -> None:
-        """Print calculated metrics and optionally write to file (json/tb).
-
-        Parameters
-        ----------
-        metrics_dict
-            Dictionary of metric names (keys) and values to log
-
-        Example
-        -------
-        >>> logger = Logger(log_train_every=5)
-        >>> metrics_dict = {"train/loss": 5.00}
-        >>> logger.log(metrics_dict)
-        [0 epochs]: TRAIN:[loss=5.000]
-        """
-        self.print_to_screen(metrics_dict)
-
-    def print_to_screen(self, metrics_dict: Dict[str, float]) -> None:
         """Print all metrics in metrics_dict to screen.
 
         Parameters

--- a/test/labeling/apply/lf_applier_spark_test_script.py
+++ b/test/labeling/apply/lf_applier_spark_test_script.py
@@ -34,7 +34,7 @@ from typing import List
 import numpy as np
 from pyspark import SparkContext
 
-from snorkel.labeling.apply.lf_applier_spark import SparkLFApplier
+from snorkel.labeling.apply.spark import SparkLFApplier
 from snorkel.labeling.lf import labeling_function
 from snorkel.types import DataPoint
 

--- a/test/labeling/model/test_logger.py
+++ b/test/labeling/model/test_logger.py
@@ -4,9 +4,17 @@ from snorkel.labeling.model.logger import Logger
 
 
 class LoggerTest(unittest.TestCase):
+    def test_basic(self):
+        metrics_dict = {"train/loss": 0.01}
+        logger = Logger(log_train_every=1)
+        logger.log(metrics_dict)
+
+        metrics_dict = {"train/message": "well done!"}
+        logger = Logger(log_train_every=1)
+        logger.log(metrics_dict)
+
     def test_bad_metrics_dict(self):
         bad_metrics_dict = {"task1/slice1/train/loss": 0.05}
-
         logger = Logger(log_train_every=1)
         self.assertRaises(Exception, logger.log, bad_metrics_dict)
 

--- a/test/labeling/model/test_logger.py
+++ b/test/labeling/model/test_logger.py
@@ -8,12 +8,12 @@ class LoggerTest(unittest.TestCase):
         bad_metrics_dict = {"task1/slice1/train/loss": 0.05}
 
         logger = Logger(log_train_every=1)
-        self.assertRaises(Exception, logger.print_to_screen, bad_metrics_dict)
+        self.assertRaises(Exception, logger.log, bad_metrics_dict)
 
     def test_valid_metrics_dict(self):
         mtl_metrics_dict = {"task1/valid/loss": 0.05}
         logger = Logger(log_train_every=1)
-        logger.print_to_screen(mtl_metrics_dict)
+        logger.log(mtl_metrics_dict)
 
 
 if __name__ == "__main__":

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
     py37,
     type,
     check,
+    doctest,
 isolated_build = true
 
 [testenv]
@@ -32,6 +33,11 @@ commands = python -m pytest -m spark {posargs}
 [testenv:complex]
 description = run the test driver for integration tests with {basepython}
 commands = python -m pytest -m 'complex and not spark' {posargs}
+
+[testenv:doctest]
+description = run doctest
+skipsdist = true
+commands = python -m pytest --doctest-plus snorkel
 
 [testenv:check]
 description = check the code and doc style


### PR DESCRIPTION
Use `pytest-doctestplus` to check our docstring examples. Fixes a few docstring examples to comply.

Also cleans up logger which had two identical functions.

**Test plan**
Manually check Travis execution