### PR TITLE
[EASY] Refactor SnorkelClassifier as MultitaskClassifier

### DIFF
--- a/docs/packages/classification.rst
+++ b/docs/packages/classification.rst
@@ -17,8 +17,8 @@ PyTorch-based multi-task learning framework for discriminative modeling.
    LogManagerConfig
    LogWriter
    LogWriterConfig
+   MultitaskClassifier
    Operation
-   SnorkelClassifier
    Task
    TensorBoardWriter
    Trainer

--- a/snorkel/classification/__init__.py
+++ b/snorkel/classification/__init__.py
@@ -1,7 +1,7 @@
 """PyTorch-based multi-task learning framework for discriminative modeling."""
 
 from .data import DictDataLoader, DictDataset  # noqa: F401
-from .snorkel_classifier import SnorkelClassifier  # noqa: F401
+from .multitask_classifier import MultitaskClassifier  # noqa: F401
 from .task import Operation, Task, ce_loss, softmax  # noqa: F401
 from .training.loggers import (  # noqa: F401
     Checkpointer,

--- a/snorkel/classification/multitask_classifier.py
+++ b/snorkel/classification/multitask_classifier.py
@@ -46,7 +46,7 @@ class ClassifierConfig(Config):
     dataparallel: bool = True
 
 
-class SnorkelClassifier(nn.Module):
+class MultitaskClassifier(nn.Module):
     r"""A classifier built from one or more tasks to support advanced workflows.
 
     Parameters

--- a/snorkel/classification/training/loggers/checkpointer.py
+++ b/snorkel/classification/training/loggers/checkpointer.py
@@ -4,7 +4,7 @@ import os
 from shutil import copyfile
 from typing import Any, Dict, Iterable, List, Optional, Set
 
-from snorkel.classification.snorkel_classifier import SnorkelClassifier
+from snorkel.classification.multitask_classifier import MultitaskClassifier
 from snorkel.types import Config
 
 Metrics = Dict[str, float]
@@ -105,7 +105,7 @@ class Checkpointer:
         self.best_metric_dict: Dict[str, float] = {}
 
     def checkpoint(
-        self, iteration: float, model: SnorkelClassifier, metric_dict: Metrics
+        self, iteration: float, model: MultitaskClassifier, metric_dict: Metrics
     ) -> None:
         """Check if iteration and current metrics necessitate a checkpoint.
 
@@ -183,7 +183,7 @@ class Checkpointer:
             for fname in file_list:
                 os.remove(fname)
 
-    def load_best_model(self, model: SnorkelClassifier) -> SnorkelClassifier:
+    def load_best_model(self, model: MultitaskClassifier) -> MultitaskClassifier:
         """Load the best model from the checkpoint."""
         metric = list(self.checkpoint_metric.keys())[0]
         if metric not in self.best_metric_dict:  # pragma: no cover

--- a/snorkel/classification/training/loggers/log_manager.py
+++ b/snorkel/classification/training/loggers/log_manager.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-from snorkel.classification.snorkel_classifier import SnorkelClassifier
+from snorkel.classification.multitask_classifier import MultitaskClassifier
 from snorkel.types import Config
 
 from .checkpointer import Checkpointer
@@ -127,7 +127,7 @@ class LogManager:
         self.epoch_count = 0
         self.unit_count = 0
 
-    def close(self, model: SnorkelClassifier) -> SnorkelClassifier:
+    def close(self, model: MultitaskClassifier) -> MultitaskClassifier:
         """Close the log writer and checkpointer if needed. Reload best model."""
         if self.log_writer is not None:
             self.log_writer.close()

--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -8,9 +8,9 @@ import torch.optim as optim
 from tqdm import tqdm
 
 from snorkel.classification.data import DictDataLoader  # noqa: F401
-from snorkel.classification.snorkel_classifier import (
+from snorkel.classification.multitask_classifier import (
     ClassifierConfig,
-    SnorkelClassifier,
+    MultitaskClassifier,
 )
 from snorkel.types import Config
 from snorkel.utils.config_utils import merge_config
@@ -55,7 +55,7 @@ class TrainerConfig(Config):
     progress_bar
         If True, print a tqdm progress bar during training
     model_config
-        Settings for the SnorkelClassifier
+        Settings for the MultitaskClassifier
     log_manager_config
         Settings for the LogManager
     checkpointing
@@ -105,7 +105,7 @@ class TrainerConfig(Config):
 
 
 class Trainer:
-    """A class for training a SnorkelClassifier.
+    """A class for training a MultitaskClassifier.
 
     Parameters
     ----------
@@ -141,9 +141,9 @@ class Trainer:
         self.name = name if name is not None else type(self).__name__
 
     def fit(
-        self, model: SnorkelClassifier, dataloaders: List["DictDataLoader"]
+        self, model: MultitaskClassifier, dataloaders: List["DictDataLoader"]
     ) -> None:
-        """Train a SnorkelClassifier.
+        """Train a MultitaskClassifier.
 
         Parameters
         ----------
@@ -419,7 +419,7 @@ class Trainer:
         self.batch_scheduler = scheduler_class()  # type: ignore
 
     def _evaluate(
-        self, model: SnorkelClassifier, dataloaders: List["DictDataLoader"], split: str
+        self, model: MultitaskClassifier, dataloaders: List["DictDataLoader"], split: str
     ) -> Metrics:
         """Evalute the current quality of the model on data for the requested split."""
         loaders = [d for d in dataloaders if d.dataset.split in split]  # type: ignore
@@ -427,7 +427,7 @@ class Trainer:
 
     def _logging(
         self,
-        model: SnorkelClassifier,
+        model: MultitaskClassifier,
         dataloaders: List["DictDataLoader"],
         batch_size: int,
     ) -> Metrics:
@@ -468,7 +468,7 @@ class Trainer:
                     metric_name, metric_value, self.log_manager.point_total
                 )
 
-    def _checkpoint_model(self, model: SnorkelClassifier, metric_dict: Metrics) -> None:
+    def _checkpoint_model(self, model: MultitaskClassifier, metric_dict: Metrics) -> None:
         """Save the current model."""
         if self.checkpointer is not None:
             self.checkpointer.checkpoint(

--- a/snorkel/classification/training/trainer.py
+++ b/snorkel/classification/training/trainer.py
@@ -419,7 +419,10 @@ class Trainer:
         self.batch_scheduler = scheduler_class()  # type: ignore
 
     def _evaluate(
-        self, model: MultitaskClassifier, dataloaders: List["DictDataLoader"], split: str
+        self,
+        model: MultitaskClassifier,
+        dataloaders: List["DictDataLoader"],
+        split: str,
     ) -> Metrics:
         """Evalute the current quality of the model on data for the requested split."""
         loaders = [d for d in dataloaders if d.dataset.split in split]  # type: ignore
@@ -468,7 +471,9 @@ class Trainer:
                     metric_name, metric_value, self.log_manager.point_total
                 )
 
-    def _checkpoint_model(self, model: MultitaskClassifier, metric_dict: Metrics) -> None:
+    def _checkpoint_model(
+        self, model: MultitaskClassifier, metric_dict: Metrics
+    ) -> None:
         """Save the current model."""
         if self.checkpointer is not None:
             self.checkpointer.checkpoint(

--- a/snorkel/slicing/utils.py
+++ b/snorkel/slicing/utils.py
@@ -6,7 +6,7 @@ from torch import nn
 
 from snorkel.analysis import Scorer
 from snorkel.classification.data import DictDataLoader
-from snorkel.classification.snorkel_classifier import Operation, Task
+from snorkel.classification.multitask_classifier import Operation, Task
 
 from .modules.slice_combiner import SliceCombinerModule
 

--- a/test/classification/training/loggers/test_checkpointer.py
+++ b/test/classification/training/loggers/test_checkpointer.py
@@ -3,7 +3,7 @@ import shutil
 import tempfile
 import unittest
 
-from snorkel.classification.snorkel_classifier import SnorkelClassifier
+from snorkel.classification.multitask_classifier import MultitaskClassifier
 from snorkel.classification.training.loggers import Checkpointer
 
 log_manager_config = {"counter_unit": "epochs", "evaluation_freq": 1}
@@ -23,7 +23,7 @@ class TestLogManager(unittest.TestCase):
             checkpoint_runway=3,
             checkpoint_metric="task/dataset/valid/f1:max",
         )
-        model = SnorkelClassifier([])
+        model = MultitaskClassifier([])
         checkpointer.checkpoint(2, model, {"task/dataset/valid/f1": 0.5})
         self.assertEqual(len(checkpointer.best_metric_dict), 0)
         checkpointer.checkpoint(
@@ -40,7 +40,7 @@ class TestLogManager(unittest.TestCase):
             checkpoint_runway=3,
             checkpoint_metric="task/dataset/valid/f1:min",
         )
-        model = SnorkelClassifier([])
+        model = MultitaskClassifier([])
         checkpointer.checkpoint(
             3, model, {"task/dataset/valid/f1": 0.8, "task/dataset/valid/f2": 0.5}
         )
@@ -56,7 +56,7 @@ class TestLogManager(unittest.TestCase):
             checkpoint_metric="task/dataset/valid/f1:max",
             checkpoint_clear=True,
         )
