### PR TITLE
Restore dtypes after pandas data augmentation

### DIFF
--- a/snorkel/augmentation/apply/pandas.py
+++ b/snorkel/augmentation/apply/pandas.py
@@ -40,7 +40,7 @@ class PandasTFApplier(BaseTFApplier):
         for i, (_, x) in enumerate(df.iterrows()):
             batch_transformed.extend(self._apply_policy_to_data_point(x))
             if (i + 1) % batch_size == 0:
-                yield pd.concat(batch_transformed, axis=1).T
+                yield pd.concat(batch_transformed, axis=1).T.infer_objects()
                 batch_transformed = []
         yield pd.concat(batch_transformed, axis=1).T.infer_objects()
 

--- a/snorkel/augmentation/apply/pandas.py
+++ b/snorkel/augmentation/apply/pandas.py
@@ -42,7 +42,7 @@ class PandasTFApplier(BaseTFApplier):
             if (i + 1) % batch_size == 0:
                 yield pd.concat(batch_transformed, axis=1).T
                 batch_transformed = []
-        yield pd.concat(batch_transformed, axis=1).T
+        yield pd.concat(batch_transformed, axis=1).T.infer_objects()
 
     def apply(self, df: pd.DataFrame, progress_bar: bool = True) -> pd.DataFrame:
         """Augment a Pandas DataFrame of data points using TFs and policy.
@@ -62,4 +62,4 @@ class PandasTFApplier(BaseTFApplier):
         x_transformed: List[pd.Series] = []
         for _, x in tqdm(df.iterrows(), total=len(df), disable=(not progress_bar)):
             x_transformed.extend(self._apply_policy_to_data_point(x))
-        return pd.concat(x_transformed, axis=1).T
+        return pd.concat(x_transformed, axis=1).T.infer_objects()

--- a/test/augmentation/apply/test_tf_applier.py
+++ b/test/augmentation/apply/test_tf_applier.py
@@ -158,6 +158,7 @@ class TestPandasTFApplier(unittest.TestCase):
         applier = PandasTFApplier([square], policy)
         df_augmented = applier.apply(df, progress_bar=False)
         df_expected = pd.DataFrame(dict(num=[1, 16, 81]), index=[0, 1, 2])
+        self.assertEqual(df_augmented.num.dtype, "int64")
         pd.testing.assert_frame_equal(df_augmented, df_expected)
         pd.testing.assert_frame_equal(df, self._get_x_df())
 
@@ -176,6 +177,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 16, 16, 3, 81, 81]), index=[0, 0, 0, 1, 1, 1, 2, 2, 2]
         )
+        self.assertEqual(df_augmented.num.dtype, "int64")
         pd.testing.assert_frame_equal(df_augmented, df_expected)
         pd.testing.assert_frame_equal(df, self._get_x_df())
 
@@ -189,6 +191,7 @@ class TestPandasTFApplier(unittest.TestCase):
         df_expected = pd.DataFrame(
             dict(num=[1, 1, 1, 2, 3, 81, 81]), index=[0, 0, 0, 1, 2, 2, 2]
         )
+        self.assertEqual(df_augmented.num.dtype, "int64")
         pd.testing.assert_frame_equal(df_augmented, df_expected)
         pd.testing.assert_frame_equal(df, self._get_x_df())
 
@@ -213,6 +216,7 @@ class TestPandasTFApplier(unittest.TestCase):
         gen = applier.apply_generator(df, batch_size=2)
         df_expected = [make_df([1, 1, 16, 16], [0, 0, 1, 1]), make_df([81, 81], [2, 2])]
         for df_batch, df_batch_expected in zip(gen, df_expected):
+            self.assertEqual(df_batch.num.dtype, "int64")
             pd.testing.assert_frame_equal(df_batch, df_batch_expected)
         pd.testing.assert_frame_equal(df, self._get_x_df())
 


### PR DESCRIPTION
Restore dtypes after pandas data augmentation.

Test Plan
Added lines to existing test to check dtypes after PandasTFApplier apply(), and apply_generator().