### PR TITLE
Add LF names to analysis init

### DIFF
--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -8,6 +8,8 @@ from sklearn.metrics import confusion_matrix
 
 from snorkel.analysis.utils import to_int_label_array
 
+from .lf import LabelingFunction
+
 
 class LFAnalysis:
     """Run analyses on LFs using label matrix.
@@ -24,9 +26,12 @@ class LFAnalysis:
         See above.
     """
 
-    def __init__(self, L: np.ndarray) -> None:
+    def __init__(
+        self, L: np.ndarray, lfs: Optional[List[LabelingFunction]] = None
+    ) -> None:
         self.L = L
         self._L_sparse = sparse.csr_matrix(L + 1)
+        self._lf_names = None if lfs is None else [lf.name for lf in lfs]
 
     def _covered_data_points(self) -> np.ndarray:
         """Get indicator vector z where z_i = 1 if x_i is labeled by at least one LF."""
@@ -300,10 +305,7 @@ class LFAnalysis:
         return P
 
     def lf_summary(
-        self,
-        Y: Optional[np.ndarray] = None,
-        lf_names: Optional[Union[List[str], List[int]]] = None,
-        est_accs: Optional[np.ndarray] = None,
+        self, Y: Optional[np.ndarray] = None, est_accs: Optional[np.ndarray] = None
     ) -> DataFrame:
         """Create a pandas DataFrame with the various per-LF statistics.
 
@@ -323,9 +325,11 @@ class LFAnalysis:
             Summary statistics for each LF
         """
         n, m = self.L.shape
-        if lf_names is not None:
+        lf_names: Union[List[str], List[int]]
+        if self._lf_names is not None:
             col_names = ["j"]
             d = {"j": list(range(m))}
+            lf_names = self._lf_names
         else:
             lf_names = list(range(m))
             col_names = []

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 
 from snorkel.labeling.analysis import LFAnalysis