-        model = SnorkelClassifier([])
+        model = MultitaskClassifier([])
         checkpointer.checkpoint(1, model, {"task/dataset/valid/f1": 0.8})
         expected_files = ["checkpoint_1.pth", "best_model_task_dataset_valid_f1.pth"]
         self.assertEqual(set(os.listdir(checkpoint_dir)), set(expected_files))
@@ -71,7 +71,7 @@ class TestLogManager(unittest.TestCase):
             checkpoint_dir=checkpoint_dir,
             checkpoint_metric="task/dataset/valid/f1:max",
         )
-        model = SnorkelClassifier([])
+        model = MultitaskClassifier([])
         checkpointer.checkpoint(1, model, {"task/dataset/valid/f1": 0.8})
         load_model = checkpointer.load_best_model(model)
         self.assertEqual(model, load_model)

--- a/test/classification/training/loggers/test_log_manager.py
+++ b/test/classification/training/loggers/test_log_manager.py
@@ -2,7 +2,7 @@ import shutil
 import tempfile
 import unittest
 
-from snorkel.classification.snorkel_classifier import SnorkelClassifier
+from snorkel.classification.multitask_classifier import MultitaskClassifier
 from snorkel.classification.training.loggers import Checkpointer, LogManager, LogWriter
 
 
