### PR TITLE
Slicing API updates

### DIFF
--- a/docs/packages/slicing.rst
+++ b/docs/packages/slicing.rst
@@ -14,8 +14,10 @@ Programmatic data set slicing: SF creation, monitoring utilities, and representa
    PandasSFApplier
    SFApplier
    SliceCombinerModule
+   SliceScorer
    SlicingFunction
    apply.spark.SparkSFApplier
    add_slice_labels
    convert_to_slice_tasks
+   slice_dataframe
    slicing_function

--- a/docs/packages/slicing.rst
+++ b/docs/packages/slicing.rst
@@ -19,5 +19,6 @@ Programmatic data set slicing: SF creation, monitoring utilities, and representa
    apply.spark.SparkSFApplier
    add_slice_labels
    convert_to_slice_tasks
+   nlp_slicing_function
    slice_dataframe
    slicing_function

--- a/snorkel/analysis/scorer.py
+++ b/snorkel/analysis/scorer.py
@@ -92,7 +92,6 @@ class Scorer:
 
         for metric_name, metric in self.metrics.items():
             score = metric(golds, preds, probs)
-
             if isinstance(score, dict):
                 metric_dict.update(score)
             else:

--- a/snorkel/classification/multitask_classifier.py
+++ b/snorkel/classification/multitask_classifier.py
@@ -396,6 +396,9 @@ class MultitaskClassifier(nn.Module):
         remap_labels
             A dict specifying which labels in the dataset's Y_dict (key)
             to remap to a new task (value)
+        as_dataframe
+            A boolean indicating whether to return results as pandas
+            DataFrame (True) or dict (False)
 
         Returns
         -------

--- a/snorkel/classification/multitask_classifier.py
+++ b/snorkel/classification/multitask_classifier.py
@@ -20,7 +20,7 @@ import torch.nn as nn
 
 from snorkel.analysis import Scorer
 from snorkel.classification.data import DictDataLoader
-from snorkel.classification.utils import move_to_device
+from snorkel.classification.utils import metrics_dict_to_dataframe, move_to_device
 from snorkel.types import Config
 from snorkel.utils import probs_to_preds
 
@@ -382,7 +382,10 @@ class MultitaskClassifier(nn.Module):
 
     @torch.no_grad()
     def score(
-        self, dataloaders: List[DictDataLoader], remap_labels: Dict[str, str] = {}
+        self,
+        dataloaders: List[DictDataLoader],
+        remap_labels: Dict[str, str] = {},
+        as_dataframe: bool = False,
     ) -> Dict[str, float]:
         """Calculate scores for the provided DictDataLoaders.
 
@@ -446,7 +449,10 @@ class MultitaskClassifier(nn.Module):
                     )
                     metric_score_dict[identifier] = metric_value
 
-        return metric_score_dict
+        if as_dataframe:
+            return metrics_dict_to_dataframe(metric_score_dict)
+        else:
+            return metric_score_dict
 
     def _get_labels_to_tasks(
         self, label_names: Iterable[str], remap_labels: Dict[str, str] = {}
@@ -458,16 +464,16 @@ class MultitaskClassifier(nn.Module):
         """
         labels_to_tasks = {}
         for label in label_names:
-            # If available in task flows, label should map to task of same name
-            if label in self.task_flows:
-                labels_to_tasks[label] = label
-
             # Override any existing label -> task mappings
             if label in remap_labels:
                 task = remap_labels.get(label)
                 # Note: task might be manually remapped to None to remove it from the labels_to_tasks
                 if task is not None:
                     labels_to_tasks[label] = task
+
+            # If available in task flows, label should map to task of same name
+            elif label in self.task_flows:
+                labels_to_tasks[label] = label
 
         return labels_to_tasks
 

--- a/snorkel/classification/utils.py
+++ b/snorkel/classification/utils.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Tuple, Union
 
 import numpy as np
+import pandas as pd
 import torch
 
 TensorCollection = Union[torch.Tensor, dict, list, tuple]
