### PR TITLE
Allow remapping labelsets in Scorer API

### DIFF
--- a/snorkel/analysis/metrics.py
+++ b/snorkel/analysis/metrics.py
@@ -53,9 +53,6 @@ def metric_score(
         msg = f"The metric you provided ({metric}) is not currently implemented."
         raise ValueError(msg)
 
-    if filter_dict is None:
-        filter_dict = {"golds": [-1]}  # Assumes -1 = ABSTAIN
-
     # Print helpful error messages if golds or preds has invalid shape or type
     golds = to_int_label_array(golds) if golds is not None else None
     preds = to_int_label_array(preds) if preds is not None else None

--- a/snorkel/classification/data.py
+++ b/snorkel/classification/data.py
@@ -66,6 +66,14 @@ class DictDataset(Dataset):
         except StopIteration:
             return 0
 
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}"
+            f"(name={self.name}, "
+            f"X_keys={list(self.X_dict.keys())}, "
+            f"Y_keys={list(self.Y_dict.keys())})"
+        )
+
 
 def collate_dicts(batch: List[Batch]) -> Batch:
     """Combine many one-element dicts into a single many-element dict for both X and Y.

--- a/snorkel/classification/scorer.py
+++ b/snorkel/classification/scorer.py
@@ -91,7 +91,6 @@ class Scorer:
         metric_dict = dict()
 
         for metric_name, metric in self.metrics.items():
-            # Filter golds/preds/probs based on abstain_label
             score = metric(golds, preds, probs)
 
             if isinstance(score, dict):

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -447,11 +447,21 @@ class SnorkelClassifier(nn.Module):
         """Map each label to its corresponding task outputs based on whether the task is available.
 
         If remap_labels specified, overrides specific label -> task mappings.
+        If a label is mappied to `None`, that key is removed from the mapping.
         """
-        labels_to_tasks = {
-            name: name for name in label_names if name in self.task_flows
-        }
-        labels_to_tasks.update(remap_labels)
+        labels_to_tasks = {}
+        for label in label_names:
+            # If available in task flows, label should map to task of same name
+            if label in self.task_flows:
+                labels_to_tasks[label] = label
+
+            # Override any existing label -> task mappings
+            if label in remap_labels:
+                task = remap_labels.get(label)
+                # Note: task might be manually remapped to None to remove it from the labels_to_tasks
+                if task is not None:
+                    labels_to_tasks[label] = task
+
         return labels_to_tasks
 
     def _move_to_device(self) -> None:  # pragma: no cover

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -338,13 +338,14 @@ class SnorkelClassifier(nn.Module):
         prob_dict_list: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
         labels_to_tasks = self._get_labels_to_tasks(
-            label_names=dataloader.dataset.Y_dict.keys(), remap_labels=remap_labels
+            label_names=dataloader.dataset.Y_dict.keys(),  # type: ignore
+            remap_labels=remap_labels,
         )
         for batch_num, (X_batch_dict, Y_batch_dict) in enumerate(dataloader):
             prob_batch_dict = self._calculate_probs(
                 X_batch_dict, labels_to_tasks.values()
             )
-            for label_name in labels_to_tasks.keys():
+            for label_name in labels_to_tasks:
                 task_name = labels_to_tasks[label_name]
                 Y = Y_batch_dict[label_name]
 
@@ -399,7 +400,7 @@ class SnorkelClassifier(nn.Module):
 
         for dataloader in dataloaders:
             # Construct label to task mapping for evaluation
-            Y_dict = dataloader.dataset.Y_dict
+            Y_dict = dataloader.dataset.Y_dict  # type: ignore
             labels_to_tasks = self._get_labels_to_tasks(
                 label_names=Y_dict.keys(), remap_labels=remap_labels
             )
@@ -408,7 +409,7 @@ class SnorkelClassifier(nn.Module):
             extra_labels = set(Y_dict.keys()).difference(set(labels_to_tasks.keys()))
             if extra_labels:
                 logging.warning(
-                    f"Ignoring extra labels in dataloader ({dataloader.dataset.split}): {extra_labels}"
+                    f"Ignoring extra labels in dataloader ({dataloader.dataset.split}): {extra_labels}"  # type: ignore
                 )
 
             # Obtain predictions

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -368,8 +368,6 @@ class SnorkelClassifier(nn.Module):
         remap_labels
             A dict specifying which labels in the dataset's Y_dict (key)
             to remap to a new task (value)
-        kwargs
-            Keyword arguments to pass on to Scorer.score(golds, preds, probs, **kwargs)
 
         Returns
         -------
@@ -393,13 +391,9 @@ class SnorkelClassifier(nn.Module):
 
             for label_name, task_name in eval_dict.items():
                 # Use the original gold labels, which include abstains
-                golds = (
-                    dataloader.dataset.Y_dict[  # type:ignore
-                        label_name
-                    ]
-                    .numpy()
-                    .squeeze()
-                )
+                golds = dataloader.dataset.Y_dict[label_name]  # type:ignore
+                golds = golds.numpy().squeeze()
+
                 preds = results["preds"][task_name]
                 probs = results["probs"][task_name]
                 metric_scores = self.scorers[task_name].score(golds, preds, probs)

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -396,7 +396,9 @@ class SnorkelClassifier(nn.Module):
 
                 preds = results["preds"][task_name]
                 probs = results["probs"][task_name]
-                metric_scores = self.scorers[task_name].score(golds, preds, probs)
+                metric_scores = self.scorers[task_name].score(
+                    golds=golds, preds=preds, probs=probs
+                )
 
                 for metric_name, metric_value in metric_scores.items():
                     # Type ignore statements are necessary because the DataLoader class

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -250,6 +250,7 @@ class SnorkelClassifier(nn.Module):
         loss_dict = dict()
         count_dict = dict()
 
+        # Collect the available tasks for this module
         task_names = [name for name in Y_dict.keys() if name in self.task_flows]
         outputs = self.forward(X_dict, task_names)
 
@@ -359,7 +360,7 @@ class SnorkelClassifier(nn.Module):
 
     @torch.no_grad()
     def score(
-        self, dataloaders: List[DictDataLoader], labels_to_tasks: Dict[str, str] = {}
+        self, dataloaders: List[DictDataLoader], remap_labels: Dict[str, str] = {}
     ) -> Dict[str, float]:
         """Calculate scores for the provided DictDataLoaders.
 
