### PR TITLE
Remove support for multiclass (buggy) in SliceCombiner

### DIFF
--- a/snorkel/slicing/modules/slice_combiner.py
+++ b/snorkel/slicing/modules/slice_combiner.py
@@ -15,7 +15,7 @@ class SliceCombinerModule(nn.Module):
         * Prediction operations
         * Prediction transform features
 
-    NOTE: This module currently assumes binary labels.
+    NOTE: This module currently only handles binary labels.
 
     Parameters
     ----------
@@ -97,7 +97,7 @@ class SliceCombinerModule(nn.Module):
 
         predictor_confidences = torch.cat(
             [
-                # Compute the "confidence" using probability score of the positive class
+                # Compute the "confidence" using score of the positive class
                 F.softmax(output, dim=1)[:, 0].unsqueeze(-1)
                 for output in predictor_outputs
             ],

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -138,7 +138,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Train
         # NOTE: Needs more epochs to convergence with more heads
-        trainer = Trainer(lr=0.001, n_epochs=80, progress_bar=False)
+        trainer = Trainer(lr=0.001, n_epochs=60, progress_bar=False)
         trainer.fit(model, dataloaders)
         scores = model.score(dataloaders)
 

--- a/test/slicing/test_slice_combiner.py
+++ b/test/slicing/test_slice_combiner.py
@@ -199,9 +199,7 @@ class SliceCombinerTest(unittest.TestCase):
 
         # Ensure smoother temperature for multi-class
         combiner_module = SliceCombinerModule()
-        with self.assertRaisesRegexp(
-            NotImplementedError, "SliceCombiner does not support multiclass labels."
-        ):
+        with self.assertRaisesRegex(NotImplementedError, "not support multiclass"):
             combiner_module(outputs)
 
     def test_temperature(self):
@@ -251,9 +249,12 @@ class SliceCombinerTest(unittest.TestCase):
         combined_rep = combiner_module(outputs)
 
         # Check number of elements that match either of the original weights
-        num_matching_original = torch.sum(
-            torch.isclose(combined_rep, torch.ones(batch_size, h_dim) * 2, atol=1e-4)
-        ) + torch.sum(
-            torch.isclose(combined_rep, torch.ones(batch_size, h_dim) * 4, atol=1e-4)
+        # Every example should either match 2 or 4
+        isclose_four = torch.isclose(
+            combined_rep, torch.ones(batch_size, h_dim) * 2, atol=1e-4
         )
+        isclose_two = torch.isclose(
+            combined_rep, torch.ones(batch_size, h_dim) * 4, atol=1e-4
+        )
+        num_matching_original = torch.sum(isclose_four) + torch.sum(isclose_two)
         self.assertEqual(num_matching_original, batch_size * h_dim)

--- a/test/slicing/test_slice_combiner.py
+++ b/test/slicing/test_slice_combiner.py
@@ -199,17 +199,16 @@ class SliceCombinerTest(unittest.TestCase):
 
         # Ensure smoother temperature for multi-class
         combiner_module = SliceCombinerModule()
-        combined_rep = combiner_module(outputs)
-        # higher tolerance because randomness in non-max class outputs -> for softmax
-        self.assertTrue(
-            torch.allclose(combined_rep, torch.ones(batch_size, h_dim) * 3, atol=1e-2)
-        )
+        with self.assertRaisesRegexp(
+            NotImplementedError, "SliceCombiner does not support multiclass labels."
+        ):
+            combiner_module(outputs)
 
     def test_temperature(self):
         """Test temperature parameter for attention weights."""
         batch_size = 4
         h_dim = 20
-        num_classes = 3
+        num_classes = 2
 
         # Add noise to each set of inputs to attention weights
         epsilon = 1e-5
@@ -253,6 +252,8 @@ class SliceCombinerTest(unittest.TestCase):
 
         # Check number of elements that match either of the original weights
         num_matching_original = torch.sum(
-            torch.isclose(combined_rep, torch.ones(batch_size, h_dim) * 2)
-        ) + torch.sum(torch.isclose(combined_rep, torch.ones(batch_size, h_dim) * 4))
+            torch.isclose(combined_rep, torch.ones(batch_size, h_dim) * 2, atol=1e-4)
+        ) + torch.sum(
+            torch.isclose(combined_rep, torch.ones(batch_size, h_dim) * 4, atol=1e-4)
+        )
         self.assertEqual(num_matching_original, batch_size * h_dim)


### PR DESCRIPTION
* Raises `NotImplementedError` in multiclass setting

**Test Plan**
* Fixed existing tests 
* `tox` + `tox -e complex` passes