@@ -116,3 +117,17 @@ def collect_flow_outputs_by_suffix(
         for flow_name in sorted(flow_dict.keys())
         if flow_name.endswith(suffix)
     ]
+
+
+def metrics_dict_to_dataframe(metrics_dict: Dict[str, float]) -> pd.DataFrame:
+    """Format a metrics_dict (with keys 'label/dataset/split/metric') format as a pandas DataFrame."""
+
+    metrics = []
+
+    for full_metric, score in metrics_dict.items():
+        label_name, dataset_name, split, metric = tuple(full_metric.split("/"))
+        metrics.append((label_name, dataset_name, split, metric, score))
+
+    return pd.DataFrame(
+        metrics, columns=["label", "dataset", "split", "metric", "score"]
+    )

--- a/snorkel/slicing/__init__.py
+++ b/snorkel/slicing/__init__.py
@@ -2,5 +2,6 @@
 
 from .apply.core import PandasSFApplier, SFApplier  # noqa: F401
 from .modules.slice_combiner import SliceCombinerModule  # noqa: F401
+from .monitor import SliceScorer, slice_dataframe  # noqa: F401
 from .sf import SlicingFunction, slicing_function  # noqa: F401
 from .utils import add_slice_labels, convert_to_slice_tasks  # noqa: F401

--- a/snorkel/slicing/__init__.py
+++ b/snorkel/slicing/__init__.py
@@ -3,5 +3,5 @@
 from .apply.core import PandasSFApplier, SFApplier  # noqa: F401
 from .modules.slice_combiner import SliceCombinerModule  # noqa: F401
 from .monitor import SliceScorer, slice_dataframe  # noqa: F401
-from .sf import SlicingFunction, slicing_function  # noqa: F401
+from .sf import SlicingFunction, nlp_slicing_function, slicing_function  # noqa: F401
 from .utils import add_slice_labels, convert_to_slice_tasks  # noqa: F401

--- a/snorkel/slicing/monitor.py
+++ b/snorkel/slicing/monitor.py
@@ -11,7 +11,7 @@ SliceMetricsDict = Dict[str, Dict[str, float]]
 
 
 class SliceScorer:
-    """Scorer that returns metrics on overall performance and slices.
+    """Scorer that returns metrics on overall performance, as well as slices.
 
     Parameters
     ----------