@@ -367,6 +368,9 @@ class SnorkelClassifier(nn.Module):
         ----------
         dataloaders
             A list of DictDataLoaders to calculate scores for
+        remap_labels
+            A dict specifying which labels in the dataset's Y_dict (key)
+            to remap to a new task (value)
         kwargs
             Keyword arguments to pass on to Scorer.score(golds, preds, probs, **kwargs)
 
@@ -388,7 +392,7 @@ class SnorkelClassifier(nn.Module):
             # By default, evaluate each label_name on task with corresponding task_name
             eval_dict = {name: name for name in results["golds"].keys()}
             # Then, override the current results with manually specified mappings
-            eval_dict.update(labels_to_tasks)
+            eval_dict.update(remap_labels)
 
             for label_name, task_name in eval_dict.items():
                 # Use the original gold labels, which include abstains

--- a/snorkel/classification/snorkel_classifier.py
+++ b/snorkel/classification/snorkel_classifier.py
@@ -250,8 +250,7 @@ class SnorkelClassifier(nn.Module):
         loss_dict = dict()
         count_dict = dict()
 
-        # Collect the available tasks for this module
-        task_names = [name for name in Y_dict.keys() if name in self.task_flows]
+        task_names = self._get_valid_task_names(Y_dict)
         outputs = self.forward(X_dict, task_names)
 
         # Calculate loss for each task
@@ -330,9 +329,7 @@ class SnorkelClassifier(nn.Module):
         prob_dict_list: Dict[str, List[torch.Tensor]] = defaultdict(list)
 
         for batch_num, (X_batch_dict, Y_batch_dict) in enumerate(dataloader):
-            task_names = [
-                name for name in Y_batch_dict.keys() if name in self.task_flows
-            ]
+            task_names = self._get_valid_task_names(Y_batch_dict)
             prob_batch_dict = self._calculate_probs(X_batch_dict, task_names)
             for task_name in task_names:
                 Y = Y_batch_dict[task_name]
@@ -422,6 +419,10 @@ class SnorkelClassifier(nn.Module):
                     metric_score_dict[identifier] = metric_value
 
         return metric_score_dict
+
+    def _get_valid_task_names(self, Y_dict: Dict[str, torch.Tensor]) -> List[str]:
+        """Given a Y_dict, return a list of task names if appear in the task_flow."""
+        return [name for name in Y_dict.keys() if name in self.task_flows]
 
     def _move_to_device(self) -> None:  # pragma: no cover
         """Move the model to the device specified in the model config."""

--- a/snorkel/classification/task.py
+++ b/snorkel/classification/task.py
@@ -118,14 +118,14 @@ class Task:
 
 
 def ce_loss(
-    module_name: str, outputs: Outputs, Y: torch.Tensor, active: torch.Tensor
+    op_name: str, outputs: Outputs, Y: torch.Tensor, active: torch.Tensor
 ) -> torch.Tensor:
     """Calculate cross-entropy loss for the outputs of the specified module.
 
     Parameters
     ----------
-    module_name
-        The name of the module whose output should be used for calculating loss
+    op_name
+        The name of the operation whose output should be used for calculating loss
     outputs
         The dictionary of operation outputs
     Y
@@ -140,16 +140,16 @@ def ce_loss(
     """
     # Subtract 1 from hard labels in Y to account for Snorkel reserving the label 0 for
     # abstains while F.cross_entropy() expects 0-indexed labels
