### PR TITLE
Add no tqdm option

### DIFF
--- a/snorkel/augmentation/apply/core.py
+++ b/snorkel/augmentation/apply/core.py
@@ -88,13 +88,17 @@ class TFApplier(BaseTFApplier):
                 batch_transformed.extend(self._apply_policy_to_data_point(x))
             yield batch_transformed
 
-    def apply(self, data_points: DataPoints) -> List[DataPoint]:
+    def apply(
+        self, data_points: DataPoints, progress_bar: bool = True
+    ) -> List[DataPoint]:
         """Augment a list of data points using TFs and policy.
 
         Parameters
         ----------
         data_points
             List containing data points to be transformed
+        progress_bar
+            Display a progress bar?
 
         Returns
         -------
@@ -102,6 +106,7 @@ class TFApplier(BaseTFApplier):
             List of data points in augmented data set
         """
         x_transformed: List[DataPoint] = []
-        for x in tqdm(data_points):
+        gen = tqdm(data_points) if progress_bar else data_points
+        for x in gen:
             x_transformed.extend(self._apply_policy_to_data_point(x))
         return x_transformed

--- a/snorkel/augmentation/apply/core.py
+++ b/snorkel/augmentation/apply/core.py
@@ -106,7 +106,6 @@ class TFApplier(BaseTFApplier):
             List of data points in augmented data set
         """
         x_transformed: List[DataPoint] = []
-        gen = tqdm(data_points) if progress_bar else data_points
-        for x in gen:
+        for x in tqdm(data_points, disable=(not progress_bar)):
             x_transformed.extend(self._apply_policy_to_data_point(x))
         return x_transformed

--- a/snorkel/augmentation/apply/pandas.py
+++ b/snorkel/augmentation/apply/pandas.py
@@ -60,7 +60,6 @@ class PandasTFApplier(BaseTFApplier):
             Pandas DataFrame of data points in augmented data set
         """
         x_transformed: List[pd.Series] = []
-        gen = tqdm(df.iterrows(), total=len(df)) if progress_bar else df.iterrows()
-        for _, x in gen:
+        for _, x in tqdm(df.iterrows(), total=len(df), disable=(not progress_bar)):
             x_transformed.extend(self._apply_policy_to_data_point(x))
         return pd.concat(x_transformed, axis=1).T

--- a/snorkel/augmentation/apply/pandas.py
+++ b/snorkel/augmentation/apply/pandas.py
@@ -44,13 +44,15 @@ class PandasTFApplier(BaseTFApplier):
                 batch_transformed = []
         yield pd.concat(batch_transformed, axis=1).T
 
-    def apply(self, df: pd.DataFrame) -> pd.DataFrame:
+    def apply(self, df: pd.DataFrame, progress_bar: bool = True) -> pd.DataFrame:
         """Augment a Pandas DataFrame of data points using TFs and policy.
 
         Parameters
         ----------
         df
             Pandas DataFrame containing data points to be transformed
+        progress_bar
+            Display a progress bar?
 
         Returns
         -------
@@ -58,6 +60,7 @@ class PandasTFApplier(BaseTFApplier):
             Pandas DataFrame of data points in augmented data set
         """
         x_transformed: List[pd.Series] = []
-        for _, x in tqdm(df.iterrows(), total=len(df)):
+        gen = tqdm(df.iterrows(), total=len(df)) if progress_bar else df.iterrows()
+        for _, x in gen:
             x_transformed.extend(self._apply_policy_to_data_point(x))
         return pd.concat(x_transformed, axis=1).T

--- a/snorkel/labeling/apply/core.py
+++ b/snorkel/labeling/apply/core.py
@@ -89,9 +89,6 @@ class LFApplier(BaseLFApplier):
             Matrix of labels emitted by LFs
         """
         labels = []
-        gen = enumerate(data_points)
-        if progress_bar:
-            gen = tqdm(gen)
-        for i, x in gen:
+        for i, x in tqdm(enumerate(data_points), disable=(not progress_bar)):
             labels.append(apply_lfs_to_data_point(x, i, self._lfs))
         return self._matrix_from_row_data(labels)

--- a/snorkel/labeling/apply/core.py
+++ b/snorkel/labeling/apply/core.py
@@ -73,13 +73,15 @@ class LFApplier(BaseLFApplier):
     useful for testing.
     """
 