--- a/snorkel/slicing/monitor.py
+++ b/snorkel/slicing/monitor.py
@@ -1,0 +1,120 @@
+from typing import Dict, List, Union
+
+import numpy as np
+import pandas as pd
+
+from snorkel.classification.scorer import Scorer
+from snorkel.labeling.lf import LabelingFunction
+from snorkel.slicing.apply import PandasSFApplier
+
+SliceMetricsDict = Dict[str, Dict[str, float]]
+
+
+class PandasSlicer:
+    """Create DataFrames corresponding to slices.
+
+    Parameters
+    ----------
+    df
+        A pandas DataFrame that will be sliced
+
+    Attributes
+    ----------
+    df
+        See above.
+    """
+
+    def __init__(self, df: pd.DataFrame):
+        self.df = df
+
+    def slice(self, slicing_function: LabelingFunction) -> pd.DataFrame:
+        """Return a dataframe with examples corresponding to specified slice_name.
+
+        Parameters
+        ----------
+        slicing_function
+            slicing_function which will operate over self.df to return a subset of examples
+
+        Returns
+        -------
+        pd.DataFrame
+            A DataFrame including only examples belonging to slice_name
+        """
+
+        S_matrix = PandasSFApplier([slicing_function]).apply(self.df)
+
+        # Index into the SF labels for the first (and only) column
+        df_idx = np.where(S_matrix[:, 0])[0]
+        return self.df.iloc[df_idx]
+
+
+class SliceScorer:
+    """Scorer that returns metrics on overall performance and slices.
+
+    Parameters
+    ----------
+    scorer
+        A pre-defined ``Scorer`` used for evaluation
+    slice_names
+        A list of slice names corresponding to columns of ``S_matrix`` (accepted by score method)
+
+    Attributes
+    ----------
+    scorer
+        See above
+    slice_names
+        See above.
+    """
+
+    def __init__(self, scorer: Scorer, slice_names: List[str]):
+        self.scorer = scorer
+        self.slice_names = slice_names
+
+    def score(
+        self,
+        S_matrix: np.ndarray,
+        golds: np.ndarray,
+        preds: np.ndarray,
+        probs: np.ndarray,
+        as_dataframe: bool = False,
+    ) -> Union[SliceMetricsDict, pd.DataFrame]:
+        """Calculate user-specified and/or user-defined metrics overall + slices.
+
+        Parameters
+        ----------
+        S_matrix
+            An [num_examples x num_slices] matrix of slicing function outputs
+        golds
+            Gold (aka ground truth) labels (integers)
+        preds
+            Predictions (integers)
+        probs:
+            Probabilities (floats)
+        as_dataframe
+            A boolean indicating whether to return results as pandas DataFrame (True)
+            or dict (False)
+
+        Returns
+        -------
+        Union[SliceMetricsDict, pd.DataFrame]
+            A dictionary mapping slice_name to metric names to metric scores
+            or aforementioned dictionary formatted as pandas DataFrame
+        """
+        assert S_matrix.shape[1] == len(self.slice_names)
+        assert S_matrix.shape[0] == len(golds) == len(preds) == len(probs)
+
+        # Include overall metrics
+        metrics_dict = dict()
+        metrics_dict.update({"overall": self.scorer.score(golds, preds, probs)})
+
+        # Include slice metrics
+        for idx, slice_name in enumerate(self.slice_names):
+            mask = S_matrix[:, idx].astype(bool)
+            metrics_dict.update(
+                {slice_name: self.scorer.score(golds[mask], preds[mask], probs[mask])}
+            )
+
+        if as_dataframe:
+            return pd.DataFrame.from_dict(metrics_dict).transpose()
+        else:
+            return metrics_dict

--- a/snorkel/slicing/monitor.py
+++ b/snorkel/slicing/monitor.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Union
 import numpy as np
 import pandas as pd
 
-from snorkel.classification.scorer import Scorer
+from snorkel.analysis.scorer import Scorer
 from snorkel.labeling.lf import LabelingFunction
 from snorkel.slicing import PandasSFApplier
 

--- a/snorkel/slicing/monitor.py
+++ b/snorkel/slicing/monitor.py
@@ -5,7 +5,7 @@ import pandas as pd
 
 from snorkel.classification.scorer import Scorer
 from snorkel.labeling.lf import LabelingFunction
-from snorkel.slicing.apply import PandasSFApplier
+from snorkel.slicing import PandasSFApplier
 
 SliceMetricsDict = Dict[str, Dict[str, float]]
 

--- a/snorkel/slicing/sf.py
+++ b/snorkel/slicing/sf.py
@@ -1,4 +1,5 @@
 from snorkel.labeling.lf import LabelingFunction, labeling_function
+from snorkel.labeling.lf.nlp import nlp_labeling_function
 
 
 class SlicingFunction(LabelingFunction):
@@ -14,6 +15,15 @@ class slicing_function(labeling_function):
     """Decorator to define a SlicingFunction object from a function.
 
     See ``snorkel.labeling.lf.labeling_function`` for details.
+    """
+
+    pass
+
+
+class nlp_slicing_function(nlp_labeling_function):
+    """Decorator to define a NLPSlicingFunction object from a function.
+
+    See ``snorkel.labeling.lf.nlp_labeling_function`` for details.
     """
 
     pass

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -14,7 +14,7 @@ from .modules.slice_combiner import SliceCombinerModule
 def add_slice_labels(
     dataloader: DictDataLoader,
     base_task: Task,
-    slice_labels: np.ndarray,
+    S_matrix: np.ndarray,
     slice_names: List[str],
 ) -> None:
     """Modify a dataloader in-place, adding labels for slice tasks.
@@ -25,13 +25,13 @@ def add_slice_labels(
         A DictDataLoader whose dataset.Y_dict attribute will be modified in place
     base_task
        The Task for which we want corresponding slice tasks/labels
-    slice_labels
+       S_matrix
         A [num_examples x num_slices] slice matrix (output of SFApplier)
     slice_names
         A list of slice names corresponding to columns of ``slice_labels``
     """
 
