### PR TITLE
Make accuracy scorer the default

### DIFF
--- a/snorkel/classification/task.py
+++ b/snorkel/classification/task.py
@@ -97,7 +97,7 @@ class Task:
         name: str,
         module_pool: nn.ModuleDict,
         task_flow: List[Operation],
-        scorer: Scorer,
+        scorer: Scorer = Scorer(metrics=["accuracy"]),
         loss_func: Optional[Callable[..., torch.Tensor]] = None,
         output_func: Optional[Callable[..., torch.Tensor]] = None,
     ) -> None:

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -7,7 +7,6 @@ import torch
 import torch.nn as nn
 
 from snorkel.classification.data import DictDataLoader, DictDataset
-from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
 
 NUM_EXAMPLES = 10

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -169,7 +169,6 @@ def create_task(task_name, module_suffixes=("", "")):
         name=task_name,
         module_pool=module_pool,
         task_flow=task_flow,
-        scorer=Scorer(metrics=["accuracy"]),
     )
 
     return task

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -165,11 +165,7 @@ def create_task(task_name, module_suffixes=("", "")):
 
     task_flow = [op0, op1]
 
-    task = Task(
-        name=task_name,
-        module_pool=module_pool,
-        task_flow=task_flow,
-    )
+    task = Task(name=task_name, module_pool=module_pool, task_flow=task_flow)
 
     return task
 

--- a/test/classification/test_task.py
+++ b/test/classification/test_task.py
@@ -32,7 +32,6 @@ class TaskTest(unittest.TestCase):
             name=TASK_NAME,
             module_pool=module_pool,
             task_flow=task_flow,
-            scorer=Scorer(metrics=["accuracy"]),
         )
 
         # Task has no functionality on its own

--- a/test/classification/test_task.py
+++ b/test/classification/test_task.py
@@ -28,11 +28,7 @@ class TaskTest(unittest.TestCase):
             ),
         ]
 
-        task = Task(
-            name=TASK_NAME,
-            module_pool=module_pool,
-            task_flow=task_flow,
-        )
+        task = Task(name=TASK_NAME, module_pool=module_pool, task_flow=task_flow)
 
         # Task has no functionality on its own
         # Here we only confirm that the object was initialized

--- a/test/classification/test_task.py
+++ b/test/classification/test_task.py
@@ -2,7 +2,6 @@ import unittest
 
 import torch.nn as nn
 
-from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, Task
 
 TASK_NAME = "TestTask"

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -47,11 +47,7 @@ def create_task(task_name, module_suffixes=("", "")):
 
     task_flow = [op1, op2]
 
-    task = Task(
-        name=task_name,
-        module_pool=module_pool,
-        task_flow=task_flow,
-    )
+    task = Task(name=task_name, module_pool=module_pool, task_flow=task_flow)
 
     return task
 

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -7,7 +7,6 @@ import torch.nn as nn
 import torch.optim as optim
 
 from snorkel.classification.data import DictDataLoader, DictDataset
-from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, SnorkelClassifier, Task
 from snorkel.classification.training import Trainer
 from snorkel.classification.training.loggers import LogWriter, TensorBoardWriter

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -51,7 +51,6 @@ def create_task(task_name, module_suffixes=("", "")):
         name=task_name,
         module_pool=module_pool,
         task_flow=task_flow,
-        scorer=Scorer(metrics=["accuracy"]),
     )
 
     return task

--- a/test/slicing/test_utils.py
+++ b/test/slicing/test_utils.py
@@ -122,9 +122,5 @@ def create_dummy_task(task_name):
         ),
     ]
 
-    task = Task(
-        name=task_name,
-        module_pool=module_pool,
-        task_flow=task_flow,
-    )
+    task = Task(name=task_name, module_pool=module_pool, task_flow=task_flow)
     return task

--- a/test/slicing/test_utils.py
+++ b/test/slicing/test_utils.py
@@ -126,6 +126,5 @@ def create_dummy_task(task_name):
         name=task_name,
         module_pool=module_pool,
         task_flow=task_flow,
-        scorer=Scorer(metrics=["accuracy"]),
     )
     return task

--- a/test/slicing/test_utils.py
+++ b/test/slicing/test_utils.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn as nn
 
 from snorkel.classification.data import DictDataLoader, DictDataset
-from snorkel.classification.scorer import Scorer
 from snorkel.classification.snorkel_classifier import Operation, Task
 from snorkel.slicing.apply import PandasSFApplier
 from snorkel.slicing.sf import slicing_function


### PR DESCRIPTION
Make the default Scorer for tasks be accuracy. This fits with the default loss_func and output_func being cross-entropy and softmax; our default is a standard classification task.

**Test plan**
`tox`