-    return F.cross_entropy(outputs[module_name][0][active], (Y.view(-1))[active])
+    return F.cross_entropy(outputs[op_name][0][active], (Y.view(-1))[active])
 
 
-def softmax(module_name: str, outputs: Outputs) -> torch.Tensor:
+def softmax(op_name: str, outputs: Outputs) -> torch.Tensor:
     """Calculate the softmax of the outputs of the specified module.
 
     Parameters
     ----------
-    module_name
-        The name of the module whose output should be used for calculating loss
+    op_name
+        The name of the operation whose output should be used for calculating loss
     outputs
         The dictionary of operation outputs
 
@@ -158,4 +158,4 @@ def softmax(module_name: str, outputs: Outputs) -> torch.Tensor:
     torch.Tensor
         The probabilities resulting from the softmax calculation
     """
-    return F.softmax(outputs[module_name][0], dim=1)
+    return F.softmax(outputs[op_name][0], dim=1)

--- a/test/classification/test_data.py
+++ b/test/classification/test_data.py
@@ -26,6 +26,10 @@ class DatasetTest(unittest.TestCase):
         # Check if the dataset is correctly constructed
         self.assertTrue(torch.equal(dataset[0][0]["data1"], x1[0]))
         self.assertTrue(torch.equal(dataset[0][1]["task1"], y1[0]))
+        self.assertEqual(
+            repr(dataset),
+            "DictDataset(name=new_data, X_keys=['data1'], Y_keys=['task1'])",
+        )
 
     def test_classifier_dataloader(self):
         """Unit test of DictDataLoader"""

--- a/test/classification/test_scorer.py
+++ b/test/classification/test_scorer.py
@@ -47,6 +47,30 @@ class ScorerTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Cannot score"):
             scorer.score([], [], [])
 
+    def test_abstain_labels(self) -> None:
+        # We abstain on the last example by convention (label=-1)
+        golds = np.array([1, 0, 1, 0, -1])
+        preds = np.array([1, 0, 1, 1, 0])
+        probs = np.array([0.8, 0.6, 0.9, 0.7, 0.4])
+
+        # Test no abstain
+        scorer = Scorer(metrics=["accuracy"], abstain_label=None)
+        results = scorer.score(golds, preds, probs)
+        results_expected = dict(accuracy=0.6)
+        self.assertEqual(results, results_expected)
+
+        # Test abstain=-1
+        scorer = Scorer(metrics=["accuracy"], abstain_label=-1)
+        results = scorer.score(golds, preds, probs)
+        results_expected = dict(accuracy=0.75)
+        self.assertEqual(results, results_expected)
+
+        # Test abstain set to different value
+        scorer = Scorer(metrics=["accuracy"], abstain_label=10)
+        results = scorer.score(golds, preds, probs)
+        results_expected = dict(accuracy=0.6)
+        self.assertEqual(results, results_expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -105,16 +105,22 @@ class ClassifierTest(unittest.TestCase):
         )
         dataloader = DictDataLoader(dataset, batch_size=BATCH_SIZE)
 
-        # Test setting without remapping
         model = SnorkelClassifier([self.task1])
         loss_dict, count_dict = model.calculate_loss(dataset.X_dict, dataset.Y_dict)
         self.assertIn("task1", loss_dict)
 
-        results = model.score([dataloader])
-        self.assertIn("task1/dataset/train/accuracy", results)
-        self.assertNotIn("other_task/dataset/train/accuracy", results)
+        # Test setting without remapping
+        results = model.predict(dataloader)
+        self.assertIn("task1", results["golds"])
+        self.assertNotIn("other_task", results["golds"])
+        scores = model.score([dataloader])
+        self.assertIn("task1/dataset/train/accuracy", scores)
+        self.assertNotIn("other_task/dataset/train/accuracy", scores)
 
         # Test remapped labelsets
+        results = model.predict(dataloader, remap_labels={"other_task": task_name})
+        self.assertIn("task1", results["golds"])
+        self.assertIn("other_task", results["golds"])
         results = model.score([dataloader], remap_labels={"other_task": task_name})
         self.assertIn("task1/dataset/train/accuracy", results)
         self.assertIn("other_task/dataset/train/accuracy", results)


### PR DESCRIPTION
**Changes**
1. Builds API for remapping labelsets to different tasks:
```
model.score([dl_valid], remap_labels={
        "spam_task_slice:sf_link_pred": "spam_task"
})
```

2. Support "abstain_label" in `Scorer.score` (defaults to -1)


(This PR is a cleaner take on https://github.com/HazyResearch/snorkel/pull/1323— makes less assumptions about how to name labelsets)

**Test Plan**
* Added tests for new code + `tox` passes