-    slice_labels, slice_names = _add_base_slice(slice_labels, slice_names)
+    slice_labels, slice_names = _add_base_slice(S_matrix, slice_names)
     assert slice_labels.shape[1] == len(slice_names)
 
     Y_dict: Dict[str, np.ndarray] = dataloader.dataset.Y_dict  # type: ignore

--- a/test/classification/test_snorkel_classifier.py
+++ b/test/classification/test_snorkel_classifier.py
@@ -3,6 +3,7 @@ import tempfile
 import unittest
 
 import numpy as np
+import pandas as pd
 import torch
 import torch.nn as nn
 
@@ -135,6 +136,11 @@ class ClassifierTest(unittest.TestCase):
         metrics = model.score([self.dataloader])
         # deterministic random tie breaking alternates predicted labels
         self.assertEqual(metrics["task1/dataset/train/accuracy"], 0.4)
+
+        # test dataframe format
+        metrics_df = model.score([self.dataloader], as_dataframe=True)
+        self.assertTrue(isinstance(metrics_df, pd.DataFrame))
+        self.assertEqual(metrics_df.at[0, "score"], 0.4)
 
     def test_score_shuffled(self):
         # Test scoring with a shuffled dataset

--- a/test/slicing/test_monitor.py
+++ b/test/slicing/test_monitor.py
@@ -1,0 +1,61 @@
+import unittest
+from types import SimpleNamespace
+
+import numpy as np
+import pandas as pd
+
+from snorkel.analysis.utils import preds_to_probs
+from snorkel.classification.scorer import Scorer
+from snorkel.slicing.apply import SFApplier
+from snorkel.slicing.monitor import PandasSlicer, SliceScorer
+from snorkel.slicing.sf import slicing_function
+
+DATA = [5, 10, 19, 22, 25]
+
+
+@slicing_function()
+def sf(x):
+    return x.num < 20
+
+
+class PandasSlicerTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.df = pd.DataFrame(dict(num=DATA))
+
+    def test_slice(self):
+        self.assertEqual(len(self.df), 5)
+        slicer = PandasSlicer(self.df)
+
+        # Should return a subset
+        sliced_df = slicer.slice(sf)
+        self.assertEqual(len(sliced_df), 3)
+
+
+class SliceScorerTest(unittest.TestCase):
+    def test_slice(self):
+        # We expect 3/5 correct -> 0.6 accuracy
+        golds = np.array([0, 1, 0, 1, 0])
+        preds = np.array([0, 0, 0, 0, 0])
+        probs = preds_to_probs(preds, 2)
+
+        scorer = Scorer(metrics=["accuracy"])
+        metrics = scorer.score(golds, preds, probs)
+        self.assertEqual(metrics["accuracy"], 0.6)
+
+        # In the slice, we expect the last 2 elements to masked
+        # We expect 2/3 correct -> 0.666 accuracy
+        data = [SimpleNamespace(num=x) for x in DATA]
+        S_matrix = SFApplier([sf]).apply(data)
+        slice_names = [sf.name]
+        scorer = SliceScorer(scorer, slice_names)
+        metrics = scorer.score(S_matrix=S_matrix, golds=golds, preds=preds, probs=probs)
+        self.assertEqual(metrics["overall"]["accuracy"], 0.6)
+        self.assertEqual(metrics["sf"]["accuracy"], 2.0 / 3.0)
+
+        metrics_df = scorer.score(
+            S_matrix=S_matrix, golds=golds, preds=preds, probs=probs, as_dataframe=True
+        )
+        self.assertTrue(isinstance(metrics_df, pd.DataFrame))
+        self.assertEqual(metrics_df["accuracy"]["overall"], 0.6)
+        self.assertEqual(metrics_df["accuracy"]["sf"], 2.0 / 3.0)