@@ -117,7 +117,7 @@ class TestLogManager(unittest.TestCase):
             n_batches_per_epoch=2, checkpointer=checkpointer, log_writer=log_writer
         )
 
-        classifier = SnorkelClassifier([])
+        classifier = MultitaskClassifier([])
         best_classifier = log_manager.close(classifier)
         self.assertEqual(best_classifier, classifier)
 

--- a/test/classification/training/test_trainer.py
+++ b/test/classification/training/test_trainer.py
@@ -9,8 +9,8 @@ import torch.optim as optim
 from snorkel.classification import (
     DictDataLoader,
     DictDataset,
+    MultitaskClassifier,
     Operation,
-    SnorkelClassifier,
     Task,
     Trainer,
 )
@@ -61,7 +61,7 @@ tasks = [
     create_task(TASK_NAMES[0], module_suffixes=["A", "A"]),
     create_task(TASK_NAMES[1], module_suffixes=["A", "B"]),
 ]
-model = SnorkelClassifier([tasks[0]])
+model = MultitaskClassifier([tasks[0]])
 
 
 class TrainerTest(unittest.TestCase):
@@ -72,7 +72,7 @@ class TrainerTest(unittest.TestCase):
 
     def test_trainer_twotask(self):
         """Train a model with overlapping modules and flows"""
-        multitask_model = SnorkelClassifier(tasks)
+        multitask_model = MultitaskClassifier(tasks)
         trainer = Trainer(**base_config)
         trainer.fit(multitask_model, dataloaders)
 

--- a/test/slicing/test_convergence.py
+++ b/test/slicing/test_convergence.py
@@ -11,8 +11,8 @@ from snorkel.analysis import Scorer
 from snorkel.classification import (
     DictDataLoader,
     DictDataset,
+    MultitaskClassifier,
     Operation,
-    SnorkelClassifier,
     Task,
     Trainer,
 )
@@ -92,7 +92,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Convert to slice tasks
         tasks = convert_to_slice_tasks(base_task, slice_names)
-        model = SnorkelClassifier(tasks=tasks)
+        model = MultitaskClassifier(tasks=tasks)
 
         # Train
         trainer = Trainer(lr=0.001, n_epochs=50, progress_bar=False)
@@ -142,7 +142,7 @@ class SlicingConvergenceTest(unittest.TestCase):
 
         # Convert to slice tasks
         tasks = convert_to_slice_tasks(base_task, slice_names)
-        model = SnorkelClassifier(tasks=tasks)
+        model = MultitaskClassifier(tasks=tasks)
 
         # Train
         # NOTE: Needs more epochs to convergence with more heads


### PR DESCRIPTION
Renames SnorkelClassifier as MultitaskClassifier to make it clear what use cases this model is intended for. We replace all instances of the class name and change the name of the file containing the class from `snorkel_classifier.py` to `multitask_classifier.py`.

**Test plan:**
`tox`
Corresponding PR in `snorkel-tutorials` updates usage there