### PR TITLE
Cleanup checkpointer + fix checkpoint_metric silent failure from malformed naming

### DIFF
--- a/snorkel/classification/training/loggers/checkpointer.py
+++ b/snorkel/classification/training/loggers/checkpointer.py
@@ -62,6 +62,7 @@ class Checkpointer:
         self, counter_unit: str, evaluation_freq: float, **kwargs: Any
     ) -> None:
         self.config = CheckpointerConfig(**kwargs)
+        self._validate_config()
 
         # Pull out checkpoint settings
         self.checkpoint_unit = counter_unit
@@ -70,9 +71,6 @@ class Checkpointer:
         self.checkpoint_runway = self.config.checkpoint_runway
         self.checkpoint_factor = self.config.checkpoint_factor
         self.checkpoint_condition_met = False
-
-        if self.checkpoint_dir is None:
-            raise ValueError("Checkpointing is on but no checkpoint_dir was specified.")
 
         # Collect all metrics to checkpoint
         self.checkpoint_metric = self._make_metric_map([self.config.checkpoint_metric])
@@ -198,6 +196,16 @@ class Checkpointer:
             model.load(best_model_path)
 
         return model
+
+    def _validate_config(self) -> None:
+        if self.config.checkpoint_dir is None:
+            raise ValueError("Checkpointing is on but no checkpoint_dir was specified.")
+
+        split_checkpoint_metric = self.config.checkpoint_metric.split("/")
+        if len(split_checkpoint_metric) != 4:
+            raise ValueError(
+                "checkpoint_metric must be formatted 'task/dataset/split/metric:mode'."
+            )
 
     def _make_metric_map(
         self, metric_mode_iter: Optional[Iterable[str]]

--- a/snorkel/classification/training/loggers/checkpointer.py
+++ b/snorkel/classification/training/loggers/checkpointer.py
@@ -199,9 +199,6 @@ class Checkpointer:
         return model
 
     def _validate_config(self) -> None:
-        if self.config.checkpoint_dir is None:
-            raise ValueError("Checkpointing is on but no checkpoint_dir was specified.")
-
         split_checkpoint_metric = self.config.checkpoint_metric.split("/")
         if len(split_checkpoint_metric) != 4:
             raise ValueError(
@@ -211,7 +208,7 @@ class Checkpointer:
         if self.config.checkpoint_runway < 0:
             raise ValueError(
                 f"Invalid checkpoint_runway {self.config.checkpoint_runway}, "
-                f"must be greater than 0."
+                f"must be greater than or equal to 0."
             )
 
     def _make_metric_map(

--- a/snorkel/classification/training/loggers/checkpointer.py
+++ b/snorkel/classification/training/loggers/checkpointer.py
@@ -35,7 +35,7 @@ class CheckpointerConfig(Config):
         If True, clear all checkpoints besides the best so far.
     """
 
-    checkpoint_dir: Optional[str] = None
+    checkpoint_dir: str = "checkpoints"
     checkpoint_factor: int = 1
     checkpoint_metric: str = "model/all/train/loss:min"
     checkpoint_task_metrics: Optional[List[str]] = None
@@ -88,18 +88,19 @@ class Checkpointer:
         if self.checkpoint_freq <= 0:
             raise ValueError(
                 f"Invalid checkpoint freq {self.checkpoint_freq}, "
-                f"must be greater 0."
+                f"must be greater than 0."
             )
 
         logging.info(
-            f"Save checkpoints at {self.checkpoint_dir} every "
+            f"Save checkpoints at '{self.checkpoint_dir}' every "
             f"{self.checkpoint_freq} {self.checkpoint_unit}."
         )
 
-        logging.info(
-            f"No checkpoints will be saved before {self.checkpoint_runway} "
-            f"{self.checkpoint_unit}."
-        )
+        if self.checkpoint_runway > 0:
+            logging.info(
+                f"No checkpoints will be saved before {self.checkpoint_runway} "
+                f"{self.checkpoint_unit}."
+            )
 
         self.best_metric_dict: Dict[str, float] = {}
 
@@ -205,6 +206,12 @@ class Checkpointer:
         if len(split_checkpoint_metric) != 4:
             raise ValueError(
                 "checkpoint_metric must be formatted 'task/dataset/split/metric:mode'."
+            )
+
+        if self.config.checkpoint_runway < 0:
+            raise ValueError(
+                f"Invalid checkpoint_runway {self.config.checkpoint_runway}, "
+                f"must be greater than 0."
             )
 
     def _make_metric_map(

--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -343,16 +343,6 @@ class Trainer:
 
         if self.config.checkpointing:
             checkpointer_config = self.config.checkpointer_config
-
-            # Default checkpoint_dir to log_dir if available
-            if (
-                checkpointer_config.checkpoint_dir is None
-                and self.log_writer is not None
-            ):
-                checkpointer_config = checkpointer_config._replace(
-                    checkpoint_dir=self.log_writer.log_dir
-                )
-
             evaluation_freq = self.config.log_manager_config.evaluation_freq
             counter_unit = self.config.log_manager_config.counter_unit
             self.checkpointer = Checkpointer(

--- a/test/classification/training/loggers/test_checkpointer.py
+++ b/test/classification/training/loggers/test_checkpointer.py
@@ -76,6 +76,10 @@ class TestLogManager(unittest.TestCase):
         load_model = checkpointer.load_best_model(model)
         self.assertEqual(model, load_model)
 
+    def test_bad_checkpoint_runway(self) -> None:
+        with self.assertRaisesRegex(ValueError, "checkpoint_runway"):
+            Checkpointer(**log_manager_config, checkpoint_runway=-1)
+
     def test_no_checkpoint_dir(self) -> None:
         with self.assertRaisesRegex(ValueError, "no checkpoint_dir"):
             Checkpointer(**log_manager_config, checkpoint_dir=None)

--- a/test/classification/training/loggers/test_checkpointer.py
+++ b/test/classification/training/loggers/test_checkpointer.py
@@ -21,43 +21,47 @@ class TestLogManager(unittest.TestCase):
             **log_manager_config,
             checkpoint_dir=self.test_dir,
             checkpoint_runway=3,
-            checkpoint_metric="f1:max",
+            checkpoint_metric="task/dataset/valid/f1:max",
         )
         model = SnorkelClassifier([])
-        checkpointer.checkpoint(2, model, dict(f1=0.5))
+        checkpointer.checkpoint(2, model, {"task/dataset/valid/f1": 0.5})
         self.assertEqual(len(checkpointer.best_metric_dict), 0)
-        checkpointer.checkpoint(3, model, dict(f1=0.8, f2=0.5))
-        self.assertEqual(checkpointer.best_metric_dict["f1"], 0.8)
-        checkpointer.checkpoint(4, model, dict(f1=0.9))
-        self.assertEqual(checkpointer.best_metric_dict["f1"], 0.9)
+        checkpointer.checkpoint(
+            3, model, {"task/dataset/valid/f1": 0.8, "task/dataset/valid/f2": 0.5}
+        )
+        self.assertEqual(checkpointer.best_metric_dict["task/dataset/valid/f1"], 0.8)
+        checkpointer.checkpoint(4, model, {"task/dataset/valid/f1": 0.9})
+        self.assertEqual(checkpointer.best_metric_dict["task/dataset/valid/f1"], 0.9)
 
     def test_checkpointer_min(self) -> None:
         checkpointer = Checkpointer(
             **log_manager_config,
             checkpoint_dir=self.test_dir,
             checkpoint_runway=3,
-            checkpoint_metric="f1:min",
+            checkpoint_metric="task/dataset/valid/f1:min",
         )
         model = SnorkelClassifier([])
-        checkpointer.checkpoint(3, model, dict(f1=0.8, f2=0.5))
-        self.assertEqual(checkpointer.best_metric_dict["f1"], 0.8)
-        checkpointer.checkpoint(4, model, dict(f1=0.7))
-        self.assertEqual(checkpointer.best_metric_dict["f1"], 0.7)
+        checkpointer.checkpoint(
+            3, model, {"task/dataset/valid/f1": 0.8, "task/dataset/valid/f2": 0.5}
+        )
+        self.assertEqual(checkpointer.best_metric_dict["task/dataset/valid/f1"], 0.8)
+        checkpointer.checkpoint(4, model, {"task/dataset/valid/f1": 0.7})
+        self.assertEqual(checkpointer.best_metric_dict["task/dataset/valid/f1"], 0.7)
 
     def test_checkpointer_clear(self) -> None:
         checkpoint_dir = os.path.join(self.test_dir, "clear")
         checkpointer = Checkpointer(
             **log_manager_config,
             checkpoint_dir=checkpoint_dir,
-            checkpoint_metric="f1:max",
+            checkpoint_metric="task/dataset/valid/f1:max",
             checkpoint_clear=True,
         )
         model = SnorkelClassifier([])
-        checkpointer.checkpoint(1, model, dict(f1=0.8))
-        expected_files = ["checkpoint_1.pth", "best_model_f1.pth"]
+        checkpointer.checkpoint(1, model, {"task/dataset/valid/f1": 0.8})
+        expected_files = ["checkpoint_1.pth", "best_model_task_dataset_valid_f1.pth"]
         self.assertEqual(set(os.listdir(checkpoint_dir)), set(expected_files))
         checkpointer.clear()
-        expected_files = ["best_model_f1.pth"]
+        expected_files = ["best_model_task_dataset_valid_f1.pth"]
         self.assertEqual(os.listdir(checkpoint_dir), expected_files)
 
     def test_checkpointer_load_best(self) -> None:
@@ -65,10 +69,10 @@ class TestLogManager(unittest.TestCase):
         checkpointer = Checkpointer(
             **log_manager_config,
             checkpoint_dir=checkpoint_dir,
-            checkpoint_metric="f1:max",
+            checkpoint_metric="task/dataset/valid/f1:max",
         )
         model = SnorkelClassifier([])
-        checkpointer.checkpoint(1, model, dict(f1=0.8))
+        checkpointer.checkpoint(1, model, {"task/dataset/valid/f1": 0.8})
         load_model = checkpointer.load_best_model(model)
         self.assertEqual(model, load_model)
 
@@ -87,12 +91,19 @@ class TestLogManager(unittest.TestCase):
             Checkpointer(
                 **log_manager_config,
                 checkpoint_dir=self.test_dir,
-                checkpoint_metric="f1-min",
+                checkpoint_metric="task/dataset/split/f1-min",
             )
 
         with self.assertRaisesRegex(ValueError, "metric mode"):
             Checkpointer(
                 **log_manager_config,
                 checkpoint_dir=self.test_dir,
-                checkpoint_metric="f1:mode",
+                checkpoint_metric="task/dataset/split/f1:mode",
+            )
+
+        with self.assertRaisesRegex(ValueError, "checkpoint_metric must be formatted"):
+            Checkpointer(
+                **log_manager_config,
+                checkpoint_dir=self.test_dir,
+                checkpoint_metric="accuracy:max",
             )

--- a/test/classification/training/loggers/test_checkpointer.py
+++ b/test/classification/training/loggers/test_checkpointer.py
@@ -80,10 +80,6 @@ class TestLogManager(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "checkpoint_runway"):
             Checkpointer(**log_manager_config, checkpoint_runway=-1)
 
-    def test_no_checkpoint_dir(self) -> None:
-        with self.assertRaisesRegex(ValueError, "no checkpoint_dir"):
-            Checkpointer(**log_manager_config, checkpoint_dir=None)
-
     def test_no_zero_frequency(self) -> None:
         with self.assertRaisesRegex(ValueError, "checkpoint freq"):
             Checkpointer(

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -95,18 +95,20 @@ class TrainerTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temp_dir:
             more_config = {
                 "checkpointing": True,
-                "checkpointer_config": {"checkpoint_dir": None},
+                "checkpointer_config": {"checkpoint_dir": temp_dir},
                 "log_writer_config": {"log_dir": temp_dir},
             }
             trainer = Trainer(**base_config, **more_config, logging=True)
             trainer.train_model(model, [dataloaders[0]])
             self.assertIsNotNone(trainer.checkpointer)
-            self.assertEqual(
-                trainer.checkpointer.checkpoint_dir, trainer.log_writer.log_dir
-            )
 
+            broken_config = {
+                "checkpointing": True,
+                "checkpointer_config": {"checkpoint_dir": None},
+                "log_writer_config": {"log_dir": temp_dir},
+            }
             with self.assertRaisesRegex(ValueError, "Checkpointing is on but"):
-                trainer = Trainer(**base_config, **more_config, logging=False)
+                trainer = Trainer(**base_config, **broken_config, logging=False)
                 trainer.train_model(model, [dataloaders[0]])
 
     def test_log_writer_init(self):

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -107,7 +107,7 @@ class TrainerTest(unittest.TestCase):
                 "checkpointer_config": {"checkpoint_dir": None},
                 "log_writer_config": {"log_dir": temp_dir},
             }
-            with self.assertRaisesRegex(ValueError, "Checkpointing is on but"):
+            with self.assertRaises(TypeError):
                 trainer = Trainer(**base_config, **broken_config, logging=False)
                 trainer.train_model(model, [dataloaders[0]])
 


### PR DESCRIPTION
1. BugFix: Silent checkpointing failure
https://github.com/HazyResearch/snorkel/blob/redux/snorkel/classification/training/loggers/checkpointer.py#L138-L139 is never triggered for checkpointing.

When the `checkpointer_config` is specified in the form `metric:mode`, checkpointing silently fails:
```
trainer_config = {
    "progress_bar": True,
    "n_epochs": 10,
    "optimizer_config":{"lr": 1e-5},
    "checkpointing": True,
    "checkpointer_config": {
        "checkpoint_dir": "checkpoints",
        "checkpoint_metric": "spam_task/spam_dataset/valid/accuracy:max"
    }
}

trainer = Trainer(**trainer_config)
```

* `checkpoint_task_metrics` is populated with `checkpoint_metric`, which is usually specified as `metric:mode` in the tests
* however, `checkpoint_metric` never passed as `metric:mode` in end to end training, because it always end up being passed into the checkpointer as `task/dataset/split/metric:mode`

so, it silently fails to checkpoint if `checkpoint_metric` is of the form `metric:mode`, instead of `task/dataset/split/metric:mode`

2. Cleanup: Decouple `checkpoint_dir` from `log_writer.log_dir`—they are set completely independently for now.
3. Cleanup: Add `checkpoint_runway` validation (cannot be < 0) 

**Test Plan**
* Added additional test under `test_bad_metric_name`
* Fixed previous tests with correctly formatted metrics
* Add additional unit tests for (2) / (3)
* Pass with `tox -e complex` and full `tox`