### PR TITLE
Add metrics helpers

### DIFF
--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -20,9 +20,9 @@ def error_buckets(
 
     Parameters
     ----------
-    gold
+    golds
         An np.ndarray of gold (int) labels
-    pred
+    preds
         An np.ndarray of (int) predictions
     X
         Optional, a sequence of examples corresponding to golds/preds
@@ -32,8 +32,7 @@ def error_buckets(
     -------
     Dict
         A mapping of each error bucket to its corresponding indices/examples
-        If X is None, return indices
-            instead.
+        If X is None, return indices instead.
     """
     buckets: Mapping[Tuple[int, int], List[Any]] = defaultdict(list)
     golds = to_int_label_array(golds)

--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -37,8 +37,8 @@ def error_buckets(
     buckets: Mapping[Tuple[int, int], List[Any]] = defaultdict(list)
     golds = to_int_label_array(golds)
     preds = to_int_label_array(preds)
-    for i, (y, l) in enumerate(zip(preds, golds)):
-        buckets[y, l].append(X[i] if X is not None else i)
+    for i, (l, y) in enumerate(zip(preds, golds)):
+        buckets[(l, y)].append(X[i] if X is not None else i)
     return dict(buckets)
 
 

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -76,7 +76,9 @@ def metric_score(
     return func(*inputs, **kwargs)
 
 
-def predictions_score(golds, preds, metric, **kwargs):
+def predictions_score(
+    golds: np.ndarray, preds: np.ndarray, metric: np.ndarray, **kwargs: Any
+) -> float:
     """Wrap metric_score() and pass probs=None."""
     if "probs" in METRICS[metric].inputs:
         raise ValueError(
@@ -86,7 +88,9 @@ def predictions_score(golds, preds, metric, **kwargs):
     return metric_score(golds=golds, preds=preds, probs=None, metric=metric, **kwargs)
 
 
-def probabilities_score(golds, probs, metric, **kwargs):
+def probabilities_score(
+    golds: np.ndarray, probs: np.ndarray, metric: np.ndarray, **kwargs: Any
+) -> float:
     """Wrap metric_score() and pass preds=None."""
     if "preds" in METRICS[metric].inputs:
         raise ValueError(

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -76,6 +76,20 @@ def metric_score(
     return func(*inputs, **kwargs)
 
 
+def predictions_score(golds, preds, metric, **kwargs):
+    """A thin wrapper around metric_score() that passes probs=None"""
+    if "probs" in METRICS[metric].inputs:
+        raise ValueError(f"predictions_score() is not compatible with metric {metric}. Use metric_score() or probability_score() instead.")
+    return metric_score(golds=golds, preds=preds, probs=None, metric=metric, **kwargs)
+
+
+def probabilities_score(golds, probs, metric, **kwargs):
+    """A thin wrapper around metric_score() that passes preds=None"""
+    if "preds" in METRICS[metric].inputs:
+        raise ValueError(f"probabilities_score() is not compatible with metric {metric}. Use metric_score() or predictions_score() instead.")
+    return metric_score(golds=golds, preds=None, probs=probs, metric=metric, **kwargs)
+
+
 def _coverage_score(preds: np.ndarray) -> float:
     return np.sum(preds != 0) / len(preds)
 

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -77,16 +77,22 @@ def metric_score(
 
 
 def predictions_score(golds, preds, metric, **kwargs):
-    """A thin wrapper around metric_score() that passes probs=None"""
+    """Wrap metric_score() and pass probs=None."""
     if "probs" in METRICS[metric].inputs:
-        raise ValueError(f"predictions_score() is not compatible with metric {metric}. Use metric_score() or probability_score() instead.")
+        raise ValueError(
+            f"predictions_score() is not compatible with metric {metric}. "
+            "Use metric_score() or probability_score() instead."
+        )
     return metric_score(golds=golds, preds=preds, probs=None, metric=metric, **kwargs)
 
 
 def probabilities_score(golds, probs, metric, **kwargs):
-    """A thin wrapper around metric_score() that passes preds=None"""
+    """Wrap metric_score() and pass preds=None."""
     if "preds" in METRICS[metric].inputs:
-        raise ValueError(f"probabilities_score() is not compatible with metric {metric}. Use metric_score() or predictions_score() instead.")
+        raise ValueError(
+            f"probabilities_score() is not compatible with metric {metric}. "
+            "Use metric_score() or predictions_score() instead."
+        )
     return metric_score(golds=golds, preds=None, probs=probs, metric=metric, **kwargs)
 
 

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, Dict, List, NamedTuple, Optional
 import numpy as np
 import sklearn.metrics as skmetrics
 
-from .utils import filter_labels, probs_to_preds, to_int_label_array
+from .utils import filter_labels, to_int_label_array
 
 
 class Metric(NamedTuple):
@@ -69,16 +69,8 @@ def metric_score(
             )
         label_dict = filter_labels(label_dict, filter_dict)
 
-    # If preds are required but only probs were given, calculate preds from probs
-    func, label_names = METRICS[metric]
-    if (
-        "preds" in label_names
-        and label_dict["preds"] is None
-        and label_dict["probs"] is not None
-    ):
-        label_dict["preds"] = probs_to_preds(label_dict["probs"])
-
     # Confirm that required label sets are available
+    func, label_names = METRICS[metric]
     for label_name in label_names:
         if label_dict[label_name] is None:
             raise ValueError("Metric {metric} requires access to {label_name}.")

--- a/snorkel/analysis/utils.py
+++ b/snorkel/analysis/utils.py
@@ -168,7 +168,7 @@ def filter_labels(
     for label_name, filter_values in filter_dict.items():
         if label_dict[label_name] is not None:
             masks.append(_get_mask(label_dict[label_name], filter_values))
-    mask = np.multiply(*masks) if len(masks) > 1 else masks[0]
+    mask = (np.multiply(*masks) if len(masks) > 1 else masks[0]).squeeze()
 
     filtered = {}
     for label_name, label_array in label_dict.items():

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -150,11 +150,6 @@ class MetricsTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "requires access to"):
             metric_score(golds=golds, metric="accuracy")
 
-    def test_probs_to_preds_conversion(self):
-        golds = np.array([1, 1, 2, 2])
-        probs = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
-        self.assertEqual(metric_score(golds=golds, probs=probs, metric="accuracy"), 0.5)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -2,7 +2,11 @@ import unittest
 
 import numpy as np
 
-from snorkel.analysis.metrics import metric_score, predictions_score, probabilities_score
+from snorkel.analysis.metrics import (
+    metric_score,
+    predictions_score,
+    probabilities_score,
+)
 
 
 class MetricsTest(unittest.TestCase):

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -2,11 +2,7 @@ import unittest
 
 import numpy as np
 
-from snorkel.analysis.metrics import (
-    metric_score,
-    predictions_score,
-    probabilities_score,
-)
+from snorkel.analysis.metrics import metric_score
 
 
 class MetricsTest(unittest.TestCase):
@@ -149,19 +145,15 @@ class MetricsTest(unittest.TestCase):
         ):
             metric_score(golds, preds=None, probs=probs_nonbinary, metric="roc_auc")
 
-    def test_predictions_score(self):
+    def test_missing_preds(self):
         golds = np.array([1, 1, 2, 2])
-        preds = np.array([1, 2, 1, 2])
-        self.assertEqual(predictions_score(golds, preds, "accuracy"), 0.5)
-        with self.assertRaisesRegex(ValueError, "is not compatible with"):
-            predictions_score(golds, preds, "roc_auc")
+        with self.assertRaisesRegex(ValueError, "requires access to"):
+            metric_score(golds=golds, metric="accuracy")
 
-    def test_probabilities_score(self):
+    def test_probs_to_preds_conversion(self):
         golds = np.array([1, 1, 2, 2])
         probs = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
-        self.assertEqual(probabilities_score(golds, probs, "roc_auc"), 0.5)
-        with self.assertRaisesRegex(ValueError, "is not compatible with"):
-            probabilities_score(golds, probs, "accuracy")
+        self.assertEqual(metric_score(golds=golds, probs=probs, metric="accuracy"), 0.5)
 
 
 if __name__ == "__main__":

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from snorkel.analysis.metrics import metric_score
+from snorkel.analysis.metrics import metric_score, predictions_score, probabilities_score
 
 
 class MetricsTest(unittest.TestCase):
@@ -144,6 +144,20 @@ class MetricsTest(unittest.TestCase):
             ValueError, "Metric roc_auc is currently only defined for binary"
         ):
             metric_score(golds, preds=None, probs=probs_nonbinary, metric="roc_auc")
+
+    def test_predictions_score(self):
+        golds = np.array([1, 1, 2, 2])
+        preds = np.array([1, 2, 1, 2])
+        self.assertEqual(predictions_score(golds, preds, "accuracy"), 0.5)
+        with self.assertRaisesRegex(ValueError, "is not compatible with"):
+            predictions_score(golds, preds, "roc_auc")
+
+    def test_probabilities_score(self):
+        golds = np.array([1, 1, 2, 2])
+        probs = np.array([[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]])
+        self.assertEqual(probabilities_score(golds, probs, "roc_auc"), 0.5)
+        with self.assertRaisesRegex(ValueError, "is not compatible with"):
+            probabilities_score(golds, probs, "accuracy")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
People (ourselves included) are going to want to use the metrics methods outside of the scorer, and currently that requires an argument for golds, preds, _and_ probs, when no metric actually ever requires both preds and probs. These two skinny wrappers let the user be explicit about what they're passing and reduce extra/unnecessary passing of `None`s.

**Test plan:**
New unit tests confirm that they work as expected and raise errors when they should.