### PR TITLE
Rename learned LabelModel params

### DIFF
--- a/snorkel/labeling/analysis.py
+++ b/snorkel/labeling/analysis.py
@@ -321,17 +321,17 @@ class LFAnalysis:
         return P
 
     def lf_summary(
-        self, Y: Optional[np.ndarray] = None, est_accs: Optional[np.ndarray] = None
+        self, Y: Optional[np.ndarray] = None, est_weights: Optional[np.ndarray] = None
     ) -> DataFrame:
         """Create a pandas DataFrame with the various per-LF statistics.
 
         Parameters
         ----------
         Y
-            [n] or [n, 1] np.ndarray of gold labels. If provided, the empirical accuracy
+            [n] or [n, 1] np.ndarray of gold labels. If provided, the empirical weight
             for each LF will be calculated.
-        est_accs
-            Learned accuracies for each LF
+        est_weights
+            Learned weights for each LF
 
         Returns
         -------
@@ -364,7 +364,7 @@ class LFAnalysis:
             d["Incorrect"] = Series(data=incorrects, index=lf_names)
             d["Emp. Acc."] = Series(data=accs, index=lf_names)
 
-        if est_accs is not None:
-            d["Learned Acc."] = Series(est_accs, index=lf_names)
+        if est_weights is not None:
+            d["Learned Weight"] = Series(est_weights, index=lf_names)
 
         return DataFrame(data=d, index=lf_names)

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -329,12 +329,12 @@ class LabelModel(nn.Module):
             return c_probs
 
     def get_weights(self) -> np.ndarray:
-        """Return the vector of LF weights related to LF accuracies.
+        """Return the vector of learned LF weights for combining LFs.
 
         Returns
         -------
         np.ndarray
-            [m,1] vector of LF weights related to LF accuracies
+            [m,1] vector of learned LF weights for combining LFs.
 
         Example
         -------
@@ -698,7 +698,7 @@ class LabelModel(nn.Module):
     ) -> None:
         """Train label model.
 
-        Train label model to estimate mu, the parameters related to accuracies of LFs.
+        Train label model to estimate mu, the parameters used to combine LFs.
 
         Parameters
         ----------

--- a/snorkel/labeling/model/label_model.py
+++ b/snorkel/labeling/model/label_model.py
@@ -82,7 +82,7 @@ class _CliqueData(NamedTuple):
 
 
 class LabelModel(nn.Module):
-    """A conditionally independent LabelModel to learn LF accuracies and assign training labels.
+    """A conditionally independent LabelModel to learn LF weights and assign training labels.
 
     Examples
     --------
@@ -328,20 +328,20 @@ class LabelModel(nn.Module):
         else:
             return c_probs
 
-    def get_accuracies(self) -> np.ndarray:
-        """Return the vector of LF accuracies.
+    def get_weights(self) -> np.ndarray:
+        """Return the vector of LF weights related to LF accuracies.
 
         Returns
         -------
         np.ndarray
-            [m,1] vector of LF accuracies
+            [m,1] vector of LF weights related to LF accuracies
 
         Example
         -------
         >>> L = np.array([[1, 1, 1], [1, 1, -1], [-1, 0, 0], [0, 0, 0]])
         >>> label_model = LabelModel(verbose=False)
         >>> label_model.fit(L, seed=123)
-        >>> np.around(label_model.get_accuracies(), 2)  # doctest: +SKIP
+        >>> np.around(label_model.get_weights(), 2)  # doctest: +SKIP
         array([0.99, 0.99, 0.99])
         """
         accs = np.zeros(self.m)

--- a/test/labeling/model/test_label_model.py
+++ b/test/labeling/model/test_label_model.py
@@ -124,7 +124,7 @@ class LabelModelTest(unittest.TestCase):
         self.assertLessEqual(probs.max(), 1.0)
         self.assertGreaterEqual(probs.min(), 0.0)
 
-    def test_get_accuracy(self):
+    def test_get_weight(self):
         # set up L matrix
         true_accs = [0.95, 0.6, 0.7, 0.55, 0.8]
         coverage = [1.0, 0.8, 1.0, 1.0, 1.0]
@@ -142,10 +142,10 @@ class LabelModelTest(unittest.TestCase):
         label_model = LabelModel(cardinality=2)
         label_model.fit(L, n_epochs=1000, seed=123)
 
-        accs = label_model.get_accuracies()
+        accs = label_model.get_weights()
         for i in range(len(accs)):
             true_acc = true_accs[i]
-            self.assertAlmostEqual(accs[i], true_acc, delta=0.05)
+            self.assertAlmostEqual(accs[i], true_acc, delta=0.1)
 
     def test_build_mask(self):
 

--- a/test/labeling/test_analysis.py
+++ b/test/labeling/test_analysis.py
@@ -82,7 +82,7 @@ class TestAnalysis(unittest.TestCase):
         np.testing.assert_array_almost_equal(P, P_emp)
 
     def test_lf_summary(self) -> None:
-        df = self.lfa.lf_summary(self.Y, est_accs=None)
+        df = self.lfa.lf_summary(self.Y, est_weights=None)
         df_expected = pd.DataFrame(
             {
                 "Polarity": [[1, 2], [], [0, 2], [2], [0, 1], [0]],
@@ -96,7 +96,7 @@ class TestAnalysis(unittest.TestCase):
         )
         pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
 
-        df = self.lfa.lf_summary(Y=None, est_accs=None)
+        df = self.lfa.lf_summary(Y=None, est_weights=None)
         df_expected = pd.DataFrame(
             {
                 "Polarity": [[1, 2], [], [0, 2], [2], [0, 1], [0]],
@@ -107,11 +107,11 @@ class TestAnalysis(unittest.TestCase):
         )
         pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))
 
-        est_accs = [1, 0, 1, 1, 1, 0.5]
+        est_weights = [1, 0, 1, 1, 1, 0.5]
         names = list("abcdef")
         lfs = [LabelingFunction(s, f) for s in names]
         lfa = LFAnalysis(np.array(L), lfs)
-        df = lfa.lf_summary(self.Y, est_accs=est_accs)
+        df = lfa.lf_summary(self.Y, est_weights=est_weights)
         df_expected = pd.DataFrame(
             {
                 "j": [0, 1, 2, 3, 4, 5],
@@ -122,7 +122,7 @@ class TestAnalysis(unittest.TestCase):
                 "Correct": [1, 0, 1, 1, 1, 2],
                 "Incorrect": [2, 0, 2, 1, 1, 2],
                 "Emp. Acc.": [1 / 3, 0, 1 / 3, 1 / 2, 1 / 2, 2 / 4],
-                "Learned Acc.": [1, 0, 1, 1, 1, 0.5],
+                "Learned Weight": [1, 0, 1, 1, 1, 0.5],
             }
         ).set_index(pd.Index(names))
         pd.testing.assert_frame_equal(df.round(6), df_expected.round(6))


### PR DESCRIPTION
* Rename LabelModel params from accuracies to weights
* Change LF summary table field from `Learned Acc.` to `Learned Weight`
* Increase delta for parameter for one test

__Test Plan__
* Change tests according to renaming scheme 