### PR TITLE
Add muticlass F1 support, fix Scorer() test

### DIFF
--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -96,7 +96,7 @@ def _f1_score(golds: np.ndarray, preds: np.ndarray) -> float:
         return skmetrics.f1_score(golds, preds)
     else:
         raise ValueError(
-            "f1 not supported for multiclass. Try f1_micro aor f1_macro instead."
+            "f1 not supported for multiclass. Try f1_micro or f1_macro instead."
         )
 
 

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -95,7 +95,17 @@ def _f1_score(golds: np.ndarray, preds: np.ndarray) -> float:
     if golds.max() <= 1:
         return skmetrics.f1_score(golds, preds)
     else:
-        return skmetrics.f1_score(golds, preds, average="micro")
+        raise ValueError(
+            "f1 not supported for multiclass. Try f1_micro aor f1_macro instead."
+        )
+
+
+def _f1_micro_score(golds: np.ndarray, preds: np.ndarray) -> float:
+    return skmetrics.f1_score(golds, preds, average="micro")
+
+
+def _f1_macro_score(golds: np.ndarray, preds: np.ndarray) -> float:
+    return skmetrics.f1_score(golds, preds, average="macro")
 
 
 # See https://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics
@@ -106,6 +116,8 @@ METRICS = {
     "precision": Metric(skmetrics.precision_score),
     "recall": Metric(skmetrics.recall_score),
     "f1": Metric(_f1_score, ["golds", "preds"]),
+    "f1_micro": Metric(_f1_micro_score, ["golds", "preds"]),
+    "f1_macro": Metric(_f1_macro_score, ["golds", "preds"]),
     "fbeta": Metric(skmetrics.fbeta_score),
     "matthews_corrcoef": Metric(skmetrics.matthews_corrcoef),
     "roc_auc": Metric(_roc_auc_score, ["golds", "probs"]),

--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -91,6 +91,13 @@ def _roc_auc_score(golds: np.ndarray, probs: np.ndarray) -> float:
     return skmetrics.roc_auc_score(golds, probs[:, 0])
 
 
+def _f1_score(golds: np.ndarray, preds: np.ndarray) -> float:
+    if golds.max() <= 1:
+        return skmetrics.f1_score(golds, preds)
+    else:
+        return skmetrics.f1_score(golds, preds, average="micro")
+
+
 # See https://scikit-learn.org/stable/modules/classes.html#module-sklearn.metrics
 # for details on the definitions and available kwargs for all metrics from scikit-learn
 METRICS = {
@@ -98,7 +105,7 @@ METRICS = {
     "coverage": Metric(_coverage_score, ["preds"]),
     "precision": Metric(skmetrics.precision_score),
     "recall": Metric(skmetrics.recall_score),
-    "f1": Metric(skmetrics.f1_score),
+    "f1": Metric(_f1_score, ["golds", "preds"]),
     "fbeta": Metric(skmetrics.fbeta_score),
     "matthews_corrcoef": Metric(skmetrics.matthews_corrcoef),
     "roc_auc": Metric(_roc_auc_score, ["golds", "probs"]),

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -88,11 +88,19 @@ class MetricsTest(unittest.TestCase):
         score = metric_score(golds, preds, probs=None, metric="f1")
         self.assertAlmostEqual(score, 0.4)
 
-        # Test Multiclass F1
         golds = np.array([0, 0, 1, 1, 2])
         preds = np.array([1, 1, 0, 1, 2])
-        score = metric_score(golds, preds, probs=None, metric="f1")
+        with self.assertRaisesRegex(ValueError, "f1 not supported for multiclass"):
+            score = metric_score(golds, preds, probs=None, metric="f1")
+
+    def test_f1_multiclass(self):
+        golds = np.array([0, 0, 1, 1, 2])
+        preds = np.array([1, 1, 0, 1, 2])
+        score = metric_score(golds, preds, probs=None, metric="f1_micro")
         self.assertAlmostEqual(score, 0.4)
+
+        score = metric_score(golds, preds, probs=None, metric="f1_macro")
+        self.assertAlmostEqual(score, 0.47, 2)
 
     def test_fbeta(self):
         golds = np.array([0, 0, 0, 0, 1])

--- a/test/analysis/test_metrics.py
+++ b/test/analysis/test_metrics.py
@@ -88,6 +88,12 @@ class MetricsTest(unittest.TestCase):
         score = metric_score(golds, preds, probs=None, metric="f1")
         self.assertAlmostEqual(score, 0.4)
 
+        # Test Multiclass F1
+        golds = np.array([0, 0, 1, 1, 2])
+        preds = np.array([1, 1, 0, 1, 2])
+        score = metric_score(golds, preds, probs=None, metric="f1")
+        self.assertAlmostEqual(score, 0.4)
+
     def test_fbeta(self):
         golds = np.array([0, 0, 0, 0, 1])
         preds = np.array([1, 1, 0, 0, 1])

--- a/test/classification/test_scorer.py
+++ b/test/classification/test_scorer.py
@@ -8,8 +8,8 @@ from snorkel.classification.scorer import Scorer
 
 class ScorerTest(unittest.TestCase):
     def _get_labels(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        golds = np.array([1, 2, 1, 2, 1])
-        preds = np.array([1, 2, 1, 1, 2])
+        golds = np.array([1, 0, 1, 0, 1])
+        preds = np.array([1, 0, 1, 1, 0])
         probs = np.array([0.8, 0.6, 0.9, 0.7, 0.4])
         return golds, preds, probs
 
@@ -22,7 +22,7 @@ class ScorerTest(unittest.TestCase):
         )
 
         results = scorer.score(*self._get_labels())
-        results_expected = dict(accuracy=0.6, f1=2 / 3, pred_sum=7)
+        results_expected = dict(accuracy=0.6, f1=2 / 3, pred_sum=3)
         self.assertEqual(results, results_expected)
 
     def test_dict_metric(self) -> None:


### PR DESCRIPTION
* Add options for multi class F1 score (micro and macro)
* Fix Scorer test that used old label convention

__Test Plan__
* Added to metrics test to cover multi class F1 
* Fix Scorer test case