### PR TITLE
Catch no parens on LFs/mappers

### DIFF
--- a/snorkel/labeling/lf/core.py
+++ b/snorkel/labeling/lf/core.py
@@ -108,6 +108,10 @@ class labeling_function:
     ...     return 0 if x.a > 42 else -1
     >>> f
     LabelingFunction f, Preprocessors: []
+    >>> from types import SimpleNamespace
+    >>> x = SimpleNamespace(a=90, b=12)
+    >>> f(x)
+    0
 
     >>> @labeling_function(name="my_lf")
     ... def g(x):
@@ -123,6 +127,8 @@ class labeling_function:
         preprocessors: Optional[List[BasePreprocessor]] = None,
         fault_tolerant: bool = False,
     ) -> None:
+        if callable(name):
+            raise ValueError("Looks like this decorator is missing parentheses!")
         self.name = name
         self.resources = resources
         self.preprocessors = preprocessors

--- a/snorkel/labeling/lf/nlp.py
+++ b/snorkel/labeling/lf/nlp.py
@@ -3,7 +3,7 @@ from typing import Any, Callable, List, Mapping, NamedTuple, Optional
 from snorkel.labeling.preprocess import BasePreprocessor
 from snorkel.labeling.preprocess.nlp import EN_CORE_WEB_SM, SpacyPreprocessor
 
-from .core import LabelingFunction
+from .core import LabelingFunction, labeling_function
 
 
 class SpacyPreprocessorParameters(NamedTuple):
@@ -156,7 +156,7 @@ class NLPLabelingFunction(LabelingFunction):
         )
 
 
-class nlp_labeling_function:
+class nlp_labeling_function(labeling_function):
     """Decorator to define an NLPLabelingFunction object from a function.
 
     Parameters
@@ -191,10 +191,7 @@ class nlp_labeling_function:
         disable: Optional[List[str]] = None,
         memoize: bool = True,
     ) -> None:
-        self.name = name
-        self.resources = resources
-        self.preprocessors = preprocessors
-        self.fault_tolerant = fault_tolerant
+        super().__init__(name, resources, preprocessors, fault_tolerant)
         self.text_field = text_field
         self.doc_field = doc_field
         self.language = language

--- a/snorkel/slicing/apply/dask.py
+++ b/snorkel/slicing/apply/dask.py
@@ -1,4 +1,7 @@
-from snorkel.labeling.apply.dask import DaskLFApplier, PandasParallelLFApplier
+from snorkel.labeling.apply.dask import (  # pragma: no cover
+    DaskLFApplier,
+    PandasParallelLFApplier,
+)
 
 
 class DaskSFApplier(DaskLFApplier):  # pragma: no cover

--- a/test/labeling/lf/test_core.py
+++ b/test/labeling/lf/test_core.py
@@ -100,3 +100,10 @@ class TestLabelingFunction(unittest.TestCase):
         self.assertEqual(lf.name, "my_lf")
         self._run_lf(lf)
         self._run_lf_no_raise(lf)
+
+    def test_labeling_function_decorator_no_parens(self) -> None:
+        with self.assertRaisesRegex(ValueError, "missing parentheses"):
+
+            @labeling_function
+            def lf(x: DataPoint) -> int:
+                return 0 if x.num > 42 else -1

--- a/test/labeling/lf/test_nlp.py
+++ b/test/labeling/lf/test_nlp.py
@@ -64,6 +64,14 @@ class TestNLPLabelingFunction(unittest.TestCase):
         self.assertEqual(has_person_mention.name, "has_person_mention")
         self._run_lf(has_person_mention)
 
+    def test_nlp_labeling_function_decorator_no_parens(self) -> None:
+        with self.assertRaisesRegex(ValueError, "missing parentheses"):
+
+            @nlp_labeling_function
+            def has_person_mention(x: DataPoint) -> int:
+                person_ents = [ent for ent in x.doc.ents if ent.label_ == "PERSON"]
+                return 0 if len(person_ents) > 0 else -1
+
     def test_nlp_labeling_function_shared_cache(self) -> None:
         lf = NLPLabelingFunction(
             name="my_lf", f=has_person_mention, preprocessors=[combine_text]

--- a/test/map/test_core.py
+++ b/test/map/test_core.py
@@ -328,6 +328,14 @@ class TestMapperCore(unittest.TestCase):
         self.assertEqual(x8_mapped.double_num_squared, 128)
         self.assertEqual(square_hit_tracker.n_hits, 3)
 
+    def test_mapper_decorator_no_parens(self) -> None:
+        with self.assertRaisesRegex(ValueError, "missing parentheses"):
+
+            @lambda_mapper
+            def square(x: DataPoint) -> DataPoint:
+                x.num_squared = x.num ** 2
+                return x
+
     def test_mapper_with_args_kwargs(self) -> None:
         with self.assertRaises(ValueError):
             MapperWithArgs("my_mapper")


### PR DESCRIPTION
Common silent failure: no parens on a mapper or LF. This throws a meaningful error if you try to do that. Looked into allowing both parens and non-parens, and it makes the decorator definition unreadable (whereas now it's extremely readable). I also like the parens because they imply to the user that there are more options.

**Test plan**
Added unit tests