### PR TITLE
Genericize error_buckets

### DIFF
--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -6,33 +6,32 @@ import numpy as np
 from .utils import to_int_label_array
 
 
-def error_buckets(
-    golds: np.ndarray, preds: np.ndarray
-) -> Dict[Tuple[int, int], List[int]]:
-    """Return data point indices bucketed by gold label/pred label combination.
+def label_buckets(*y: np.ndarray) -> Dict[Tuple[int, int], np.ndarray]:
+    """Return data point indices bucketed by label combinations.
 
-    Returned buckets[i,j] is a list of items with predicted label i and true label j.
-    For a binary problem with (1=positive, 0=negative):
-        buckets[1,1] = true positives
-        buckets[1,0] = false positives
-        buckets[0,1] = false negatives
-        buckets[0,0] = true negatives
+    A common use case is calling ``label_buckets(Y_gold, Y_pred)`` where
+    ``Y_gold`` is a set of gold (i.e. ground truth) labels and ``Y_pred`` is a
+    corresponding set of predicted labels.
+    The returned ``buckets[(i, j)]`` is a NumPy array of data point indices with
+    predicted label i and true label j.
+    For a binary problem with (1 = positive, 0 = negative):
+        ``buckets[(1, 1)]`` = true positives
+        ``buckets[(1, 0)]`` = false negatives
+        ``buckets[(0, 1)]`` = false positives
+        ``buckets[(0, 0)]`` = true negatives
 
     Parameters
     ----------
-    golds
-        An np.ndarray of gold (int) labels
-    preds
-        An np.ndarray of (int) predictions
+    *y
+        A list of np.ndarray of (int) labels
 
     Returns
     -------
     Dict
-        A mapping of each error bucket to its corresponding indices
+        A mapping of each label bucket to a NumPy array of its corresponding indices
     """
     buckets: DefaultDict[Tuple[int, int], List[int]] = defaultdict(list)
-    golds = to_int_label_array(golds)
-    preds = to_int_label_array(preds, flatten_vector=True)
-    for i, (l, y) in enumerate(zip(preds, golds)):
-        buckets[(l, y)].append(i)
-    return dict(buckets)
+    y_flat = map(lambda x: to_int_label_array(x, flatten_vector=True), y)
+    for i, labels in enumerate(zip(*y_flat)):
+        buckets[labels].append(i)
+    return {k: np.array(v) for k, v in buckets.items()}

--- a/snorkel/analysis/error_analysis.py
+++ b/snorkel/analysis/error_analysis.py
@@ -6,19 +6,8 @@ import numpy as np
 from .utils import to_int_label_array
 
 
-def label_buckets(*y: np.ndarray) -> Dict[Tuple[int, int], np.ndarray]:
+def get_label_buckets(*y: np.ndarray) -> Dict[Tuple[int, ...], np.ndarray]:
     """Return data point indices bucketed by label combinations.
-
-    A common use case is calling ``label_buckets(Y_gold, Y_pred)`` where
-    ``Y_gold`` is a set of gold (i.e. ground truth) labels and ``Y_pred`` is a
-    corresponding set of predicted labels.
-    The returned ``buckets[(i, j)]`` is a NumPy array of data point indices with
-    predicted label i and true label j.
-    For a binary problem with (1 = positive, 0 = negative):
-        ``buckets[(1, 1)]`` = true positives
-        ``buckets[(1, 0)]`` = false negatives
-        ``buckets[(0, 1)]`` = false positives
-        ``buckets[(0, 0)]`` = true negatives
 
     Parameters
     ----------
@@ -27,11 +16,39 @@ def label_buckets(*y: np.ndarray) -> Dict[Tuple[int, int], np.ndarray]:
 
     Returns
     -------
-    Dict
+    Dict[Tuple[int, ...], np.ndarray]
         A mapping of each label bucket to a NumPy array of its corresponding indices
