### PR TITLE
Remove div by zero warning when using nan_to_num.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,5 +131,3 @@ dask-worker-space/
 
 # nohup
 nohup.out
-
-

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,12 @@ dmypy.json
 
 # Editors
 .vscode/
+.code-workspace*
 
 # Dask
 dask-worker-space/
+
+# nohup
+nohup.out
+
+

--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -285,7 +285,7 @@ class LFAnalysis:
             0,
             np.where(self.L == np.vstack([Y] * self.L.shape[1]).T, 1, -1),
         )
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             return np.nan_to_num(0.5 * (X.sum(axis=0) / (self.L != -1).sum(axis=0) + 1))
 
     def lf_empirical_probs(self, Y: np.ndarray, k: int) -> np.ndarray:

--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -285,7 +285,8 @@ class LFAnalysis:
             0,
             np.where(self.L == np.vstack([Y] * self.L.shape[1]).T, 1, -1),
         )
-        return np.nan_to_num(0.5 * (X.sum(axis=0) / (self.L != -1).sum(axis=0) + 1))
+        with np.errstate(divide='ignore', invalid='ignore'):
+            return np.nan_to_num(0.5 * (X.sum(axis=0) / (self.L != -1).sum(axis=0) + 1))
 
     def lf_empirical_probs(self, Y: np.ndarray, k: int) -> np.ndarray:
         """Estimate conditional probability tables for each LF.


### PR DESCRIPTION
Remove div by zero warning when using nan_to_num
Also add nohup.out to gitignore.

**Test Plan**
Tests pass. Also, tried locally and no longer get div by zero warning.