-    def apply(self, data_points: DataPoints) -> np.ndarray:
+    def apply(self, data_points: DataPoints, progress_bar: bool = True) -> np.ndarray:
         """Label list of data points with LFs.
 
         Parameters
         ----------
         data_points
             List of data points to be labeled by LFs
+        progress_bar
+            Display a progress bar?
 
         Returns
         -------
@@ -87,6 +89,9 @@ class LFApplier(BaseLFApplier):
             Matrix of labels emitted by LFs
         """
         labels = []
-        for i, x in tqdm(enumerate(data_points)):
+        gen = enumerate(data_points)
+        if progress_bar:
+            gen = tqdm(gen)
+        for i, x in gen:
             labels.append(apply_lfs_to_data_point(x, i, self._lfs))
         return self._matrix_from_row_data(labels)

--- a/snorkel/labeling/apply/pandas.py
+++ b/snorkel/labeling/apply/pandas.py
@@ -53,13 +53,15 @@ class PandasLFApplier(BaseLFApplier):
     For large datasets, consider ``DaskLFApplier`` or ``SparkLFApplier``.
     """
 
-    def apply(self, df: DataFrame) -> np.ndarray:
+    def apply(self, df: DataFrame, progress_bar: bool = True) -> np.ndarray:
         """Label Pandas DataFrame of data points with LFs.
 
         Parameters
         ----------
         df
             Pandas DataFrame containing data points to be labeled by LFs
+        progress_bar
+            Display a progress bar?
 
         Returns
         -------
