### PR TITLE
Add Spark version of NLPLabelingFunction

### DIFF
--- a/docs/packages.json
+++ b/docs/packages.json
@@ -15,7 +15,9 @@
             "apply.dask.PandasParallelLFApplier",
             "apply.spark.SparkLFApplier",
             "lf.nlp.NLPLabelingFunction",
-            "lf.nlp.nlp_labeling_function"
+            "lf.nlp.nlp_labeling_function",
+            "lf.nlp_spark.SparkNLPLabelingFunction",
+            "lf.nlp_spark.spark_nlp_labeling_function"
         ],
         "map": [
             "spark.make_spark_mapper"

--- a/docs/packages/labeling.rst
+++ b/docs/packages/labeling.rst
@@ -21,6 +21,8 @@ Programmatic data set labeling: LF creation, models, and analysis utilities.
    apply.dask.PandasParallelLFApplier
    RandomVoter
    apply.spark.SparkLFApplier
+   lf.nlp_spark.SparkNLPLabelingFunction
    filter_unlabeled_dataframe
    labeling_function
    lf.nlp.nlp_labeling_function
+   lf.nlp_spark.spark_nlp_labeling_function

--- a/snorkel/labeling/lf/nlp.py
+++ b/snorkel/labeling/lf/nlp.py
@@ -27,22 +27,87 @@ class SpacyPreprocessorConfig(NamedTuple):
     parameters: SpacyPreprocessorParameters
 
 
-class NLPLabelingFunction(LabelingFunction):
-    r"""Special labeling function type for SpaCy-based LFs.
+class BaseNLPLabelingFunction(LabelingFunction):
+    """Base class for spaCy-based LFs."""
+
+    _nlp_config: SpacyPreprocessorConfig
+
+    @classmethod
+    def _create_preprocessor(
+        cls, parameters: SpacyPreprocessorParameters
+    ) -> SpacyPreprocessor:
+        raise NotImplementedError
+
+    @classmethod
+    def _create_or_check_preprocessor(
+        cls,
+        text_field: str,
+        doc_field: str,
+        language: str,
+        disable: Optional[List[str]],
+        pre: List[BasePreprocessor],
+        memoize: bool,
+    ) -> None:
+        # Create a SpacyPreprocessor if one has not yet been instantiated.
+        # Otherwise, check that configuration matches already instantiated one.
+        parameters = SpacyPreprocessorParameters(
+            text_field=text_field,
+            doc_field=doc_field,
+            language=language,
+            disable=disable,
+            pre=pre,
+            memoize=memoize,
+        )
+        if not hasattr(cls, "_nlp_config"):
+            nlp = cls._create_preprocessor(parameters)
+            cls._nlp_config = SpacyPreprocessorConfig(nlp=nlp, parameters=parameters)
+        elif parameters != cls._nlp_config.parameters:
+            raise ValueError(
+                "{cls.__name__} already configured with different parameters: "
+                f"{cls._nlp_config.parameters}"
+            )
+
+    def __init__(
+        self,
+        name: str,
+        f: Callable[..., int],
+        resources: Optional[Mapping[str, Any]] = None,
+        pre: Optional[List[BasePreprocessor]] = None,
+        fault_tolerant: bool = False,
+        text_field: str = "text",
+        doc_field: str = "doc",
+        language: str = EN_CORE_WEB_SM,
+        disable: Optional[List[str]] = None,
+        memoize: bool = True,
+    ) -> None:
+        self._create_or_check_preprocessor(
+            text_field, doc_field, language, disable, pre or [], memoize
+        )
+        super().__init__(
+            name,
+            f,
+            resources=resources,
+            pre=[self._nlp_config.nlp],
+            fault_tolerant=fault_tolerant,
+        )
+
+
+class NLPLabelingFunction(BaseNLPLabelingFunction):
+    r"""Special labeling function type for spaCy-based LFs.
 
     This class is a special version of ``LabelingFunction``. It
     has a ``SpacyPreprocessor`` integrated which shares a cache
     with all other ``NLPLabelingFunction`` instances. This makes
     it easy to define LFs that have a text input field and have
-    logic written over SpaCy ``Doc`` objects. Examples passed
+    logic written over spaCy ``Doc`` objects. Examples passed
     into an ``NLPLabelingFunction`` will have a new field which
-    can be accessed which contains a SpaCy ``Doc``. By default,
+    can be accessed which contains a spaCy ``Doc``. By default,
     this field is called ``doc``. A ``Doc`` object is
     a sequence of ``Token`` objects, which contain information
     on lemmatization, parts-of-speech, etc. ``Doc`` objects also
     contain fields like ``Doc.ents``, a list of named entities,
     and ``Doc.noun_chunks``, a list of noun phrases. For details
-    of SpaCy ``Doc`` objects and a full attribute listing,
+    of spaCy ``Doc`` objects and a full attribute listing,
     see https://spacy.io/api/doc.
 
     Simple ``NLPLabelingFunction``\s can be defined via a
@@ -65,7 +130,7 @@ class NLPLabelingFunction(LabelingFunction):
     doc_field
         Name of data point field to output parsed document to
     language
-        SpaCy model to load
+        spaCy model to load
         See https://spacy.io/usage/models#usage
     disable
         List of pipeline components to disable
@@ -100,41 +165,21 @@ class NLPLabelingFunction(LabelingFunction):
         See above
     """
 
-    _nlp_config: SpacyPreprocessorConfig
-
     @classmethod
-    def _create_or_check_preprocessor(
-        cls,
-        text_field: str,
-        doc_field: str,
-        language: str,
-        disable: Optional[List[str]],
-        pre: List[BasePreprocessor],
-        memoize: bool,
-    ) -> None:
-        # Create a SpacyPreprocessor if one has not yet been instantiated.
-        # Otherwise, check that configuration matches already instantiated one.
-        parameters = SpacyPreprocessorParameters(
-            text_field=text_field,
-            doc_field=doc_field,
-            language=language,
-            disable=disable,
-            pre=pre,
-            memoize=memoize,
-        )
-        if not hasattr(cls, "_nlp_config"):
-            nlp = SpacyPreprocessor(**parameters._asdict())
-            cls._nlp_config = SpacyPreprocessorConfig(nlp=nlp, parameters=parameters)
-        elif parameters != cls._nlp_config.parameters:
-            raise ValueError(
-                "NLPLabelingFunction already configured with different parameters: "
-                f"{cls._nlp_config.parameters}"
-            )
+    def _create_preprocessor(
+        cls, parameters: SpacyPreprocessorParameters
+    ) -> SpacyPreprocessor:
+        return SpacyPreprocessor(**parameters._asdict())
+
+
+class base_nlp_labeling_function(labeling_function):
+    """Decorator to define a BaseNLPLabelingFunction child object from a function."""
+
+    _lf_cls: Optional[type] = None
 
     def __init__(
         self,
-        name: str,
-        f: Callable[..., int],
+        name: Optional[str] = None,
         resources: Optional[Mapping[str, Any]] = None,
         pre: Optional[List[BasePreprocessor]] = None,
         fault_tolerant: bool = False,
@@ -144,19 +189,44 @@ class NLPLabelingFunction(LabelingFunction):
         disable: Optional[List[str]] = None,
         memoize: bool = True,
     ) -> None:
-        self._create_or_check_preprocessor(
-            text_field, doc_field, language, disable, pre or [], memoize
-        )
-        super().__init__(
-            name,
-            f,
-            resources=resources,
-            pre=[self._nlp_config.nlp],
-            fault_tolerant=fault_tolerant,
+        super().__init__(name, resources, pre, fault_tolerant)
+        self.text_field = text_field
+        self.doc_field = doc_field
+        self.language = language
+        self.disable = disable
+        self.memoize = memoize
+
+    def __call__(self, f: Callable[..., int]) -> BaseNLPLabelingFunction:
+        """Wrap a function to create an ``BaseNLPLabelingFunction``.
+
+        Parameters
+        ----------
+        f
+            Function that implements the core NLP LF logic
+
+        Returns
+        -------
+        BaseNLPLabelingFunction
+            New ``BaseNLPLabelingFunction`` executing logic in wrapped function
+        """
+        if self._lf_cls is None:
+            raise NotImplementedError("_lf_cls must be defined")
+        name = self.name or f.__name__
+        return self._lf_cls(
+            name=name,
+            f=f,
+            resources=self.resources,
+            pre=self.pre,
+            fault_tolerant=self.fault_tolerant,
+            text_field=self.text_field,
+            doc_field=self.doc_field,
+            language=self.language,
+            disable=self.disable,
+            memoize=self.memoize,
         )
 
 
-class nlp_labeling_function(labeling_function):
+class nlp_labeling_function(base_nlp_labeling_function):
     """Decorator to define an NLPLabelingFunction object from a function.
 
     Parameters
@@ -174,7 +244,7 @@ class nlp_labeling_function(labeling_function):
     doc_field
         Name of data point field to output parsed document to
     language
-        SpaCy model to load
+        spaCy model to load
         See https://spacy.io/usage/models#usage
     disable
         List of pipeline components to disable
@@ -198,48 +268,4 @@ class nlp_labeling_function(labeling_function):
     -1
     """
 
-    def __init__(
-        self,
-        name: Optional[str] = None,
-        resources: Optional[Mapping[str, Any]] = None,
-        pre: Optional[List[BasePreprocessor]] = None,
-        fault_tolerant: bool = False,
-        text_field: str = "text",
-        doc_field: str = "doc",
-        language: str = EN_CORE_WEB_SM,
-        disable: Optional[List[str]] = None,
-        memoize: bool = True,
-    ) -> None:
-        super().__init__(name, resources, pre, fault_tolerant)
-        self.text_field = text_field
-        self.doc_field = doc_field
-        self.language = language
-        self.disable = disable
-        self.memoize = memoize
-
-    def __call__(self, f: Callable[..., int]) -> NLPLabelingFunction:
-        """Wrap a function to create an ``NLPLabelingFunction``.
-
-        Parameters
-        ----------
-        f
-            Function that implements the core NLP LF logic
-
-        Returns
-        -------
-        NLPLabelingFunction
-            New ``NLPLabelingFunction`` executing logic in wrapped function
-        """
-        name = self.name or f.__name__
-        return NLPLabelingFunction(
-            name=name,
-            f=f,
-            resources=self.resources,
-            pre=self.pre,
-            fault_tolerant=self.fault_tolerant,
-            text_field=self.text_field,
-            doc_field=self.doc_field,
-            language=self.language,
-            disable=self.disable,
-            memoize=self.memoize,
-        )
+    _lf_cls = NLPLabelingFunction

--- a/snorkel/labeling/lf/nlp.py
+++ b/snorkel/labeling/lf/nlp.py
@@ -235,7 +235,7 @@ class nlp_labeling_function(base_nlp_labeling_function):
         Name of the LF
     resources
         Labeling resources passed in to ``f`` via ``kwargs``
-    preprocessors
+    pre
         Preprocessors to run before SpacyPreprocessor is executed
     fault_tolerant
         Output -1 if LF execution fails?

--- a/snorkel/labeling/lf/nlp_spark.py
+++ b/snorkel/labeling/lf/nlp_spark.py
@@ -1,12 +1,8 @@
 from snorkel.map import Mapper
-from snorkel.preprocess.nlp import SpacyPreprocessor
 from snorkel.preprocess.spark import make_spark_preprocessor
+from snorkel.preprocess.nlp import SpacyPreprocessor
 
-from .nlp import (
-    BaseNLPLabelingFunction,
-    SpacyPreprocessorParameters,
-    base_nlp_labeling_function,
-)
+from .nlp import BaseNLPLabelingFunction, SpacyPreprocessorParameters, base_nlp_labeling_function
 
 
 class SparkNLPLabelingFunction(BaseNLPLabelingFunction):
@@ -70,7 +66,7 @@ class spark_nlp_labeling_function(base_nlp_labeling_function):
         Name of the LF
     resources
         Labeling resources passed in to ``f`` via ``kwargs``
-    preprocessors
+    pre
         Preprocessors to run before SpacyPreprocessor is executed
     fault_tolerant
         Output -1 if LF execution fails?
@@ -102,5 +98,4 @@ class spark_nlp_labeling_function(base_nlp_labeling_function):
     >>> has_person_mention(x)
     -1
     """
-
     _lf_cls = SparkNLPLabelingFunction

--- a/snorkel/labeling/lf/nlp_spark.py
+++ b/snorkel/labeling/lf/nlp_spark.py
@@ -1,4 +1,3 @@
-from snorkel.map import Mapper
 from snorkel.preprocess.nlp import SpacyPreprocessor
 from snorkel.preprocess.spark import make_spark_preprocessor
 
@@ -54,11 +53,12 @@ class SparkNLPLabelingFunction(BaseNLPLabelingFunction):
     """
 
     @classmethod
-    def _create_preprocessor(  # type: ignore
+    def _create_preprocessor(
         cls, parameters: SpacyPreprocessorParameters
-    ) -> Mapper:
+    ) -> SpacyPreprocessor:
         preprocessor = SpacyPreprocessor(**parameters._asdict())
-        return make_spark_preprocessor(preprocessor)
+        make_spark_preprocessor(preprocessor)
+        return preprocessor
 
 
 class spark_nlp_labeling_function(base_nlp_labeling_function):

--- a/snorkel/labeling/lf/nlp_spark.py
+++ b/snorkel/labeling/lf/nlp_spark.py
@@ -1,0 +1,106 @@
+from snorkel.map import Mapper
+from snorkel.preprocess.nlp import SpacyPreprocessor
+from snorkel.preprocess.spark import make_spark_preprocessor
+
+from .nlp import (
+    BaseNLPLabelingFunction,
+    SpacyPreprocessorParameters,
+    base_nlp_labeling_function,
+)
+
+
+class SparkNLPLabelingFunction(BaseNLPLabelingFunction):
+    r"""Special labeling function type for SpaCy-based LFs running on Spark.
+
+    This class is a Spark-compatabile version of ``NLPLabelingFunction``.
+    See ``NLPLabelingFunction`` for details.
+
+    Parameters
+    ----------
+    name
+        Name of the LF
+    f
+        Function that implements the core LF logic
+    resources
+        Labeling resources passed in to ``f`` via ``kwargs``
+    pre
+        Preprocessors to run before SpacyPreprocessor is executed
+    fault_tolerant
+        Output -1 if LF execution fails?
+    text_field
+        Name of data point text field to input
+    doc_field
+        Name of data point field to output parsed document to
+    language
+        SpaCy model to load
+        See https://spacy.io/usage/models#usage
+    disable
+        List of pipeline components to disable
+        See https://spacy.io/usage/processing-pipelines#disabling
+    memoize
+        Memoize preprocessor outputs?
+
+    Raises
+    ------
+    ValueError
+        Calling incorrectly defined preprocessors
+
+    Attributes
+    ----------
+    name
+        See above
+    fault_tolerant
+        See above
+    """
+
+    @classmethod
+    def _create_preprocessor(  # type: ignore
+        cls, parameters: SpacyPreprocessorParameters
+    ) -> Mapper:
+        preprocessor = SpacyPreprocessor(**parameters._asdict())
+        return make_spark_preprocessor(preprocessor)
+
+
+class spark_nlp_labeling_function(base_nlp_labeling_function):
+    """Decorator to define a SparkNLPLabelingFunction object from a function.
+
+    Parameters
+    ----------
+    name
+        Name of the LF
+    resources
+        Labeling resources passed in to ``f`` via ``kwargs``
+    preprocessors
+        Preprocessors to run before SpacyPreprocessor is executed
+    fault_tolerant
+        Output -1 if LF execution fails?
+    text_field
+        Name of data point text field to input
+    doc_field
+        Name of data point field to output parsed document to
+    language
+        SpaCy model to load
+        See https://spacy.io/usage/models#usage
+    disable
+        List of pipeline components to disable
+        See https://spacy.io/usage/processing-pipelines#disabling
+    memoize
+        Memoize preprocessor outputs?
+
+
+    Example
+    -------
+    >>> @spark_nlp_labeling_function()
+    ... def has_person_mention(x):
+    ...     person_ents = [ent for ent in x.doc.ents if ent.label_ == "PERSON"]
+    ...     return 0 if len(person_ents) > 0 else -1
+    >>> has_person_mention
+    SparkNLPLabelingFunction has_person_mention, Preprocessors: [SpacyPreprocessor...]
+
+    >>> from pyspark.sql import Row
+    >>> x = Row(text="The movie was good.")
+    >>> has_person_mention(x)
+    -1
+    """
+
+    _lf_cls = SparkNLPLabelingFunction

--- a/snorkel/labeling/lf/nlp_spark.py
+++ b/snorkel/labeling/lf/nlp_spark.py
@@ -1,8 +1,12 @@
 from snorkel.map import Mapper
-from snorkel.preprocess.spark import make_spark_preprocessor
 from snorkel.preprocess.nlp import SpacyPreprocessor
+from snorkel.preprocess.spark import make_spark_preprocessor
 
-from .nlp import BaseNLPLabelingFunction, SpacyPreprocessorParameters, base_nlp_labeling_function
+from .nlp import (
+    BaseNLPLabelingFunction,
+    SpacyPreprocessorParameters,
+    base_nlp_labeling_function,
+)
 
 
 class SparkNLPLabelingFunction(BaseNLPLabelingFunction):
@@ -98,4 +102,5 @@ class spark_nlp_labeling_function(base_nlp_labeling_function):
     >>> has_person_mention(x)
     -1
     """
+
     _lf_cls = SparkNLPLabelingFunction

--- a/test/labeling/lf/test_nlp_spark.py
+++ b/test/labeling/lf/test_nlp_spark.py
@@ -1,0 +1,47 @@
+import unittest
+from types import SimpleNamespace
+
+import pytest
+from pyspark.sql import Row
+
+from snorkel.labeling.lf.nlp import NLPLabelingFunction
+from snorkel.labeling.lf.nlp_spark import (
+    SparkNLPLabelingFunction,
+    spark_nlp_labeling_function,
+)
+from snorkel.types import DataPoint
+
+
+def has_person_mention(x: DataPoint) -> int:
+    person_ents = [ent for ent in x.doc.ents if ent.label_ == "PERSON"]
+    return 0 if len(person_ents) > 0 else -1
+
+
+@pytest.mark.spark
+class TestNLPLabelingFunction(unittest.TestCase):
+    def _run_lf(self, lf: SparkNLPLabelingFunction) -> None:
+        x = Row(num=8, text="The movie is really great!")
+        self.assertEqual(lf(x), -1)
+        x = Row(num=8, text="Jane Doe acted well.")
+        self.assertEqual(lf(x), 0)
+
+    def test_nlp_labeling_function(self) -> None:
+        lf = SparkNLPLabelingFunction(name="my_lf", f=has_person_mention)
+        self._run_lf(lf)
+
+    def test_nlp_labeling_function_decorator(self) -> None:
+        @spark_nlp_labeling_function()
+        def has_person_mention(x: DataPoint) -> int:
+            person_ents = [ent for ent in x.doc.ents if ent.label_ == "PERSON"]
+            return 0 if len(person_ents) > 0 else -1
+
+        self.assertIsInstance(has_person_mention, SparkNLPLabelingFunction)
+        self.assertEqual(has_person_mention.name, "has_person_mention")
+        self._run_lf(has_person_mention)
+
+    def test_spark_nlp_labeling_function_with_nlp_labeling_function(self) -> None:
+        # Do they have separate _nlp_configs?
+        lf = NLPLabelingFunction(name="my_lf", f=has_person_mention)
+        lf_spark = SparkNLPLabelingFunction(name="my_lf_spark", f=has_person_mention)
+        self.assertEqual(lf(SimpleNamespace(num=8, text="Jane Doe acted well.")), 0)
+        self._run_lf(lf_spark)


### PR DESCRIPTION
Useful for e.g. Drybell example. Need to go in and make the preprocessor Spark-compatible. Looks big, but just abstracting most stuff to a parent class (which is almost the same as NLPLF now), then adding two extremely simple subclasses

**Test plan**
* Added unit tests
* Local `tox -e spark`