### PR TITLE
Add meaningful repr to appliers

### DIFF
--- a/snorkel/augmentation/apply/core.py
+++ b/snorkel/augmentation/apply/core.py
@@ -25,8 +25,8 @@ class BaseTFApplier:
 
     Raises
     ------
-    NotImplementedError
-        ``apply`` method must be implemented by subclasses
+    ValueError
+        If names of TFs are not unique
     """
 
     def __init__(self, tfs: List[BaseTransformationFunction], policy: Policy) -> None:

--- a/snorkel/augmentation/apply/core.py
+++ b/snorkel/augmentation/apply/core.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 from snorkel.augmentation.policy.core import Policy
 from snorkel.augmentation.tf import BaseTransformationFunction
 from snorkel.types import DataPoint, DataPoints
+from snorkel.utils.data_operators import check_unique_names
 
 
 class BaseTFApplier:
@@ -30,6 +31,8 @@ class BaseTFApplier:
 
     def __init__(self, tfs: List[BaseTransformationFunction], policy: Policy) -> None:
         self._tfs = tfs
+        self._tf_names = [tf.name for tf in tfs]
+        check_unique_names(self._tf_names)
         self._policy = policy
 
     def _apply_policy_to_data_point(self, x: DataPoint) -> DataPoints:
@@ -50,6 +53,10 @@ class BaseTFApplier:
             if transform_applied:
                 x_transformed.append(x_t)
         return x_transformed
+
+    def __repr__(self) -> str:
+        policy_name = type(self._policy).__name__
+        return f"{type(self).__name__}, Policy: {policy_name}, TFs: {self._tf_names}"
 
 
 class TFApplier(BaseTFApplier):

--- a/snorkel/labeling/apply/core.py
+++ b/snorkel/labeling/apply/core.py
@@ -6,6 +6,7 @@ from tqdm import tqdm
 
 from snorkel.labeling.lf import LabelingFunction
 from snorkel.types import DataPoint, DataPoints
+from snorkel.utils.data_operators import check_unique_names
 
 RowData = List[Tuple[int, int, int]]
 
@@ -25,12 +26,14 @@ class BaseLFApplier:
 
     Raises
     ------
-    NotImplementedError
-        ``apply`` method must be implemented by subclasses
+    ValueError
+        If names of LFs are not unique
     """
 
     def __init__(self, lfs: List[LabelingFunction]) -> None:
         self._lfs = lfs
+        self._lf_names = [lf.name for lf in lfs]
+        check_unique_names(self._lf_names)
 
     def _matrix_from_row_data(self, labels: List[RowData]) -> np.ndarray:
         L = np.zeros((len(labels), len(self._lfs)), dtype=int) - 1
@@ -39,6 +42,9 @@ class BaseLFApplier:
             row, col, data = zip(*chain.from_iterable(labels))
             L[row, col] = data
         return L
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}, LFs: {self._lf_names}"
 
 
 def apply_lfs_to_data_point(

--- a/snorkel/utils/data_operators.py
+++ b/snorkel/utils/data_operators.py
@@ -1,0 +1,9 @@
+from collections import Counter
+from typing import List
+
+
+def check_unique_names(names: List[str]) -> None:
+    """Check that operator names are unique."""
+    k, ct = Counter(names).most_common(1)[0]
+    if ct > 1:
+        raise ValueError(f"Operator names not unique: {ct} operators with name {k}")

--- a/test/labeling/apply/test_lf_applier.py
+++ b/test/labeling/apply/test_lf_applier.py
@@ -92,7 +92,7 @@ class TestLFApplier(unittest.TestCase):
 
     def test_lf_applier_no_labels(self) -> None:
         data_points = [SimpleNamespace(num=num) for num in DATA]
-        applier = LFApplier([h, h])
+        applier = LFApplier([h])
         L = applier.apply(data_points)
         np.testing.assert_equal(L, -1)
 

--- a/test/utils/test_data_operators.py
+++ b/test/utils/test_data_operators.py
@@ -1,0 +1,10 @@
+import unittest
+
+from snorkel.utils.data_operators import check_unique_names
+
+
+class DataOperatorsTest(unittest.TestCase):
+    def test_check_unique_names(self):
+        check_unique_names(["alice", "bob", "chuck"])
+        with self.assertRaisesRegex(ValueError, "3 operators with name c"):
+            check_unique_names(["a", "a", "b", "c", "c", "c"])


### PR DESCRIPTION
Also enforces unique LF/TF naming

**Test plan**
Added unit test. Note we don't currently unit test reprs, so I manually validated.