+
+    Example
+    -------
+    A common use case is calling ``buckets = label_buckets(Y_gold, Y_pred)`` where
+    ``Y_gold`` is a set of gold (i.e. ground truth) labels and ``Y_pred`` is a
+    corresponding set of predicted labels.
+
+    >>> Y_gold = np.array([1, 1, 1, 0])
+    >>> Y_pred = np.array([1, 1, -1, -1])
+    >>> buckets = get_label_buckets(Y_gold, Y_pred)
+
+    The returned ``buckets[(i, j)]`` is a NumPy array of data point indices with
+    predicted label i and true label j.
+
+    >>> buckets[(1, 1)]  # true positives
+    array([0, 1])
+    >>> (1, 0) in buckets  # false negatives
+    False
+    >>> (0, 1) in buckets  # false positives
+    False
+    >>> (0, 0) in buckets  # true negatives
+    False
+    >>> buckets[(1, -1)]  # abstained positives
+    array([2])
+    >>> buckets[(0, -1)]  # abstained negatives
+    array([3])
     """
     buckets: DefaultDict[Tuple[int, int], List[int]] = defaultdict(list)
-    y_flat = map(lambda x: to_int_label_array(x, flatten_vector=True), y)
+    y_flat = list(map(lambda x: to_int_label_array(x, flatten_vector=True), y))
+    if len(set(map(len, y_flat))) != 1:
+        raise ValueError("Arrays must all have the same number of elements")
     for i, labels in enumerate(zip(*y_flat)):
         buckets[labels].append(i)
     return {k: np.array(v) for k, v in buckets.items()}

--- a/test/analysis/test_error_analysis.py
+++ b/test/analysis/test_error_analysis.py
@@ -2,24 +2,27 @@ import unittest
 
 import numpy as np
 
-from snorkel.analysis.error_analysis import label_buckets
+from snorkel.analysis.error_analysis import get_label_buckets
 
 
 class ErrorAnalysisTest(unittest.TestCase):
-    def test_label_buckets(self) -> None:
+    def test_get_label_buckets(self) -> None:
         y1 = np.array([[2], [1], [3], [1], [1], [3]])
         y2 = np.array([1, 2, 3, 1, 2, 3])
-        buckets = label_buckets(y1, y2)
+        buckets = get_label_buckets(y1, y2)
         expected_buckets = {(2, 1): [0], (1, 2): [1, 4], (3, 3): [2, 5], (1, 1): [3]}
         expected_buckets = {k: np.array(v) for k, v in expected_buckets.items()}
         np.testing.assert_equal(buckets, expected_buckets)
 
         y1_1d = np.array([2, 1, 3, 1, 1, 3])
-        buckets = label_buckets(y1_1d, y2)
+        buckets = get_label_buckets(y1_1d, y2)
         np.testing.assert_equal(buckets, expected_buckets)
 
+    def test_get_label_buckets_multi(self) -> None:
+        y1 = np.array([[2], [1], [3], [1], [1], [3]])
+        y2 = np.array([1, 2, 3, 1, 2, 3])
         y3 = np.array([[3], [2], [1], [1], [2], [3]])
-        buckets = label_buckets(y1, y2, y3)
+        buckets = get_label_buckets(y1, y2, y3)
         expected_buckets = {
             (2, 1, 3): [0],
             (1, 2, 2): [1, 4],
@@ -29,6 +32,10 @@ class ErrorAnalysisTest(unittest.TestCase):
         }
         expected_buckets = {k: np.array(v) for k, v in expected_buckets.items()}
         np.testing.assert_equal(buckets, expected_buckets)
+
+    def test_get_label_buckets_bad_shape(self) -> None:
+        with self.assertRaisesRegex(ValueError, "same number of elements"):
+            get_label_buckets(np.array([0, 1, 1]), np.array([1, 1]))
 
 
 if __name__ == "__main__":

--- a/test/analysis/test_error_analysis.py
+++ b/test/analysis/test_error_analysis.py
@@ -2,20 +2,33 @@ import unittest
 
 import numpy as np
 
-from snorkel.analysis.error_analysis import error_buckets
+from snorkel.analysis.error_analysis import label_buckets
 
 
 class ErrorAnalysisTest(unittest.TestCase):
-    def test_error_buckets(self) -> None:
-        golds = np.array([1, 2, 3, 1, 2, 3])
-        preds = np.array([[2], [1], [3], [1], [1], [3]])
-        buckets = error_buckets(golds, preds)
+    def test_label_buckets(self) -> None:
+        y1 = np.array([[2], [1], [3], [1], [1], [3]])
+        y2 = np.array([1, 2, 3, 1, 2, 3])
+        buckets = label_buckets(y1, y2)
         expected_buckets = {(2, 1): [0], (1, 2): [1, 4], (3, 3): [2, 5], (1, 1): [3]}
-        self.assertEqual(buckets, expected_buckets)
+        expected_buckets = {k: np.array(v) for k, v in expected_buckets.items()}
+        np.testing.assert_equal(buckets, expected_buckets)
 
-        preds_1d = np.array([2, 1, 3, 1, 1, 3])
-        buckets = error_buckets(golds, preds_1d)
-        self.assertEqual(buckets, expected_buckets)
+        y1_1d = np.array([2, 1, 3, 1, 1, 3])
+        buckets = label_buckets(y1_1d, y2)
+        np.testing.assert_equal(buckets, expected_buckets)
+
+        y3 = np.array([[3], [2], [1], [1], [2], [3]])
+        buckets = label_buckets(y1, y2, y3)
+        expected_buckets = {
+            (2, 1, 3): [0],
+            (1, 2, 2): [1, 4],
+            (3, 3, 1): [2],
+            (1, 1, 1): [3],
+            (3, 3, 3): [5],
+        }
+        expected_buckets = {k: np.array(v) for k, v in expected_buckets.items()}
+        np.testing.assert_equal(buckets, expected_buckets)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Based on session feedback. 1. remove gold/pred hardcoding 2. make the name more generic (not all errors) and 3. allow n-ary

**Test plan**
Updated unit tests