@@ -67,7 +69,10 @@ class PandasLFApplier(BaseLFApplier):
             Matrix of labels emitted by LFs
         """
         apply_fn = partial(apply_lfs_to_data_point, lfs=self._lfs)
-        tqdm.pandas()
-        labels = df.progress_apply(apply_fn, axis=1)
+        call_fn = df.apply
+        if progress_bar:
+            tqdm.pandas()
+            call_fn = df.progress_apply
+        labels = call_fn(apply_fn, axis=1)
         labels_with_index = rows_to_triplets(labels)
         return self._matrix_from_row_data(labels_with_index)

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -31,9 +31,7 @@ def modify_in_place(x: DataPoint) -> DataPoint:
 
 
 DATA = [1, 2, 3]
-DATA_IN_PLACE_EXPECTED = [
-    dict(my_key=(1 + i // 3) if i % 3 == 0 else 0) for i in range(9)
-]
+DATA_IN_PLACE_EXPECTED = [(1 + i // 3) if i % 3 == 0 else 0 for i in range(9)]
 
 
 def make_df(values: list, index: list, key: str = "num") -> pd.DataFrame:
@@ -41,16 +39,16 @@ def make_df(values: list, index: list, key: str = "num") -> pd.DataFrame:
 
 
 # NB: reconstruct each time to avoid inplace updates
-def get_data_dict():
-    return [dict(my_key=num) for num in DATA]
+def get_data_dict(data: List[int] = DATA):
+    return [dict(my_key=num) for num in data]
 
 
 class TestTFApplier(unittest.TestCase):
-    def _get_x_namespace(self) -> List[SimpleNamespace]:
-        return [SimpleNamespace(num=num) for num in DATA]
+    def _get_x_namespace(self, data: List[int] = DATA) -> List[SimpleNamespace]:
+        return [SimpleNamespace(num=num) for num in data]
 
-    def _get_x_namespace_dict(self) -> List[SimpleNamespace]:
-        return [SimpleNamespace(d=d) for d in get_data_dict()]
+    def _get_x_namespace_dict(self, data: List[int] = DATA) -> List[SimpleNamespace]:
+        return [SimpleNamespace(d=d) for d in get_data_dict(data)]
 
     def test_tf_applier(self) -> None:
         data = self._get_x_namespace()
@@ -58,10 +56,13 @@ class TestTFApplier(unittest.TestCase):
             1, sequence_length=2, n_per_original=1, keep_original=False
         )
         applier = TFApplier([square], policy)
-        data_augmented = applier.apply(data)
-        vals = [x.num for x in data_augmented]
-        self.assertEqual(vals, [1, 16, 81])
-        self.assertEqual([x.num for x in data], DATA)
+        data_augmented = applier.apply(data, progress_bar=False)
+        self.assertEqual(data_augmented, self._get_x_namespace([1, 16, 81]))
+        self.assertEqual(data, self._get_x_namespace())
+
+        data_augmented = applier.apply(data, progress_bar=True)
+        self.assertEqual(data_augmented, self._get_x_namespace([1, 16, 81]))
+        self.assertEqual(data, self._get_x_namespace())
 
     def test_tf_applier_keep_original(self) -> None:
         data = self._get_x_namespace()
@@ -69,10 +70,10 @@ class TestTFApplier(unittest.TestCase):
             1, sequence_length=2, n_per_original=2, keep_original=True
         )
         applier = TFApplier([square], policy)
-        data_augmented = applier.apply(data)
-        vals = [x.num for x in data_augmented]
-        self.assertEqual(vals, [1, 1, 1, 2, 16, 16, 3, 81, 81])
-        self.assertEqual([x.num for x in data], DATA)
+        data_augmented = applier.apply(data, progress_bar=False)
+        vals = [1, 1, 1, 2, 16, 16, 3, 81, 81]
+        self.assertEqual(data_augmented, self._get_x_namespace(vals))
+        self.assertEqual(data, self._get_x_namespace())
 
     def test_tf_applier_returns_none(self) -> None:
         data = self._get_x_namespace()
@@ -80,20 +81,20 @@ class TestTFApplier(unittest.TestCase):
             1, sequence_length=2, n_per_original=2, keep_original=True
         )
         applier = TFApplier([square_returns_none], policy)
-        data_augmented = applier.apply(data)
-        vals = [x.num for x in data_augmented]
-        self.assertEqual(vals, [1, 1, 1, 2, 3, 81, 81])
-        self.assertEqual([x.num for x in data], DATA)
+        data_augmented = applier.apply(data, progress_bar=False)
+        vals = [1, 1, 1, 2, 3, 81, 81]
+        self.assertEqual(data_augmented, self._get_x_namespace(vals))
+        self.assertEqual(data, self._get_x_namespace())
 
     def test_tf_applier_keep_original_modify_in_place(self) -> None:
         data = self._get_x_namespace_dict()
         policy = ApplyOnePolicy(n_per_original=2, keep_original=True)
         applier = TFApplier([modify_in_place], policy)
-        data_augmented = applier.apply(data)
-        self.assertTrue(
-            all(x.d == d for x, d in zip(data_augmented, DATA_IN_PLACE_EXPECTED))
+        data_augmented = applier.apply(data, progress_bar=False)
+        self.assertEqual(
+            data_augmented, self._get_x_namespace_dict(DATA_IN_PLACE_EXPECTED)
         )
-        self.assertTrue(all(x.d == y for x, y in zip(data, get_data_dict())))
+        self.assertEqual(data, self._get_x_namespace_dict())
 
     def test_tf_applier_generator(self) -> None:
         data = self._get_x_namespace()
@@ -104,8 +105,8 @@ class TestTFApplier(unittest.TestCase):
         batches_expected = [[1, 1, 16, 16], [81, 81]]
         gen = applier.apply_generator(data, batch_size=2)
         for batch, batch_expected in zip(gen, batches_expected):
-            self.assertEqual([x.num for x in batch], batch_expected)
-        self.assertEqual([x.num for x in data], DATA)
+            self.assertEqual(batch, self._get_x_namespace(batch_expected))
+        self.assertEqual(data, self._get_x_namespace())
 
     def test_tf_applier_keep_original_generator(self) -> None:
         data = self._get_x_namespace()
@@ -116,8 +117,8 @@ class TestTFApplier(unittest.TestCase):
         batches_expected = [[1, 1, 1, 2, 16, 16], [3, 81, 81]]
         gen = applier.apply_generator(data, batch_size=2)
         for batch, batch_expected in zip(gen, batches_expected):
-            self.assertEqual([x.num for x in batch], batch_expected)
-        self.assertEqual([x.num for x in data], DATA)
+            self.assertEqual(batch, self._get_x_namespace(batch_expected))
+        self.assertEqual(data, self._get_x_namespace())
 
     def test_tf_applier_returns_none_generator(self) -> None:
         data = self._get_x_namespace()
@@ -128,8 +129,8 @@ class TestTFApplier(unittest.TestCase):
         batches_expected = [[1, 1, 1, 2], [3, 81, 81]]
         gen = applier.apply_generator(data, batch_size=2)
         for batch, batch_expected in zip(gen, batches_expected):
-            self.assertEqual([x.num for x in batch], batch_expected)
-        self.assertEqual([x.num for x in data], DATA)
+            self.assertEqual(batch, self._get_x_namespace(batch_expected))
+        self.assertEqual(data, self._get_x_namespace())
 
     def test_tf_applier_keep_original_modify_in_place_generator(self) -> None:
         data = self._get_x_namespace_dict()
@@ -138,8 +139,8 @@ class TestTFApplier(unittest.TestCase):
         batches_expected = [DATA_IN_PLACE_EXPECTED[:6], DATA_IN_PLACE_EXPECTED[6:]]
         gen = applier.apply_generator(data, batch_size=2)
         for batch, batch_expected in zip(gen, batches_expected):
-            self.assertTrue(all(x.d == d for x, d in zip(batch, batch_expected)))
-        self.assertTrue(all(x.d == y for x, y in zip(data, get_data_dict())))
+            self.assertEqual(batch, self._get_x_namespace_dict(batch_expected))
+        self.assertEqual(data, self._get_x_namespace_dict())
 
 
 class TestPandasTFApplier(unittest.TestCase):
@@ -155,10 +156,15 @@ class TestPandasTFApplier(unittest.TestCase):
             1, sequence_length=2, n_per_original=1, keep_original=False
         )
         applier = PandasTFApplier([square], policy)
-        df_augmented = applier.apply(df)
+        df_augmented = applier.apply(df, progress_bar=False)
         df_expected = pd.DataFrame(dict(num=[1, 16, 81]), index=[0, 1, 2])
         pd.testing.assert_frame_equal(df_augmented, df_expected)
-        self.assertEqual(df.num.tolist(), DATA)
+        pd.testing.assert_frame_equal(df, self._get_x_df())
+
+        df_augmented = applier.apply(df, progress_bar=True)
+        df_expected = pd.DataFrame(dict(num=[1, 16, 81]), index=[0, 1, 2])
+        pd.testing.assert_frame_equal(df_augmented, df_expected)
+        pd.testing.assert_frame_equal(df, self._get_x_df())
 
     def test_tf_applier_pandas_keep_original(self):
         df = self._get_x_df()
@@ -166,12 +172,12 @@ class TestPandasTFApplier(unittest.TestCase):
             1, sequence_length=2, n_per_original=2, keep_original=True
         )
         applier = PandasTFApplier([square], policy)
-        df_augmented = applier.apply(df)
+        df_augmented = applier.apply(df, progress_bar=False)
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 16, 16, 3, 81, 81]), index=[0, 0, 0, 1, 1, 1, 2, 2, 2]
         )
         pd.testing.assert_frame_equal(df_augmented, df_expected)
-        self.assertEqual(df.num.tolist(), DATA)
+        pd.testing.assert_frame_equal(df, self._get_x_df())
 
     def test_tf_applier_returns_none(self):
         df = self._get_x_df()
@@ -179,22 +185,24 @@ class TestPandasTFApplier(unittest.TestCase):
             1, sequence_length=2, n_per_original=2, keep_original=True
         )
         applier = PandasTFApplier([square_returns_none], policy)
-        df_augmented = applier.apply(df)
+        df_augmented = applier.apply(df, progress_bar=False)
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 3, 81, 81]), index=[0, 0, 0, 1, 2, 2, 2]
         )
         pd.testing.assert_frame_equal(df_augmented, df_expected)
-        self.assertEqual(df.num.tolist(), DATA)
+        pd.testing.assert_frame_equal(df, self._get_x_df())
 
     def test_tf_applier_pandas_modify_in_place(self):
         df = self._get_x_df_dict()
         policy = ApplyOnePolicy(n_per_original=2, keep_original=True)
         applier = PandasTFApplier([modify_in_place], policy)
-        df_augmented = applier.apply(df)
+        df_augmented = applier.apply(df, progress_bar=False)
         idx = [0, 0, 0, 1, 1, 1, 2, 2, 2]
-        df_expected = pd.DataFrame(dict(d=DATA_IN_PLACE_EXPECTED), index=idx)
+        df_expected = pd.DataFrame(
+            dict(d=get_data_dict(DATA_IN_PLACE_EXPECTED)), index=idx
+        )
         pd.testing.assert_frame_equal(df_augmented, df_expected)
-        self.assertEqual(df.d.tolist(), get_data_dict())
+        pd.testing.assert_frame_equal(df, self._get_x_df_dict())
 
     def test_tf_applier_pandas_generator(self):
         df = self._get_x_df()
@@ -206,7 +214,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = [make_df([1, 1, 16, 16], [0, 0, 1, 1]), make_df([81, 81], [2, 2])]
         for df_batch, df_batch_expected in zip(gen, df_expected):
             pd.testing.assert_frame_equal(df_batch, df_batch_expected)
-        self.assertEqual(df.num.tolist(), DATA)
+        pd.testing.assert_frame_equal(df, self._get_x_df())
 
     def test_tf_applier_pandas_keep_original_generator(self):
         df = self._get_x_df()
@@ -221,7 +229,7 @@ class TestPandasTFApplier(unittest.TestCase):
         ]
         for df_batch, df_batch_expected in zip(gen, df_expected):
             pd.testing.assert_frame_equal(df_batch, df_batch_expected)
-        self.assertEqual(df.num.tolist(), DATA)
+        pd.testing.assert_frame_equal(df, self._get_x_df())
 
     def test_tf_applier_returns_none_generator(self):
         df = self._get_x_df()
@@ -236,7 +244,7 @@ class TestPandasTFApplier(unittest.TestCase):
         ]
         for df_batch, df_batch_expected in zip(gen, df_expected):
             pd.testing.assert_frame_equal(df_batch, df_batch_expected)
-        self.assertEqual(df.num.tolist(), DATA)
+        pd.testing.assert_frame_equal(df, self._get_x_df())
 
     def test_tf_applier_pandas_modify_in_place_generator(self):
         df = self._get_x_df_dict()
@@ -245,9 +253,9 @@ class TestPandasTFApplier(unittest.TestCase):
         gen = applier.apply_generator(df, batch_size=2)
         idx = [0, 0, 0, 1, 1, 1, 2, 2, 2]
         df_expected = [
-            make_df(DATA_IN_PLACE_EXPECTED[:6], idx[:6], key="d"),
-            make_df(DATA_IN_PLACE_EXPECTED[6:], idx[6:], key="d"),
+            make_df(get_data_dict(DATA_IN_PLACE_EXPECTED[:6]), idx[:6], key="d"),
+            make_df(get_data_dict(DATA_IN_PLACE_EXPECTED[6:]), idx[6:], key="d"),
         ]
         for df_batch, df_batch_expected in zip(gen, df_expected):
             pd.testing.assert_frame_equal(df_batch, df_batch_expected)
-        self.assertEqual(df.d.tolist(), get_data_dict())
+        pd.testing.assert_frame_equal(df, self._get_x_df_dict())

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -57,13 +57,15 @@ class TestLFApplier(unittest.TestCase):
     def test_lf_applier(self) -> None:
         data_points = [SimpleNamespace(num=num) for num in DATA]
         applier = LFApplier([f, g])
-        L = applier.apply(data_points)
+        L = applier.apply(data_points, progress_bar=False)
+        np.testing.assert_equal(L, L_EXPECTED)
+        L = applier.apply(data_points, progress_bar=True)
         np.testing.assert_equal(L, L_EXPECTED)
 
     def test_lf_applier_preprocessor(self) -> None:
         data_points = [SimpleNamespace(num=num) for num in DATA]
         applier = LFApplier([f, fp])
-        L = applier.apply(data_points)
+        L = applier.apply(data_points, progress_bar=False)
         np.testing.assert_equal(L, L_PREPROCESS_EXPECTED)
 
     def test_lf_applier_preprocessor_memoized(self) -> None:
@@ -80,7 +82,7 @@ class TestLFApplier(unittest.TestCase):
             return 0 if x.num_squared > 42 else -1
 
         applier = LFApplier([f, fp_memoized])
-        L = applier.apply(data_points)
+        L = applier.apply(data_points, progress_bar=False)
         np.testing.assert_equal(L, L_PREPROCESS_EXPECTED)
         self.assertEqual(square_hit_tracker.n_hits, 4)
 
@@ -89,13 +91,15 @@ class TestPandasApplier(unittest.TestCase):
     def test_lf_applier_pandas(self) -> None:
         df = pd.DataFrame(dict(num=DATA))
         applier = PandasLFApplier([f, g])
-        L = applier.apply(df)
+        L = applier.apply(df, progress_bar=False)
+        np.testing.assert_equal(L, L_EXPECTED)
+        L = applier.apply(df, progress_bar=True)
         np.testing.assert_equal(L, L_EXPECTED)
 
     def test_lf_applier_pandas_preprocessor(self) -> None:
         df = pd.DataFrame(dict(num=DATA))
         applier = PandasLFApplier([f, fp])
-        L = applier.apply(df)
+        L = applier.apply(df, progress_bar=False)
         np.testing.assert_equal(L, L_PREPROCESS_EXPECTED)
 
     def test_lf_applier_pandas_preprocessor_memoized(self) -> None:
@@ -112,7 +116,7 @@ class TestPandasApplier(unittest.TestCase):
 
         df = pd.DataFrame(dict(num=DATA))
         applier = PandasLFApplier([f, fp_memoized])
-        L = applier.apply(df)
+        L = applier.apply(df, progress_bar=False)
         np.testing.assert_equal(L, L_PREPROCESS_EXPECTED)
         self.assertEqual(square_hit_tracker.n_hits, 4)
 
@@ -129,7 +133,7 @@ class TestPandasApplier(unittest.TestCase):
 
         df = pd.DataFrame(dict(text=TEXT_DATA))
         applier = PandasLFApplier([first_is_name, has_verb])
-        L = applier.apply(df)
+        L = applier.apply(df, progress_bar=False)
         np.testing.assert_equal(L, L_TEXT_EXPECTED)
 
     def test_lf_applier_pandas_spacy_preprocessor_memoized(self) -> None:
@@ -146,7 +150,7 @@ class TestPandasApplier(unittest.TestCase):
 
         df = pd.DataFrame(dict(text=TEXT_DATA))
         applier = PandasLFApplier([first_is_name, has_verb])
-        L = applier.apply(df)
+        L = applier.apply(df, progress_bar=False)
         np.testing.assert_equal(L, L_TEXT_EXPECTED)
         self.assertEqual(len(spacy._cache), 2)
 

--- a/test/labeling/test_convergence.py
+++ b/test/labeling/test_convergence.py
@@ -76,7 +76,7 @@ class LabelingConvergenceTest(unittest.TestCase):
             + [get_negative_labeling_function(divisor) for divisor in range(2, 9)]
         )
         applier = PandasLFApplier(labeling_functions)
-        L_train = applier.apply(self.df_train)
+        L_train = applier.apply(self.df_train, progress_bar=False)
 
         self.assertEqual(L_train.shape, (self.N_TRAIN, len(labeling_functions)))
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -72,8 +72,8 @@ class SlicingConvergenceTest(unittest.TestCase):
         slicing_functions = [h]  # high coverage slice
         slice_names = [sf.name for sf in slicing_functions]
         applier = PandasSFApplier(slicing_functions)
-        S_train = applier.apply(self.df_train)
-        S_valid = applier.apply(self.df_valid)
+        S_train = applier.apply(self.df_train, progress_bar=False)
+        S_valid = applier.apply(self.df_valid, progress_bar=False)
 
         self.assertEqual(S_train.shape, (self.N_TRAIN, len(slicing_functions)))
         self.assertEqual(S_valid.shape, (self.N_VALID, len(slicing_functions)))
@@ -125,8 +125,8 @@ class SlicingConvergenceTest(unittest.TestCase):
         slicing_functions = [f, g]  # low-coverage slices
         slice_names = [sf.name for sf in slicing_functions]
         applier = PandasSFApplier(slicing_functions)
-        S_train = applier.apply(self.df_train)
-        S_valid = applier.apply(self.df_valid)
+        S_train = applier.apply(self.df_train, progress_bar=False)
+        S_valid = applier.apply(self.df_valid, progress_bar=False)
 
         # Add slice labels
         add_slice_labels(dataloaders[0], base_task, S_train, slice_names)

--- a/test/slicing/test_utils.py
+++ b/test/slicing/test_utils.py
@@ -34,7 +34,7 @@ class UtilsTest(unittest.TestCase):
         slicing_functions = [f]
         slice_names = [sf.name for sf in slicing_functions]
         applier = PandasSFApplier(slicing_functions)
-        S = applier.apply(df)
+        S = applier.apply(df, progress_bar=False)
 
         dataloader = DictDataLoader(dataset)
 


### PR DESCRIPTION
For *Applier and Pandas*Applier. Useful for testing, notebooks, prod scripts, etc. Also cleaned up the TF tests since they were imprecise in what they were checking.

**Test plan**
Updated tests, added both pb and no-pb versions