### PR TITLE
[EASY] Pass loss_func and output_func args by name

### DIFF
--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -267,9 +267,9 @@ class SnorkelClassifier(nn.Module):
                 count_dict[task_name] = active.sum().item()
 
                 loss_dict[task_name] = self.loss_funcs[task_name](
-                    outputs,
-                    move_to_device(Y, self.config.device),
-                    move_to_device(active, self.config.device),
+                    outputs=outputs,
+                    Y=move_to_device(Y, self.config.device),
+                    active=move_to_device(active, self.config.device),
                 )
 
         return loss_dict, count_dict
@@ -300,7 +300,9 @@ class SnorkelClassifier(nn.Module):
         outputs = self.forward(X_dict, task_names)
 
         for task_name in task_names:
-            prob_dict[task_name] = self.output_funcs[task_name](outputs).cpu().numpy()
+            prob_dict[task_name] = (
+                self.output_funcs[task_name](outputs=outputs).cpu().numpy()
+            )
 
         return prob_dict
 


### PR DESCRIPTION
- Explicitly pass the args to loss_func and output_func by name. This is especially important for clarity because these funcs often have partial evaluations that happen elsewhere (their first argument is actually the name of the op whose output they pull from).

**Test plan:**
`tox` (Not a change, just a clarification)