--- a/test/slicing/test_monitor.py
+++ b/test/slicing/test_monitor.py
@@ -4,7 +4,7 @@ from types import SimpleNamespace
 import numpy as np
 import pandas as pd
 
-from snorkel.classification.scorer import Scorer
+from snorkel.analysis.scorer import Scorer
 from snorkel.slicing import SFApplier
 from snorkel.slicing.monitor import SliceScorer, slice_dataframe
 from snorkel.slicing.sf import slicing_function

--- a/test/slicing/test_monitor.py
+++ b/test/slicing/test_monitor.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from snorkel.classification.scorer import Scorer
 from snorkel.slicing import SFApplier
-from snorkel.slicing.monitor import PandasSlicer, SliceScorer
+from snorkel.slicing.monitor import SliceScorer, slice_dataframe
 from snorkel.slicing.sf import slicing_function
 from snorkel.utils import preds_to_probs
 
@@ -25,10 +25,9 @@ class PandasSlicerTest(unittest.TestCase):
 
     def test_slice(self):
         self.assertEqual(len(self.df), 5)
-        slicer = PandasSlicer(self.df)
 
         # Should return a subset
-        sliced_df = slicer.slice(sf)
+        sliced_df = slice_dataframe(self.df, sf)
         self.assertEqual(len(sliced_df), 3)
 
 
@@ -49,12 +48,12 @@ class SliceScorerTest(unittest.TestCase):
         S_matrix = SFApplier([sf]).apply(data)
         slice_names = [sf.name]
         scorer = SliceScorer(scorer, slice_names)
-        metrics = scorer.score(S_matrix=S_matrix, golds=golds, preds=preds, probs=probs)
+        metrics = scorer.score(S=S_matrix, golds=golds, preds=preds, probs=probs)
         self.assertEqual(metrics["overall"]["accuracy"], 0.6)
         self.assertEqual(metrics["sf"]["accuracy"], 2.0 / 3.0)
 
         metrics_df = scorer.score(
-            S_matrix=S_matrix, golds=golds, preds=preds, probs=probs, as_dataframe=True
+            S=S_matrix, golds=golds, preds=preds, probs=probs, as_dataframe=True
         )
         self.assertTrue(isinstance(metrics_df, pd.DataFrame))
         self.assertEqual(metrics_df["accuracy"]["overall"], 0.6)

--- a/test/slicing/test_monitor.py
+++ b/test/slicing/test_monitor.py
@@ -4,11 +4,11 @@ from types import SimpleNamespace
 import numpy as np
 import pandas as pd
 
-from snorkel.analysis.utils import preds_to_probs
 from snorkel.classification.scorer import Scorer
-from snorkel.slicing.apply import SFApplier
+from snorkel.slicing import SFApplier
 from snorkel.slicing.monitor import PandasSlicer, SliceScorer
 from snorkel.slicing.sf import slicing_function
+from snorkel.utils import preds_to_probs
 
 DATA = [5, 10, 19, 22, 25]
 


### PR DESCRIPTION
**Changes**
- [x] Add `PandasSlicer` for visualization
```
pd_slicer = PandasSlicer(df_valid)
polarity_df = pd_slicer.slice(textblob_polarity)
polarity_df[["text", "label"]].head()
```

- [x] Add `SliceScorer`
```
scorer = Scorer(metrics=["accuracy", "f1"])
scorer = SliceScorer(slice_names, scorer)
scorer.score(
    S_matrix=S_test,
    golds=Y_test,
    preds=preds_test,
    probs=preds_to_probs(preds_test, 2),
    as_dataframe=True,
)
```
- [x] Add dataframe visualizers to existing methods
```
slice_model.score([dl_valid], as_dataframe=True)
```

**Bug fixes**
- ~~Fix `slicing_function` alias to `labeling_function` decorator (currently initializes a `LabelingFunction`)~~ Moving to a separate PR

**Test Plan**
* Add associated tests for above changes
* `tox` + `tox -e complex` passes 