+from snorkel.labeling.lf import LabelingFunction
 
 L = [
     [-1, -1, 0, -1, -1, 0],
@@ -19,52 +20,52 @@ Y = [0, 1, 2, 0, 1, 2]
 
 class TestAnalysis(unittest.TestCase):
     def setUp(self) -> None:
-        self.LFA = LFAnalysis(np.array(L))
+        self.lfa = LFAnalysis(np.array(L))
         self.Y = np.array(Y)
 
     def test_label_coverage(self) -> None:
-        self.assertEqual(self.LFA.label_coverage(), 5 / 6)
+        self.assertEqual(self.lfa.label_coverage(), 5 / 6)
 
     def test_label_overlap(self) -> None:
-        self.assertEqual(self.LFA.label_overlap(), 4 / 6)
+        self.assertEqual(self.lfa.label_overlap(), 4 / 6)
 
     def test_label_conflict(self) -> None:
-        self.assertEqual(self.LFA.label_conflict(), 3 / 6)
+        self.assertEqual(self.lfa.label_conflict(), 3 / 6)
 
     def test_lf_polarities(self) -> None:
-        polarities = self.LFA.lf_polarities()
+        polarities = self.lfa.lf_polarities()
         self.assertEqual(polarities, [[1, 2], [], [0, 2], [2], [0, 1], [0]])
 
     def test_lf_coverages(self) -> None:
-        coverages = self.LFA.lf_coverages()
+        coverages = self.lfa.lf_coverages()
         coverages_expected = [3 / 6, 0, 3 / 6, 2 / 6, 2 / 6, 4 / 6]
         np.testing.assert_array_almost_equal(coverages, np.array(coverages_expected))
 
     def test_lf_overlaps(self) -> None:
-        overlaps = self.LFA.lf_overlaps(normalize_by_coverage=False)
+        overlaps = self.lfa.lf_overlaps(normalize_by_coverage=False)
         overlaps_expected = [3 / 6, 0, 3 / 6, 1 / 6, 2 / 6, 4 / 6]
         np.testing.assert_array_almost_equal(overlaps, np.array(overlaps_expected))
 
-        overlaps = self.LFA.lf_overlaps(normalize_by_coverage=True)
+        overlaps = self.lfa.lf_overlaps(normalize_by_coverage=True)
         overlaps_expected = [1, 0, 1, 1 / 2, 1, 1]
         np.testing.assert_array_almost_equal(overlaps, np.array(overlaps_expected))
 
     def test_lf_conflicts(self) -> None:
-        conflicts = self.LFA.lf_conflicts(normalize_by_overlaps=False)
+        conflicts = self.lfa.lf_conflicts(normalize_by_overlaps=False)
         conflicts_expected = [3 / 6, 0, 2 / 6, 1 / 6, 2 / 6, 3 / 6]
         np.testing.assert_array_almost_equal(conflicts, np.array(conflicts_expected))
 
-        conflicts = self.LFA.lf_conflicts(normalize_by_overlaps=True)
+        conflicts = self.lfa.lf_conflicts(normalize_by_overlaps=True)
         conflicts_expected = [1, 0, 2 / 3, 1, 1, 3 / 4]
         np.testing.assert_array_almost_equal(conflicts, np.array(conflicts_expected))
 
     def test_lf_empirical_accuracies(self) -> None:
-        accs = self.LFA.lf_empirical_accuracies(self.Y)
+        accs = self.lfa.lf_empirical_accuracies(self.Y)
         accs_expected = [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4]
         np.testing.assert_array_almost_equal(accs, np.array(accs_expected))
 
     def test_lf_empirical_probs(self) -> None:
-        P_emp = self.LFA.lf_empirical_probs(self.Y, 3)
+        P_emp = self.lfa.lf_empirical_probs(self.Y, 3)
         P = np.array(
             [
                 [[1 / 2, 1, 0], [0, 0, 0], [1 / 2, 0, 1 / 2], [0, 0, 1 / 2]],
@@ -78,7 +79,7 @@ class TestAnalysis(unittest.TestCase):
         np.testing.assert_array_almost_equal(P, P_emp)
 
     def test_lf_summary(self) -> None:
-        df = self.LFA.lf_summary(self.Y, lf_names=None, est_accs=None)
+        df = self.lfa.lf_summary(self.Y, est_accs=None)
         df_expected = pd.DataFrame(
             {
                 "Polarity": [[1, 2], [], [0, 2], [2], [0, 1], [0]],
@@ -92,7 +93,7 @@ class TestAnalysis(unittest.TestCase):
         )
         pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
 
-        df = self.LFA.lf_summary(Y=None, lf_names=None, est_accs=None)
+        df = self.lfa.lf_summary(Y=None, est_accs=None)
         df_expected = pd.DataFrame(
             {
                 "Polarity": [[1, 2], [], [0, 2], [2], [0, 1], [0]],
@@ -105,7 +106,13 @@ class TestAnalysis(unittest.TestCase):
 
         est_accs = [1, 0, 1, 1, 1, 0.5]
         names = list("abcdef")
-        df = self.LFA.lf_summary(self.Y, lf_names=names, est_accs=est_accs)
+
+        def f(x):
+            return -1
+
+        lfs = [LabelingFunction(s, f) for s in names]
+        lfa = LFAnalysis(np.array(L), lfs)
+        df = lfa.lf_summary(self.Y, est_accs=est_accs)
         df_expected = pd.DataFrame(
             {
                 "j": [0, 1, 2, 3, 4, 5],

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -18,6 +18,10 @@ L = [
 Y = [0, 1, 2, 0, 1, 2]
 
 
+def f(x):
+    return -1
+
+
 class TestAnalysis(unittest.TestCase):
     def setUp(self) -> None:
         self.lfa = LFAnalysis(np.array(L))
@@ -106,10 +110,6 @@ class TestAnalysis(unittest.TestCase):
 
         est_accs = [1, 0, 1, 1, 1, 0.5]
         names = list("abcdef")
-
-        def f(x):
-            return -1
-
         lfs = [LabelingFunction(s, f) for s in names]
         lfa = LFAnalysis(np.array(L), lfs)
         df = lfa.lf_summary(self.Y, est_accs=est_accs)
@@ -127,3 +127,7 @@ class TestAnalysis(unittest.TestCase):
             }
         ).set_index(pd.Index(names))
         pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
+
+    def test_wrong_number_of_lfs(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Number of LFs"):
+            LFAnalysis(np.array(L), [LabelingFunction(s, f) for s in "ab"])


### PR DESCRIPTION
Avoids repetitive boilerplate of extracting LF names for analysis.

A couple decision points:
* Didn't add Y to init since you might want to try against a couple label sets (?)
* Did LFs rather than LF names to 1. avoid name extraction boilerplate and 2. play defense if we want to extract other properties.

**Test plan**
Updated LF name unit test 