### PR TITLE
Refactor train_model() to fit()

### DIFF
--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -139,7 +139,7 @@ class Trainer:
         )
         self.name = name if name is not None else type(self).__name__
 
-    def train_model(
+    def fit(
         self, model: SnorkelClassifier, dataloaders: List["DictDataLoader"]
     ) -> None:
         """Train a SnorkelClassifier.

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -63,13 +63,13 @@ class TrainerTest(unittest.TestCase):
     def test_trainer_onetask(self):
         """Train a single-task model"""
         trainer = Trainer(**base_config)
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
 
     def test_trainer_twotask(self):
         """Train a model with overlapping modules and flows"""
         multitask_model = SnorkelClassifier(tasks)
         trainer = Trainer(**base_config)
-        trainer.train_model(multitask_model, dataloaders)
+        trainer.fit(multitask_model, dataloaders)
 
     def test_trainer_errors(self):
         dataloader = copy.deepcopy(dataloaders[0])
@@ -78,12 +78,12 @@ class TrainerTest(unittest.TestCase):
         trainer = Trainer(**base_config)
         dataloader.dataset.split = "valid"
         with self.assertRaisesRegex(ValueError, "Cannot find any dataloaders"):
-            trainer.train_model(model, [dataloader])
+            trainer.fit(model, [dataloader])
 
         # Unused split
         trainer = Trainer(**base_config, valid_split="val")
         with self.assertRaisesRegex(ValueError, "Dataloader splits must be"):
-            trainer.train_model(model, [dataloader])
+            trainer.fit(model, [dataloader])
 
     def test_checkpointer_init(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -93,7 +93,7 @@ class TrainerTest(unittest.TestCase):
                 "log_writer_config": {"log_dir": temp_dir},
             }
             trainer = Trainer(**base_config, **more_config, logging=True)
-            trainer.train_model(model, [dataloaders[0]])
+            trainer.fit(model, [dataloaders[0]])
             self.assertIsNotNone(trainer.checkpointer)
 
             broken_config = {
@@ -103,7 +103,7 @@ class TrainerTest(unittest.TestCase):
             }
             with self.assertRaises(TypeError):
                 trainer = Trainer(**base_config, **broken_config, logging=False)
-                trainer.train_model(model, [dataloaders[0]])
+                trainer.fit(model, [dataloaders[0]])
 
     def test_log_writer_init(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -114,7 +114,7 @@ class TrainerTest(unittest.TestCase):
                 log_writer="json",
                 log_writer_config=log_writer_config,
             )
-            trainer.train_model(model, [dataloaders[0]])
+            trainer.fit(model, [dataloaders[0]])
             self.assertIsInstance(trainer.log_writer, LogWriter)
 
             log_writer_config = {"log_dir": temp_dir}
@@ -124,7 +124,7 @@ class TrainerTest(unittest.TestCase):
                 log_writer="tensorboard",
                 log_writer_config=log_writer_config,
             )
-            trainer.train_model(model, [dataloaders[0]])
+            trainer.fit(model, [dataloaders[0]])
             self.assertIsInstance(trainer.log_writer, TensorBoardWriter)
 
             log_writer_config = {"log_dir": temp_dir}
@@ -135,60 +135,60 @@ class TrainerTest(unittest.TestCase):
                     log_writer="foo",
                     log_writer_config=log_writer_config,
                 )
-                trainer.train_model(model, [dataloaders[0]])
+                trainer.fit(model, [dataloaders[0]])
 
     def test_optimizer_init(self):
         trainer = Trainer(**base_config, optimizer="sgd")
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertIsInstance(trainer.optimizer, optim.SGD)
 
         trainer = Trainer(**base_config, optimizer="adam")
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertIsInstance(trainer.optimizer, optim.Adam)
 
         trainer = Trainer(**base_config, optimizer="adamax")
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertIsInstance(trainer.optimizer, optim.Adamax)
 
         with self.assertRaisesRegex(ValueError, "Unrecognized optimizer"):
             trainer = Trainer(**base_config, optimizer="foo")
-            trainer.train_model(model, [dataloaders[0]])
+            trainer.fit(model, [dataloaders[0]])
 
     def test_scheduler_init(self):
         trainer = Trainer(**base_config, lr_scheduler="constant")
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertIsNone(trainer.lr_scheduler)
 
         trainer = Trainer(**base_config, lr_scheduler="linear")
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertIsInstance(trainer.lr_scheduler, optim.lr_scheduler.LambdaLR)
 
         trainer = Trainer(**base_config, lr_scheduler="exponential")
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertIsInstance(trainer.lr_scheduler, optim.lr_scheduler.ExponentialLR)
 
         trainer = Trainer(**base_config, lr_scheduler="step")
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertIsInstance(trainer.lr_scheduler, optim.lr_scheduler.StepLR)
 
         with self.assertRaisesRegex(ValueError, "Unrecognized lr scheduler"):
             trainer = Trainer(**base_config, lr_scheduler="foo")
-            trainer.train_model(model, [dataloaders[0]])
+            trainer.fit(model, [dataloaders[0]])
 
     def test_warmup(self):
         lr_scheduler_config = {"warmup_steps": 1, "warmup_unit": "batches"}
         trainer = Trainer(**base_config, lr_scheduler_config=lr_scheduler_config)
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertEqual(trainer.warmup_steps, 1)
 
         lr_scheduler_config = {"warmup_steps": 1, "warmup_unit": "epochs"}
         trainer = Trainer(**base_config, lr_scheduler_config=lr_scheduler_config)
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertEqual(trainer.warmup_steps, BATCHES_PER_EPOCH)
 
         lr_scheduler_config = {"warmup_percentage": 1 / BATCHES_PER_EPOCH}
         trainer = Trainer(**base_config, lr_scheduler_config=lr_scheduler_config)
-        trainer.train_model(model, [dataloaders[0]])
+        trainer.fit(model, [dataloaders[0]])
         self.assertEqual(trainer.warmup_steps, 1)
 
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -88,7 +88,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Train
         trainer = Trainer(lr=0.001, n_epochs=50, progress_bar=False)
-        trainer.train_model(model, dataloaders)
+        trainer.fit(model, dataloaders)
         scores = model.score(dataloaders)
 
         # Confirm near perfect scores
@@ -139,7 +139,7 @@ class SlicingConvergenceTest(unittest.TestCase):
         # Train
         # NOTE: Needs more epochs to convergence with more heads
         trainer = Trainer(lr=0.001, n_epochs=80, progress_bar=False)
-        trainer.train_model(model, dataloaders)
+        trainer.fit(model, dataloaders)
         scores = model.score(dataloaders)
 
         # Confirm reasonably high slice scores


### PR DESCRIPTION
Refactors the remaining uses of `train_model()` to `fit()`

Note that, once approved, this will be merged simultaneously with the corresponding PR in `snorkel-tutorials`.

**Test plan:**
`tox`