### PR TITLE
Fix no labels edge case

### DIFF
--- a/snorkel/labeling/apply/core.py
+++ b/snorkel/labeling/apply/core.py
@@ -33,9 +33,11 @@ class BaseLFApplier:
         self._lfs = lfs
 
     def _matrix_from_row_data(self, labels: List[RowData]) -> np.ndarray:
-        row, col, data = zip(*chain.from_iterable(labels))
         L = np.zeros((len(labels), len(self._lfs)), dtype=int) - 1
-        L[row, col] = data
+        # NB: this check will short-circuit, so ok for large L
+        if any(map(len, labels)) > 0:
+            row, col, data = zip(*chain.from_iterable(labels))
+            L[row, col] = data
         return L
 
 

--- a/snorkel/labeling/apply/core.py
+++ b/snorkel/labeling/apply/core.py
@@ -35,7 +35,7 @@ class BaseLFApplier:
     def _matrix_from_row_data(self, labels: List[RowData]) -> np.ndarray:
         L = np.zeros((len(labels), len(self._lfs)), dtype=int) - 1
         # NB: this check will short-circuit, so ok for large L
-        if any(map(len, labels)) > 0:
+        if any(map(len, labels)):
             row, col, data = zip(*chain.from_iterable(labels))
             L[row, col] = data
         return L

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -45,6 +45,11 @@ def g(x: DataPoint, db: List[int]) -> int:
     return 0 if x.num in db else -1
 
 
+@labeling_function()
+def h(x: DataPoint) -> int:
+    return -1
+
+
 DATA = [3, 43, 12, 9, 3]
 L_EXPECTED = np.array([[-1, 0], [0, -1], [-1, -1], [-1, 0], [-1, 0]])
 L_PREPROCESS_EXPECTED = np.array([[-1, -1], [0, 0], [-1, 0], [-1, 0], [-1, -1]])
@@ -83,6 +88,12 @@ class TestLFApplier(unittest.TestCase):
         L = applier.apply(data_points)
         np.testing.assert_equal(L, L_PREPROCESS_EXPECTED)
         self.assertEqual(square_hit_tracker.n_hits, 4)
+
+    def test_lf_applier_no_labels(self) -> None:
+        data_points = [SimpleNamespace(num=num) for num in DATA]
+        applier = LFApplier([h, h])
+        L = applier.apply(data_points)
+        np.testing.assert_equal(L, -1)
 
 
 class TestPandasApplier(unittest.TestCase):


### PR DESCRIPTION
Used to throw an ambiguous ValueError if there are no labels returned by any LFs. This fixes that edge case. Not error-worthy, since it's a valid label matrix (e.g. for a single, very precise LF on a small dev set)

**Test plan**
TDD, added new test case to verify catch